### PR TITLE
Store git commit, support checkout of tags

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -60,11 +60,11 @@ function git_checkout() {
   git init
 
   # fetch only the branch that we want to build
-  git_command="git fetch https://github.com/${BASE_REPO}/${REPO}.git ${PULL_REF:-"master"}:packaging"
+  git_command="git fetch https://github.com/${BASE_REPO}/${REPO}.git ${PULL_REF:-"master"}"
   echo "Running ${git_command}"
   $git_command
 
-  git checkout packaging
+  git checkout FETCH_HEAD
 }
 
 function try_command() {

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -62,6 +62,8 @@ if grep -q 'golang' packaging/debian/control; then
   $GO mod download
 fi
 
+COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
+
 echo "Building package(s)"
 
 # Create build dir.
@@ -80,7 +82,6 @@ cp -r packaging/debian "${BUILD_DIR}/${PKGNAME}-${VERSION}/"
 
 cd "${BUILD_DIR}/${PKGNAME}-${VERSION}"
 
-COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
 sed -i"" "/^Source:/aXB-Git: ${COMMITURL}" debian/control
 
 # We generate this to enable auto-versioning.

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -80,6 +80,9 @@ cp -r packaging/debian "${BUILD_DIR}/${PKGNAME}-${VERSION}/"
 
 cd "${BUILD_DIR}/${PKGNAME}-${VERSION}"
 
+COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
+sed -i"" "/^Source:/aXB-Git: ${COMMITURL}" debian/control
+
 # We generate this to enable auto-versioning.
 [[ -f debian/changelog ]] && rm debian/changelog
 dch --create -M -v 1:${VERSION}-g1${DEB} --package $PKGNAME -D stable \

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -86,10 +86,14 @@ done
 
 [[ -z "$SPECS" ]] && build_fail "No RPM specs found"
 
+COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
+
 echo "Building package(s)"
 for spec in $SPECS; do
   PKGNAME="$(grep Name: "./packaging/${spec}"|cut -d' ' -f2-|tr -d ' ')"
   yum-builddep -y "./packaging/${spec}"
+
+  sed -i"" "/^Source/aVcs: ${COMMITURL}" "./packaging/${spec}"
 
   cp "./packaging/${spec}" "${RPMDIR}/SPECS/"
   tar czvf "${RPMDIR}/SOURCES/${PKGNAME}_${VERSION}.orig.tar.gz" \

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -73,27 +73,33 @@ for dir in ${RPMDIR}/{SOURCES,SPECS}; do
   [[ -d "$dir" ]] || mkdir -p "$dir"
 done
 
-# Find the RPM specs.
-for spec in ./packaging/*.spec; do
+# Find the RPM specs to build for this version.
+TOBUILD=""
+SPECS=$(ls ./packaging/*.spec | sed -re 's/(\.el.)?.spec//' | sort -ru)
+echo "all specs $SPECS"
+for spec in $SPECS; do
   spec=$(basename "$spec")
-  # If the spec file has elN in it, only add it if N matches VERSION_ID
-  if [[ "$spec" =~ \.el[0-9] ]]; then
-    [[ "$spec" =~ \.el${VERSION_ID} ]] && SPECS="${SPECS} ${spec}"
+  distspec="${spec}.el${VERSION_ID}.spec"
+  echo checking $spec and $distspec
+  if [[ -f "./packaging/$distspec" ]]; then
+    TOBUILD="${TOBUILD} ${distspec}"
   else
-    SPECS="${SPECS} ${spec}"
+    TOBUILD="${TOBUILD} ${spec}.spec"
   fi
 done
 
-[[ -z "$SPECS" ]] && build_fail "No RPM specs found"
+[[ -z "$TOBUILD" ]] && build_fail "No RPM specs found"
 
 COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
 
 echo "Building package(s)"
-for spec in $SPECS; do
+for spec in $TOBUILD; do
   PKGNAME="$(grep Name: "./packaging/${spec}"|cut -d' ' -f2-|tr -d ' ')"
   yum-builddep -y "./packaging/${spec}"
 
-  sed -i"" "/^Source/aVcs: ${COMMITURL}" "./packaging/${spec}"
+  if [[ $VERSION_ID -ne 6 ]]; then
+    sed -i"" "/^Source/aVcs: ${COMMITURL}" "./packaging/${spec}"
+  fi
 
   cp "./packaging/${spec}" "${RPMDIR}/SPECS/"
   tar czvf "${RPMDIR}/SOURCES/${PKGNAME}_${VERSION}.orig.tar.gz" \
@@ -108,4 +114,4 @@ done
 rpms=$(find ${RPMDIR}/{S,}RPMS -iname "${PKGNAME}*.rpm")
 echo "copying ${rpms} to $GCS_PATH/"
 gsutil cp -n ${rpms} "$GCS_PATH/"
-build_success "Built ${rpms}"
+build_success "Built $(echo ${rpms}|xargs)"


### PR DESCRIPTION
* Inject source control tags into debian control and RPM spec
* Don't assume pull ref is a branch, instead check out object into working tree using FETCH_HEAD ref (enables checkout of tags)
* Skip unversioned specs if versioned specs exist