### PR TITLE
add pipeline-set-pipeline

### DIFF
--- a/concourse/pipeline/pipeline-set-pipeline.yaml
+++ b/concourse/pipeline/pipeline-set-pipeline.yaml
@@ -1,0 +1,15 @@
+---
+resources:
+- name: guest-test-infra
+  type: git
+  source:
+    uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
+    branch: master
+
+jobs:
+- name: set-pipelines
+  plan:
+  - get: guest-test-infra
+    trigger: true
+  - set_pipeline: linux-image-build
+    file: guest-test-infra/concourse/pipelines/linux-image-build.yaml


### PR DESCRIPTION
this will automate changes to the linux-image-build pipeline based on git commits

after merge, we will create this pipeline manually via `fly set-pipeline -p set-pipeline -c pipelines/pipeline-set-pipeline.yaml`
following this, new changes to linux-image-build.yaml will be applied automatically
new pipelines we want to automate may be added by updating this file and running set-pipeline again
later, we can add `set_pipeline: self` to this file to fully automate the process