### PR TITLE
add debug lines

### DIFF
--- a/container_images/daisy-builder/main.sh
+++ b/container_images/daisy-builder/main.sh
@@ -92,6 +92,7 @@ tag_commit() {
               --tag=${LATEST_VERSION} --sha=${PULL_BASE_SHA} \
               --org=${REPO_OWNER} --repo=${REPO_NAME}"
 
+  echo "running $TAGGER_CMD ..."
   TAGGER_CMD_OUT=$(${TAGGER_CMD})
   if [[ $? -ne 0 ]]; then
     echo "could not tag github commit: $TAGGER_CMD_OUT"


### PR DESCRIPTION
some of the tagging workflow is failing. added this log line to get more helpful debug logs

example failure
https://prow.gflocks.com/view/gcs/oss-prow/logs/osconfig-build/1197953476190015488