### PR TITLE
rename daisy-build, uncouple from prow

### DIFF
--- a/container_images/autoversioner/Dockerfile
+++ b/container_images/autoversioner/Dockerfile
@@ -1,3 +1,16 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 FROM golang:alpine
 
 RUN apk add --no-cache git

--- a/container_images/cloudbuild.yaml
+++ b/container_images/cloudbuild.yaml
@@ -1,18 +1,31 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/gocheck:latest', '--tag=gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA', './container_images/gocheck']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gocheck:latest',
+    '--tag=gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA',
+    './container_images/gocheck']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/gobuild:latest', '--tag=gcr.io/$PROJECT_ID/gobuild:$COMMIT_SHA', './container_images/gobuild']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gobuild:latest',
+    '--tag=gcr.io/$PROJECT_ID/gobuild:$COMMIT_SHA',
+    './container_images/gobuild']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/gotest:latest', '--tag=gcr.io/$PROJECT_ID/gotest:$COMMIT_SHA', './container_images/gotest']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gotest:latest',
+    '--tag=gcr.io/$PROJECT_ID/gotest:$COMMIT_SHA', './container_images/gotest']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/daisy-builder:latest', '--tag=gcr.io/$PROJECT_ID/daisy-builder:$COMMIT_SHA', './container_images/daisy-builder']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/packagebuilder:latest',
+    '--tag=gcr.io/$PROJECT_ID/packagebuilder:$COMMIT_SHA',
+    '--file=./container_images/daisy-builder/Dockerfile', '/workspace']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/selinux-tools:latest', '--tag=gcr.io/$PROJECT_ID/selinux-tools:$COMMIT_SHA', './container_images/selinux-tools']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/selinux-tools:latest',
+    '--tag=gcr.io/$PROJECT_ID/selinux-tools:$COMMIT_SHA',
+    './container_images/selinux-tools']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/build-essential:latest', '--tag=gcr.io/$PROJECT_ID/build-essential:$COMMIT_SHA', './container_images/build-essential']
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/build-essential:latest',
+    '--tag=gcr.io/$PROJECT_ID/build-essential:$COMMIT_SHA',
+    './container_images/build-essential']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=gcr.io/$PROJECT_ID/autoversioner:latest', '--tag=gcr.io/$PROJECT_ID/autoversioner:$COMMIT_SHA', '--file=./container_images/autoversioner/Dockerfile', "/workspace"]
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/autoversioner:latest',
+    '--tag=gcr.io/$PROJECT_ID/autoversioner:$COMMIT_SHA',
+    '--file=./container_images/autoversioner/Dockerfile', '/workspace']
 images:
   - 'gcr.io/$PROJECT_ID/gocheck:latest'
   - 'gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA'
@@ -20,8 +33,8 @@ images:
   - 'gcr.io/$PROJECT_ID/gobuild:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/gotest:latest'
   - 'gcr.io/$PROJECT_ID/gotest:$COMMIT_SHA'
-  - 'gcr.io/$PROJECT_ID/daisy-builder:latest'
-  - 'gcr.io/$PROJECT_ID/daisy-builder:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/packagebuilder:latest'
+  - 'gcr.io/$PROJECT_ID/packagebuilder:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/selinux-tools:latest'
   - 'gcr.io/$PROJECT_ID/selinux-tools:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/build-essential:latest'

--- a/container_images/packagebuilder/Dockerfile
+++ b/container_images/packagebuilder/Dockerfile
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM gcr.io/compute-image-tools/daisy:latest
-
 FROM gcr.io/gcp-guest/autoversioner:latest
-
-#FROM alpine
 # Needed for gsutil.
 FROM google/cloud-sdk:alpine
 
@@ -28,12 +25,13 @@ WORKDIR /
 COPY --from=0 /daisy daisy
 # Daisy image copies this from gcr.io/distroless/base, we copy here.
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-
 COPY --from=1 /tagger tagger
 COPY --from=1 /versiongenerator versiongenerator
 
+COPY ./packagebuild/* /
+
 # Copy this Dockerfile for debugging.
-COPY Dockerfile Dockerfile
-COPY main.sh main.sh
+COPY container_images/packagebuilder/Dockerfile Dockerfile
+COPY container_images/packagebuilder/main.sh main.sh
 
 ENTRYPOINT ["./main.sh"]

--- a/container_images/packagebuilder/main.sh
+++ b/container_images/packagebuilder/main.sh
@@ -113,8 +113,6 @@ if [[ -n $GOOGLE_APPLICATION_CREDENTIALS ]]; then
   gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 fi
 
-cd packagebuild
-
 WF="build.wf.json"
 generate_build_workflow "$WF"
 echo "Generated workflow:"


### PR DESCRIPTION
* rename daisy-build to packagebuilder
* bake the packagebuilder code into the image

the tool still expects a variety of environment variables to be set in prow format, but this is easy to replicate with other invocation methods

/hold