### PR TITLE
Optional directory argument for gobuild,gotest,gocheck images

### DIFF
--- a/container_images/gobuild/main.sh
+++ b/container_images/gobuild/main.sh
@@ -13,19 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check this out in GOPATH since go package handling requires it to be here.
-#REPO_PATH=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
-#mkdir -p ${REPO_PATH}
-#git clone https://github.com/${REPO_OWNER}/${REPO_NAME} ${REPO_PATH}
-#cd ${REPO_PATH}
-#
-## Pull PR if this is a PR.
-#if [ ! -z "${PULL_NUMBER}" ]; then
-#  git fetch origin pull/${PULL_NUMBER}/head:${PULL_NUMBER}
-#  git checkout ${PULL_NUMBER}
-#fi
+set -xe
 
-go version
+BUILD_DIR=$1
+[[ -n $BUILD_DIR ]] && cd $BUILD_DIR
 
 echo 'Pulling Linux imports...'
 go get -d ./...

--- a/container_images/gocheck/main.sh
+++ b/container_images/gocheck/main.sh
@@ -13,26 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check this out in GOPATH since go package handling requires it to be here.
-#REPO_PATH=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
-#mkdir -p ${REPO_PATH}
-#git clone https://github.com/${REPO_OWNER}/${REPO_NAME} ${REPO_PATH}
-#cd ${REPO_PATH}
-#
-## Pull PR if this is a PR.
-#if [ ! -z "${PULL_NUMBER}" ]; then
-#  git fetch origin pull/${PULL_NUMBER}/head:${PULL_NUMBER}
-#  git checkout ${PULL_NUMBER}
-#fi
+set -xe
 
-go version
+BUILD_DIR=$1
+[[ -n $BUILD_DIR ]] && cd $BUILD_DIR
 
 echo 'Pulling Linux imports...'
 go get -d -t ./...
 echo 'Pulling Windows imports...'
 GOOS=windows go get -d -t ./...
 
-# We dont run golint on Windows only code as style often matches win32 api 
+# We dont run golint on Windows only code as style often matches win32 api
 # style, not golang style
 golint -set_exit_status ./...
 GOLINT_RET=$?

--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -xe
+
 export GOCOVPATH=/gocov.txt
 
-go version
+BUILD_DIR=$1
+[[ -n $BUILD_DIR ]] && cd $BUILD_DIR
 
 echo "Pulling Linux imports..."
 go get -d -t ./...


### PR DESCRIPTION
Support an optional directory argument, which allows these tools to be run against repos containing multiple go modules. 