### PR TITLE
Removing CentOS6 and RHEL6 from integration tests

### DIFF
--- a/container_images/gointegtest/integ-test-all.wf.json
+++ b/container_images/gointegtest/integ-test-all.wf.json
@@ -25,12 +25,6 @@
     "disk-create": {
       "CreateDisks": [
         {
-          "Name": "disk-centos-6",
-          "SourceImage": "projects/centos-cloud/global/images/family/centos-6",
-          "SizeGb": "20",
-          "Type": "pd-ssd"
-        },
-        {
           "Name": "disk-centos-7",
           "SourceImage": "projects/centos-cloud/global/images/family/centos-7",
           "SizeGb": "20",
@@ -39,12 +33,6 @@
         {
           "Name": "disk-centos-8",
           "SourceImage": "projects/centos-cloud/global/images/family/centos-8",
-          "SizeGb": "20",
-          "Type": "pd-ssd"
-        },
-        {
-          "Name": "disk-rhel-6",
-          "SourceImage": "projects/rhel-cloud/global/images/family/rhel-6",
           "SizeGb": "20",
           "Type": "pd-ssd"
         },
@@ -107,20 +95,6 @@
     "inst-create": {
       "CreateInstances": [
         {
-          "Name": "centos-6",
-          "Disks": [
-            {"Source": "disk-centos-6"}
-          ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
-          "StartupScript": "run_integ_tests",
-          "Metadata": {
-            "repo-owner": "${repo_owner}",
-            "repo-name": "${repo_name}",
-            "git-ref": "${git_ref}"
-          },
-          "MachineType": "n1-standard-2"
-        },
-        {
           "Name": "centos-7",
           "Disks": [
             {"Source": "disk-centos-7"}
@@ -138,20 +112,6 @@
           "Name": "centos-8",
           "Disks": [
             {"Source": "disk-centos-8"}
-          ],
-          "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
-          "StartupScript": "run_integ_tests",
-          "Metadata": {
-            "repo-owner": "${repo_owner}",
-            "repo-name": "${repo_name}",
-            "git-ref": "${git_ref}"
-          },
-          "MachineType": "n1-standard-2"
-        },
-        {
-          "Name": "rhel-6",
-          "Disks": [
-            {"Source": "disk-rhel-6"}
           ],
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"],
           "StartupScript": "run_integ_tests",
@@ -293,14 +253,6 @@
     "wait-for-stop": {
       "WaitForInstancesSignal": [
         {
-          "Name": "centos-6",
-          "SerialOutput": {
-            "Port": 1,
-            "FailureMatch": "Build failed",
-            "SuccessMatch": "Build succeeded"
-          }
-        },
-        {
           "Name": "centos-7",
           "SerialOutput": {
             "Port": 1,
@@ -310,14 +262,6 @@
         },
         {
           "Name": "centos-8",
-          "SerialOutput": {
-            "Port": 1,
-            "FailureMatch": "Build failed",
-            "SuccessMatch": "Build succeeded"
-          }
-        },
-        {
-          "Name": "rhel-6",
           "SerialOutput": {
             "Port": 1,
             "FailureMatch": "Build failed",


### PR DESCRIPTION
Removing CentOS6 and RHEL6 from integration tests