### PR TITLE
Update builds to use go 1.13.9

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -33,7 +33,7 @@ function install_go() {
   # Installs a specific version of go for compilation, since availability varies
   # across linux distributions. Needs curl and tar to be installed.
 
-  local GOLANG="go1.12.5.linux-amd64.tar.gz"
+  local GOLANG="go1.13.9.linux-amd64.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
Chose to not move to 1.14 as I am not positive all builders are updated to 1.14 yet, and 1.13 was the min needed to unblock guest agent builds