### PR TITLE
add fly-validate-pipelines image

### DIFF
--- a/container_images/cloudbuild.yaml
+++ b/container_images/cloudbuild.yaml
@@ -17,6 +17,8 @@ steps:
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gointegtest:latest', '--tag=gcr.io/$PROJECT_ID/gointegtest:$COMMIT_SHA', './container_images/gointegtest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/pytest:latest', '--tag=gcr.io/$PROJECT_ID/pytest:$COMMIT_SHA', './container_images/pytest']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/fly-validate-pipelines:latest', '--tag=gcr.io/$PROJECT_ID/fly-validate-pipelines:$COMMIT_SHA', './container_images/fly-validate-pipelines']
 images:
   - 'gcr.io/$PROJECT_ID/gocheck:latest'
   - 'gcr.io/$PROJECT_ID/gocheck:$COMMIT_SHA'
@@ -36,3 +38,5 @@ images:
   - 'gcr.io/$PROJECT_ID/gointegtest:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/pytest:latest'
   - 'gcr.io/$PROJECT_ID/pytest:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/fly-validate-pipelines:latest'
+  - 'gcr.io/$PROJECT_ID/fly-validate-pipelines:$COMMIT_SHA'

--- a/container_images/fly-validate-pipelines/Dockerfile
+++ b/container_images/fly-validate-pipelines/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM arbourd/concourse-fly
+
+# Copy this Dockerfile for debugging.
+COPY Dockerfile Dockerfile
+COPY main.sh main.sh
+ENTRYPOINT ["./main.sh"]

--- a/container_images/fly-validate-pipelines/main.sh
+++ b/container_images/fly-validate-pipelines/main.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+BUILD_DIR=$1
+[[ -n $BUILD_DIR ]] && cd $BUILD_DIR
+
+echo 'Validating configs'
+find . -type f -iname '*.yaml'|while read yaml; do
+  fly vp -c "$yaml"
+done
+
+echo Done


### PR DESCRIPTION
build a container image for running `fly validate-pipeline` recursively
shame, it seems there is no `fly validate-task` equivalent