### PR TITLE
Fix el8 package builds

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -84,7 +84,7 @@ done
 echo "Building package(s)"
 for spec in $SPECS; do
   PKGNAME="$(grep Name: "./packaging/${spec}"|cut -d' ' -f2-)"
-  yum-builddep "./packaging/${spec}"
+  yum-builddep -y "./packaging/${spec}"
 
   cp "./packaging/${spec}" "${RPMDIR}/SPECS/"
   tar czvf "${RPMDIR}/SOURCES/${PKGNAME}_${VERSION}.orig.tar.gz" --exclude .git \


### PR DESCRIPTION
without this the builds are getting aborted

sample failure log

Dec 27 23:24:02 inst-build-deb-build-packages-el8-build-package-gz6j2 startup-script[2671]: INFO startup-script-url: Upgrade  4 Packages
Dec 27 23:24:02 inst-build-deb-build-packages-el8-build-package-gz6j2 startup-script[2671]: INFO startup-script-url: Total download size: 5.5 M
Dec 27 23:24:02 inst-build-deb-build-packages-el8-build-package-gz6j2 startup-script[2671]: INFO startup-script-url: Is this ok [y/N]: Operation aborted.


full build log link
https://00e9e64bac9601d40f93e16f022d16fa8118a6f49607d4ba2b-apidata.googleusercontent.com/download/storage/v1/b/gcp-guest-daisy-bkt/o/daisy-build-packages-20191227-23:21:33-brdh2%2Fdaisy-build-package-20191227-23:21:34-gz6j2%2Flogs%2Finst-build-deb-build-packages-el8-build-package-gz6j2-serial-port1.log?qk=AD5uMEsz7XadCkgQ_dG2pueZj_R9C3sDr7cj5NUJ9Nfu-SS5Y3gKI6hPJ_Jyf7wMz6UzrAcYrbdNPi8JyBaH-i1zOeqBwXskAVIQL5V7gtXRXunyUa976Adi0lRSt5LQ0UkOfahpq7roLf-aEWSLivIch3h5czlvstl0FJSyQtuB_UGLj17n8Qj-mnCmWDsV8HNtW6FKiRUPuW_vQDWAE05XfPdsmcn4CBzLsu5kTjs6IWfOWTKCCh6_r_8e_PMiz3ExUK2u0A4tJ8MW_JFNIpulYrj7Smf-LyM4N5h9Sdb9h06hGgu3ZiSRiWNguuA5R_RiQYhofoAp_iUkfeXEavLTDXFR8DtYrfgWV2CsdJlTDg937PlLf5uYMLoD_MX7hAPPU58mpE87CoHK3ZH9VhPHxO3vAUYorIf-0SO7FuM7ttaWScPYCTIee3ntNO6dg78YsNVIxWYuJ_ZAvSn50KW8tzAS9Wcp3yUtLUnboj3wIYYdnZjwrZ9-CktIU0HAt9I3cB5pLiGmTKjuEbQkzx7GU-47AgtjPrqBMtG0oSxc1QZkurb0OQ-kO7vHkrDXC66NCSO_Vz5rhsh3rR_8eY3R-CluqWMyLSP8STVEGH7RdgRfRjKjtValt8i9LdtEhGK1-_TmmA0ddfQiakybAkNF_wlZ5B8AhbDcmIl_6oTq03LpMaF3rA17nTIt-Z-JpobOSAUB9aAIViYfos61cHxKFH2hCL4mscZwXW0SfBzXai1DszemB_7vekIzH-t8LHjd4ZeV6hCRivWUcmOp2t1vCJh_HZkNIbOn5xAewryW0qodU31IWlHdLJuyspfwX57s9W5NJnlla-nDnCZQ83Crrn0ywXcqVipvzt_817kTWcU7ylPL9-3N9HIPwV138MWkgZP-m5hDhgygUaYbrnFqPLRPS4r5IXFAKO0mwSLvgs9gFveo_jywfmbHRMvMru1CAeOODZn2j7LriOVbbZ2p0_29Xs0H0HpDKMSswiTYhtWpBdrHMF-2racfetKBNdFuCJLPImrJ
