### PR TITLE
verbose gotest

### DIFF
--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -22,7 +22,7 @@ go get -d -t ./...
 echo "Pulling Windows imports..."
 GOOS=windows go get -d -t ./...
 
-go test -coverprofile=/coverage.out ./... >/go-test.txt
+go test -v -coverprofile=/coverage.out ./... >/go-test.txt
 RET=$?
 if [[ $RET -ne 0 ]]; then
   echo "go test -coverprofile=/coverage.out ./... returned ${RET}"


### PR DESCRIPTION
without `-v`, go test doesn't produce enough output for go-junit-report to work with. so our prow interface isn't showing us a test breakdown.