### PR TITLE
pytest: allow in-repo dependencies

### DIFF
--- a/container_images/pytest/.dockerignore
+++ b/container_images/pytest/.dockerignore
@@ -1,0 +1,1 @@
+example

--- a/container_images/pytest/Dockerfile
+++ b/container_images/pytest/Dockerfile
@@ -19,7 +19,7 @@ FROM python:3.6.11-slim-buster
 FROM python:3.7.8-slim-buster
 
 FROM python:3.8.5-slim-buster
-RUN pip3 install tox==3.19.0
+RUN pip3 install tox==3.20.1
 
 COPY --from=0 /usr/local/lib/python3.5/ /usr/local/lib/python3.5/
 COPY --from=0 /usr/local/lib/lib*3.5* /usr/local/lib/

--- a/container_images/pytest/README.md
+++ b/container_images/pytest/README.md
@@ -63,10 +63,19 @@ See the Dockerfile for currently-installed versions.
 
 #### test-deps (optional)
 
-*Additional* dependencies to install prior to running tests. Runtime
-dependencies from `setup.py` are automatically included. 
+Dependencies to install prior to installing your package:
 
-Encode dependencies using [requirement specifiers](https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers).
+```toml
+test-deps = [
+    "pip-package",
+    "//in-repo-package"
+]
+```
+
+##### pip package
+
+To encode **pip** dependencies, use 
+[requirement specifiers](https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers):
 
 ```toml
 test-deps = [
@@ -76,3 +85,26 @@ test-deps = [
     "D ~=1.4.2"
 ]
 ```
+
+The common usecase is test-only dependencies, such as assertion libraries.
+
+##### in-repo package
+
+To install a dependency from the current repo, write the dependency's path **relative to the root
+of the repository**, starting with two slashes. 
+
+
+```
+repo
+└── src
+    ├── application
+    │   ├── main.py
+    │   ├── main_test.py
+    │   ├── pyproject.toml
+    │   └── setup.py
+    └── sums
+        ├── ints.py
+        └── setup.py
+```
+
+If `application` has a dependency on `sums`, it writes the dependency as `//src/sums`.

--- a/container_images/pytest/README.md
+++ b/container_images/pytest/README.md
@@ -63,38 +63,29 @@ See the Dockerfile for currently-installed versions.
 
 #### test-deps (optional)
 
-Dependencies to install prior to installing your package:
+Dependencies to install prior to installing your package. Two types of dependencies are supported,
+"pip package" dependencies and "in-repo" depedencies.
 
-```toml
-test-deps = [
-    "pip-package",
-    "//in-repo-package"
-]
-```
-
-##### pip package
-
-To encode **pip** dependencies, use 
+To install test-only dependencies from PyPI, use
 [requirement specifiers](https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers):
 
 ```toml
 test-deps = [
-    "A",
-    "B == 1.2",
-    "C >= 20",
-    "D ~=1.4.2"
+    "pytest",
+    "urllib3 == 1.2",
+    "six >= 1.12",
+    "botocore ~= 1"
 ]
 ```
 
-The common usecase is test-only dependencies, such as assertion libraries.
-
-##### in-repo package
 
 To install a dependency from the current repo, write the dependency's path **relative to the root
-of the repository**, starting with two slashes. 
-
+of the repository**, starting with two slashes. This example shows how `application` would depend
+on `sums`:
 
 ```
+# directory layout
+
 repo
 └── src
     ├── application
@@ -105,6 +96,10 @@ repo
     └── sums
         ├── ints.py
         └── setup.py
-```
 
-If `application` has a dependency on `sums`, it writes the dependency as `//src/sums`.
+# src/application/pyproject.toml
+
+test-deps = [
+    "//src/sums",
+]
+```

--- a/container_images/pytest/example/.gitignore
+++ b/container_images/pytest/example/.gitignore
@@ -1,0 +1,1 @@
+artifacts

--- a/container_images/pytest/example/README.md
+++ b/container_images/pytest/example/README.md
@@ -1,0 +1,3 @@
+This example shows how to setup a Python packages to be tested by the pytest container.
+The package "application" is being tested, and it depends on a library package called "sums".
+To run the tests in "application", execute `run.sh`. 

--- a/container_images/pytest/example/run.sh
+++ b/container_images/pytest/example/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Change to the directory of this script.
+cd "$(dirname "$(readlink -f "$0")")"
+
+pushd ..
+docker build . -t pytest
+popd
+
+rm -rf artifacts && mkdir artifacts
+
+docker run \
+  `# The first mount contains the repository that's being tested. In this example, we're` \
+  `# assuming that *this* is the root of the repository. The root is important since ` \
+  `# in-repo dependencies are expressed as an absolute path from the root of the repository.` \
+  --volume "$(pwd):/project:ro" \
+  --workdir /project \
+  `# After the test runs, check the "artifacts" directory for test results.` \
+  --volume "$(pwd)/artifacts:/artifacts" \
+  --env ARTIFACTS=/artifacts \
+  `# The argument to "pytest" is the path to the Python package that will be tested.` \
+  pytest src/application

--- a/container_images/pytest/example/src/application/main.py
+++ b/container_images/pytest/example/src/application/main.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ints
+
+
+def three_plus_four():
+  return ints.total([3, 4])

--- a/container_images/pytest/example/src/application/main_test.py
+++ b/container_images/pytest/example/src/application/main_test.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from main import three_plus_four
+
+
+def test_three_plus_four():
+  assert three_plus_four() == 7

--- a/container_images/pytest/example/src/application/pyproject.toml
+++ b/container_images/pytest/example/src/application/pyproject.toml
@@ -1,0 +1,28 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[tool.gcp-guest-pytest]
+
+envlist = [
+    "3.5",
+    "3.8"
+]
+
+test-deps = [
+    # The double dash ('//') means that it's an in-repo dependency.
+    # The path `src/sums` is the path relative to the repository's root.
+    # The script `run.sh` configures `pytest` to think that
+    # `guest-test-infra/container_images/pytest/example` is the repository's root.
+    '//src/sums'
+]

--- a/container_images/pytest/example/src/application/setup.py
+++ b/container_images/pytest/example/src/application/setup.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup
+
+setup(
+    name="application",
+    py_modules="main",
+    install_requires=[
+        "sums",
+    ]
+)

--- a/container_images/pytest/example/src/sums/ints.py
+++ b/container_images/pytest/example/src/sums/ints.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import reduce
+import typing
+
+
+def total(arr: typing.Iterable[int]):
+  return reduce(lambda x, y: x + y, arr)

--- a/container_images/pytest/example/src/sums/setup.py
+++ b/container_images/pytest/example/src/sums/setup.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup
+
+setup(
+    name="sums",
+    py_modules=["ints"]
+)

--- a/container_images/pytest/main.py
+++ b/container_images/pytest/main.py
@@ -16,8 +16,10 @@
 
 import configparser
 import os
+from pathlib import Path
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import typing
@@ -55,7 +57,29 @@ _per_interpreter_command = [
 ]
 
 
-def setup_execution_root(package_root: str) -> str:
+class TestConfig:
+  def __init__(self, repo_root: Path, package_root: Path,
+               envlist: typing.Iterable[str],
+               pip_deps: typing.Iterable[str],
+               local_deps: typing.Iterable[str]):
+    """ The user's test specifications.
+
+    Args:
+      repo_root: Filesystem path to the repo's root directory.
+      package_root: Filesystem path to the Python package's root directory.
+      envlist: Interpreters to run tests with.
+      pip_deps: List of dependencies from Pip
+      local_deps: List of dependencies installable from this repo.
+
+    """
+    self.repo_root = repo_root
+    self.package_root = package_root
+    self.envlist = envlist
+    self.pip_deps = pip_deps
+    self.local_deps = local_deps
+
+
+def setup_execution_root(cfg: TestConfig) -> Path:
   """Create execution directory and copy project's code to it.
 
   Tox creates in-directory files, and its execution fails when the
@@ -67,12 +91,19 @@ def setup_execution_root(package_root: str) -> str:
   Returns:
     Absolute path to execution root.
   """
-  assert os.path.exists(package_root) and os.path.isabs(package_root), \
-    f"Expected {package_root} to exist and to be an absolute path."
+  assert cfg.package_root.exists(), \
+      f"Expected {cfg.package_root} to exist and to be an absolute path."
 
-  exec_root = tempfile.mkdtemp()
-  shutil.copytree(package_root, exec_root, dirs_exist_ok=True)
-  return exec_root
+
+  exec_root = Path(tempfile.mkdtemp())
+  shutil.copytree(cfg.package_root, exec_root, dirs_exist_ok=True)
+
+  if cfg.local_deps:
+    dep_dir = exec_root / "deps"
+    dep_dir.mkdir()
+    for dep in cfg.local_deps:
+      shutil.copytree(cfg.repo_root.absolute() / dep, dep_dir / dep)
+  return Path(exec_root)
 
 
 def to_tox_version(py_version: str):
@@ -84,15 +115,16 @@ def to_tox_version(py_version: str):
     raise ValueError("Invalid version number: " + py_version)
 
 
-def write_tox_ini(artifact_dir):
+def read_tox_ini(repo_root: Path, package_root: Path) -> TestConfig:
   """Read pyproject.toml and write a new tox.ini file.
 
   The tox.ini file is generated to ensure that tests are run consistently,
   and that test reports are written to the correct location.
   """
-  assert os.path.exists("pyproject.toml"), "Expected pyproject.toml to exist."
+  cfg = package_root / "pyproject.toml"
+  assert cfg.exists(), "Expected pyproject.toml to exist."
 
-  with open("pyproject.toml") as f:
+  with cfg.open() as f:
     project_cfg = toml.load(f)
 
   # Read the [tool.gcp-guest-pytest] section of pyproject.toml.
@@ -101,24 +133,52 @@ def write_tox_ini(artifact_dir):
   # Which interpreters to enable.
   envlist = [to_tox_version(env) for env in test_cfg.get("envlist", [])]
 
-  # Test-specific dependencies to install.
-  test_deps = test_cfg.get("test-deps", [])
-
   if not envlist:
     raise ValueError(
       "pyproject.toml must contain a section [tool.gcp-guest-pytest] "
       "with a key `envlist` and at least one interpreter.")
 
+  pip_deps, local_deps = [], []
+  for dep in test_cfg.get("test-deps", []):
+    if dep.startswith("//"):
+      local = dep[2:]
+      if not (repo_root / local).exists():
+        raise ValueError("Dependency {} not found".format(dep))
+      local_deps.append(local)
+    else:
+      pip_deps.append(dep)
+
+  return TestConfig(
+      repo_root=repo_root,
+      package_root=package_root,
+      envlist=envlist,
+      pip_deps=pip_deps,
+      local_deps=local_deps
+  )
+
+
+def write_tox_ini(cfg: TestConfig, artifact_dir: Path, execution_root: Path):
+  """Write the test config to a new tox.ini file.
+
+  The tox.ini file is generated to ensure that tests are run consistently,
+  and that test reports are written to the correct location.
+  """
+
   config = configparser.ConfigParser()
   config["tox"] = {
-    "envlist": ", ".join(envlist),
+    "envlist": ", ".join(cfg.envlist),
   }
+
+  local_deps = []
+  dep_dir = execution_root.absolute() / "deps"
+  for d in cfg.local_deps:
+    local_deps.append((dep_dir / d).as_posix())
 
   config["testenv"] = {
     "envlogdir":
       "{artifact_dir}/tox/{{envname}}".format(artifact_dir=artifact_dir),
     "deps":
-      "\n\t".join(_common_test_deps + test_deps),
+      "\n\t".join(_common_test_deps + cfg.pip_deps + local_deps),
     "commands":
       " ".join(_per_interpreter_command).format(artifact_dir=artifact_dir),
   }
@@ -131,17 +191,17 @@ def write_tox_ini(artifact_dir):
     config.write(f)
 
 
-def archive_configs(dst: str):
-  if os.path.exists(dst):
-    assert os.path.isdir(dst), f"Expected {dst} to be a directory."
+def archive_configs(dst: Path):
+  if dst.exists():
+    assert dst.is_dir(), f"Expected {dst} to be a directory."
   else:
-    os.mkdir(dst)
-  print("Saving config files to " + dst)
+    dst.mkdir()
+  print("Saving config files to ", dst)
   for fname in ["pyproject.toml", "tox.ini"]:
     shutil.copy2(fname, dst)
 
 
-def validate_args(args: typing.List[str]):
+def validate_args(args: typing.List[str]) -> typing.Tuple[Path, Path]:
   if (len(args) > 1
       and os.path.isdir(args[1])
       and os.path.isfile(os.path.join(args[1], "pyproject.toml"))):
@@ -152,21 +212,22 @@ def validate_args(args: typing.List[str]):
     artifact_dir = os.path.abspath(os.environ["ARTIFACTS"])
   else:
     raise ValueError("$ARTIFACTS must point to a directory that exists")
-  return artifact_dir, package_root
+  return Path(artifact_dir), Path(package_root)
 
 
 def main():
-  print("args: %s" % sys.argv)
-  print("$ARTIFACTS: %s" % os.environ.get("ARTIFACTS"))
+  print("args:", sys.argv)
+  print("$ARTIFACTS:", os.environ.get("ARTIFACTS"))
   artifact_dir, package_root = validate_args(sys.argv)
-
+  cfg = read_tox_ini(Path.cwd(), package_root)
   # Create a new execution area, since we'll be writing files.
-  execution_root = setup_execution_root(package_root)
+  execution_root = setup_execution_root(cfg)
   os.chdir(execution_root)
-  print("Executing tests in " + execution_root)
+  subprocess.run(["ls", "-lah", "deps"])
+  print("Executing tests in", execution_root)
 
-  write_tox_ini(artifact_dir)
-  archive_configs(os.path.join(artifact_dir, "tox"))
+  write_tox_ini(cfg, artifact_dir, Path())
+  archive_configs(artifact_dir / "tox")
   result_code = tox.cmdline(["-v"])
   sys.exit(result_code)
 

--- a/container_images/pytest/main.py
+++ b/container_images/pytest/main.py
@@ -70,7 +70,6 @@ class TestConfig:
       envlist: Interpreters to run tests with.
       pip_deps: List of dependencies from Pip
       local_deps: List of dependencies installable from this repo.
-
     """
     self.repo_root = repo_root
     self.package_root = package_root
@@ -92,7 +91,7 @@ def setup_execution_root(cfg: TestConfig) -> Path:
     Absolute path to execution root.
   """
   assert cfg.package_root.exists(), \
-      f"Expected {cfg.package_root} to exist and to be an absolute path."
+    f"Expected {cfg.package_root} to exist and to be an absolute path."
 
 
   exec_root = Path(tempfile.mkdtemp())


### PR DESCRIPTION
Prior to this, the package being tested could only have dependencies on pypi packages. This PR enables dependencies on Python packages from the repo being tested.

See the new `example` directory for tests that run against an application package, where the application package depends on a library package.