### PR TITLE
allow go test for multiple main pkgs

### DIFF
--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -22,10 +22,10 @@ go get -d -t ./...
 echo "Pulling Windows imports..."
 GOOS=windows go get -d -t ./...
 
-go test -coverpkg=./... -coverprofile=/coverage.out ./... >/go-test.txt
+go test -coverprofile=/coverage.out ./... >/go-test.txt
 RET=$?
 if [[ $RET -ne 0 ]]; then
-  echo "go test -coverpkg=./... -coverprofile=/coverage.out ./... returned ${RET}"
+  echo "go test -coverprofile=/coverage.out ./... returned ${RET}"
 fi
 
 # $ARTIFACTS is provided by prow decoration containers


### PR DESCRIPTION
without this; go test is failing for presubmits
https://prow.gflocks.com/view/gcs/oss-prow/pr-logs/pull/GoogleCloudPlatform_guest-test-infra/7/infra-presubmit-gotest/1182113108668190720