### PR TITLE
Correct upload paths, log paths

### DIFF
--- a/container_images/daisy-builder/main.sh
+++ b/container_images/daisy-builder/main.sh
@@ -151,11 +151,11 @@ DAISY_BUCKET="gs://$(sed -En "s|(^.*)$pattern||p" out)"
 # copy daisy logs and artifacts to artifacts folder for prow
 # $ARTIFACTS is set by prow
 if [[ -n $ARTIFACTS ]]; then
-  echo "copying daisy outputs from $DAISY_BUCKET to prow artifacts dir"
-  gsutil cp "${DAISY_BUCKET}/outs/*" ${ARTIFACTS}/
+  echo "copying daisy outputs from ${DAISY_BUCKET}/packages to prow artifacts dir"
+  gsutil cp "${DAISY_BUCKET}/packages/*" ${ARTIFACTS}/
 fi
 
 # If invoked as periodic, postsubmit, or manually, upload the results.
 if [[ "$JOB_TYPE" != "presubmit" ]]; then
-  gsutil cp "${DAISY_BUCKET}/outs/*" $GCS_OUTPUT_BUCKET
+  gsutil cp "${DAISY_BUCKET}/packages/*" $GCS_OUTPUT_BUCKET
 fi

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -80,5 +80,5 @@ dch --create -M -v 1:${VERSION}-g1${DEB} --package $PKGNAME -D stable \
 debuild -e "VERSION=${VERSION}" -us -uc
 
 echo "copying $BUILD_DIR/*.deb to $GCS_PATH"
-echo gsutil cp -n "$BUILD_DIR"/*.deb "$GCS_PATH"
+gsutil cp -n "$BUILD_DIR"/*.deb "$GCS_PATH/"
 build_success "Built `ls "$BUILD_DIR"/*.deb|xargs`"

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -80,5 +80,5 @@ dch --create -M -v 1:${VERSION}-g1${DEB} --package $PKGNAME -D stable \
 debuild -e "VERSION=${VERSION}" -us -uc
 
 echo "copying $BUILD_DIR/*.deb to $GCS_PATH"
-gsutil cp -n "$BUILD_DIR"/*.deb "$GCS_PATH"
+echo gsutil cp -n "$BUILD_DIR"/*.deb "$GCS_PATH"
 build_success "Built `ls "$BUILD_DIR"/*.deb|xargs`"

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -79,5 +79,6 @@ dch --create -M -v 1:${VERSION}-g1${DEB} --package $PKGNAME -D stable \
   "Debian packaging for ${PKGNAME}"
 debuild -e "VERSION=${VERSION}" -us -uc
 
+echo "copying $BUILD_DIR/*.deb to $GCS_PATH"
 gsutil cp -n "$BUILD_DIR"/*.deb "$GCS_PATH"
 build_success "Built `ls "$BUILD_DIR"/*.deb|xargs`"

--- a/packagebuild/daisy_startupscript_goo.sh
+++ b/packagebuild/daisy_startupscript_goo.sh
@@ -46,5 +46,5 @@ for spec in packaging/googet/*.goospec; do
   goopack -var:version="$VERSION" "$spec"
 done
 
-gsutil cp -n *.goo "$GCS_PATH"
+gsutil cp -n *.goo "$GCS_PATH/"
 build_success "Built `ls *.goo|xargs`"

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -96,5 +96,5 @@ for spec in $SPECS; do
 done
 
 rpms=$(find ${RPMDIR}/{S,}RPMS -iname "${PKGNAME}*.rpm")
-gsutil cp -n ${rpms} "$GCS_PATH"
+gsutil cp -n ${rpms} "$GCS_PATH/"
 build_success "Built ${rpms}"


### PR DESCRIPTION
the absence of trailing slash means that for uploads with one file, we are uploading it as the 'dir'. eg. uploading my_package.rpm to gs://bucket/daisy-outs instead of gs://bucket/daisy-outs/my_package.rpm