### PR TITLE
test wrapper fixes

### DIFF
--- a/test_manager/test_utils/test_utils.go
+++ b/test_manager/test_utils/test_utils.go
@@ -1,0 +1,85 @@
+package test_utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/storage"
+)
+
+const metadataUrlPrefix = "http://metadata.google.internal/computeMetadata/v1/instance/"
+
+// GetRealVMName returns the real name of a VM running in the same test.
+func GetRealVMName(name string) (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	parts := strings.SplitN(hostname, "-", 3)
+	if len(parts) != 3 {
+		return "", errors.New("hostname doesn't match scheme")
+	}
+	return strings.Join([]string{parts[0], name, parts[2]}, "-"), nil
+}
+
+func GetMetadataAttribute(attribute string) (string, error) {
+	return GetMetadata("attributes/" + attribute)
+}
+
+func GetMetadata(path string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", metadataUrlPrefix, path), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Metadata-Flavor", "Google")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("http response code is %v", resp.StatusCode)
+	}
+	val, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(val), nil
+}
+
+func DownloadGCSObject(ctx context.Context, client *storage.Client, gcsPath string) ([]byte, error) {
+	u, err := url.Parse(gcsPath)
+	if err != nil {
+		log.Fatalf("Failed to parse GCS url: %v\n", err)
+	}
+	object := strings.TrimPrefix(u.Path, "/")
+	rc, err := client.Bucket(u.Host).Object(object).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	data, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+func DownloadGCSObjectToFile(ctx context.Context, client *storage.Client, gcsPath, file string) error {
+	data, err := DownloadGCSObject(ctx, client, gcsPath)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(file, data, 0755); err != nil {
+		return err
+	}
+	return nil
+}

--- a/test_manager/test_utils/test_utils.go
+++ b/test_manager/test_utils/test_utils.go
@@ -14,7 +14,7 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-const metadataUrlPrefix = "http://metadata.google.internal/computeMetadata/v1/instance/"
+const metadataURLPrefix = "http://metadata.google.internal/computeMetadata/v1/instance/"
 
 // GetRealVMName returns the real name of a VM running in the same test.
 func GetRealVMName(name string) (string, error) {
@@ -29,12 +29,14 @@ func GetRealVMName(name string) (string, error) {
 	return strings.Join([]string{parts[0], name, parts[2]}, "-"), nil
 }
 
+// GetMetadataAttribute returns an attribute from metadata if present, and error if not.
 func GetMetadataAttribute(attribute string) (string, error) {
 	return GetMetadata("attributes/" + attribute)
 }
 
+// GetMetadata returns a metadata value for the specified key if it is present, and error if not.
 func GetMetadata(path string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", metadataUrlPrefix, path), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", metadataURLPrefix, path), nil)
 	if err != nil {
 		return "", err
 	}
@@ -54,6 +56,7 @@ func GetMetadata(path string) (string, error) {
 	return string(val), nil
 }
 
+// DownloadGCSObject downloads a GCS object.
 func DownloadGCSObject(ctx context.Context, client *storage.Client, gcsPath string) ([]byte, error) {
 	u, err := url.Parse(gcsPath)
 	if err != nil {
@@ -73,6 +76,8 @@ func DownloadGCSObject(ctx context.Context, client *storage.Client, gcsPath stri
 
 	return data, nil
 }
+
+// DownloadGCSObjectToFile downloads a GCS object, writing it to the specified file.
 func DownloadGCSObjectToFile(ctx context.Context, client *storage.Client, gcsPath, file string) error {
 	data, err := DownloadGCSObject(ctx, client, gcsPath)
 	if err != nil {

--- a/test_manager/test_wrapper/test_wrapper.go
+++ b/test_manager/test_wrapper/test_wrapper.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/guest-test-infra/test_manager/test_utils"
+	"github.com/GoogleCloudPlatform/guest-test-infra/test_manager/utils"
 	junitFormatter "github.com/jstemmer/go-junit-report/formatter"
 	junitParser "github.com/jstemmer/go-junit-report/parser"
 )
@@ -32,18 +32,18 @@ func main() {
 		log.Fatalf("failed to create cloud storage client: %v", err)
 	}
 
-	daisyOutsPath, err := test_utils.GetMetadataAttribute("daisy-outs-path")
+	daisyOutsPath, err := utils.GetMetadataAttribute("daisy-outs-path")
 	if err != nil {
 		log.Fatalf("failed to get metadata _test_binary_url: %v", err)
 	}
 	daisyOutsPath = daisyOutsPath + "/"
 
-	testBinaryURL, err := test_utils.GetMetadataAttribute("_test_binary_url")
+	testBinaryURL, err := utils.GetMetadataAttribute("_test_binary_url")
 	if err != nil {
 		log.Fatalf("failed to get metadata _test_binary_url: %v", err)
 	}
 
-	testRun, _ := test_utils.GetMetadataAttribute("_test_run")
+	testRun, _ := utils.GetMetadataAttribute("_test_run")
 
 	var testArguments = []string{"-test.v"}
 	if testRun != "" {
@@ -56,7 +56,7 @@ func main() {
 	}
 	workDir = workDir + "/"
 
-	if err = test_utils.DownloadGCSObjectToFile(ctx, client, testBinaryURL, workDir+testBinaryLocalName); err != nil {
+	if err = utils.DownloadGCSObjectToFile(ctx, client, testBinaryURL, workDir+testBinaryLocalName); err != nil {
 		log.Fatalf("failed to download object: %v", err)
 	}
 

--- a/test_manager/test_wrapper/test_wrapper.go
+++ b/test_manager/test_wrapper/test_wrapper.go
@@ -7,64 +7,76 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
-	"os"
 	"os/exec"
+	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/guest-test-infra/test_manager/test_utils"
 	junitFormatter "github.com/jstemmer/go-junit-report/formatter"
 	junitParser "github.com/jstemmer/go-junit-report/parser"
 )
 
 const (
-	metadataURLPrefix   = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/"
-	testResultObject    = "outs/junit_go-test.xml"
 	testBinaryLocalName = "image_test"
-	workDir             = "/workspace/"
-	artifactPath        = workDir + "artifact"
 )
 
 func main() {
+	// These are placeholders until daisy supports guest attributes.
+	log.Printf("FINISHED-BOOTING")
+	defer func() { log.Printf("FINISHED-TEST") }()
+
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		log.Fatalf("failed to create cloud storage client: %v", err)
 	}
 
-	testBinaryURL, err := getMetadataAttribute("_test_binary_url")
+	daisyOutsPath, err := test_utils.GetMetadataAttribute("daisy-outs-path")
+	if err != nil {
+		log.Fatalf("failed to get metadata _test_binary_url: %v", err)
+	}
+	daisyOutsPath = daisyOutsPath + "/"
+
+	testBinaryURL, err := test_utils.GetMetadataAttribute("_test_binary_url")
 	if err != nil {
 		log.Fatalf("failed to get metadata _test_binary_url: %v", err)
 	}
 
-	testRun, _ := getMetadataAttribute("_test_run")
+	testRun, _ := test_utils.GetMetadataAttribute("_test_run")
 
 	var testArguments = []string{"-test.v"}
 	if testRun != "" {
 		testArguments = append(testArguments, "-test.run", testRun)
 	}
 
-	if err = os.Mkdir(workDir, 0755); err != nil {
+	workDir, err := ioutil.TempDir("", "image_test")
+	if err != nil {
 		log.Fatalf("failed to create work dir: %v", err)
 	}
-	if err = os.Mkdir(artifactPath, 0755); err != nil {
-		log.Fatalf("failed to create artifact dir: %v", err)
-	}
-	if err = downloadGCSObject(ctx, client, testBinaryURL, workDir); err != nil {
+	workDir = workDir + "/"
+
+	if err = test_utils.DownloadGCSObjectToFile(ctx, client, testBinaryURL, workDir+testBinaryLocalName); err != nil {
 		log.Fatalf("failed to download object: %v", err)
 	}
 
-	out, err := executeCMD(workDir+testBinaryLocalName, workDir, testArguments)
+	out, err := executeCmd(workDir+testBinaryLocalName, workDir, testArguments)
 	if err != nil {
-		log.Fatalf("failed to execute test binary: %v", err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			log.Printf("test binary exited with error: %v stderr: %q", ee, ee.Stderr)
+		} else {
+			log.Fatalf("failed to execute test binary: %v stdout: %q", err, out)
+		}
 	}
+
+	log.Printf("command output:\n%s\n", out)
 
 	testData, err := convertTxtToJunit(out)
 	if err != nil {
 		log.Fatalf("failed to convert to junit format: %v", err)
 	}
 
-	if err = uploadGCSObject(ctx, client, testBinaryURL, testData); err != nil {
+	if err = uploadGCSObject(ctx, client, daisyOutsPath+"junit.xml", testData); err != nil {
 		log.Fatalf("failed to upload test result: %v", err)
 	}
 }
@@ -82,70 +94,27 @@ func convertTxtToJunit(in []byte) (*bytes.Buffer, error) {
 	return &b, nil
 }
 
-func executeCMD(cmd, dir string, arg []string) ([]byte, error) {
+func executeCmd(cmd, dir string, arg []string) ([]byte, error) {
 	command := exec.Command(cmd, arg...)
 	command.Dir = dir
-	log.Printf("The command: %v", command.String())
+	log.Printf("Going to execute: %q", command.String())
 
 	output, err := command.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute command: %v", err)
+		return output, err
 	}
 	return output, nil
 }
 
-func getMetadataAttribute(attribute string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, metadataURLPrefix+attribute, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Add("Metadata-Flavor", "Google")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("http response code is %d", resp.StatusCode)
-	}
-	val, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(val), nil
-}
-
-func downloadGCSObject(ctx context.Context, client *storage.Client, testBinaryURL, workDir string) error {
-	u, err := url.Parse(testBinaryURL)
+func uploadGCSObject(ctx context.Context, client *storage.Client, path string, data io.Reader) error {
+	u, err := url.Parse(path)
 	if err != nil {
 		log.Fatalf("failed to parse gcs url: %v", err)
 	}
-	bucket, object := u.Host, u.Path
+	object := strings.TrimPrefix(u.Path, "/")
+	log.Printf("uploading to bucket %s object %s\n", u.Host, object)
 
-	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to open the reader: %v", err)
-	}
-	defer rc.Close()
-
-	data, err := ioutil.ReadAll(rc)
-	if err != nil {
-		return fmt.Errorf("ioutil.ReadAll: %v", err)
-	}
-
-	if err = ioutil.WriteFile(workDir+testBinaryLocalName, data, 0755); err != nil {
-		return fmt.Errorf("failed to write file: %v", err)
-	}
-	return nil
-}
-
-func uploadGCSObject(ctx context.Context, client *storage.Client, testBinaryURL string, data io.Reader) error {
-	u, err := url.Parse(testBinaryURL)
-	if err != nil {
-		log.Fatalf("failed to parse gcs url: %v", err)
-	}
-	bucket := u.Host
-	dst := client.Bucket(bucket).Object(testResultObject).NewWriter(ctx)
+	dst := client.Bucket(u.Host).Object(object).NewWriter(ctx)
 	if _, err := io.Copy(dst, data); err != nil {
 		return fmt.Errorf("failed to write file: %v", err)
 	}

--- a/test_manager/utils/test_utils.go
+++ b/test_manager/utils/test_utils.go
@@ -1,4 +1,4 @@
-package test_utils
+package utils
 
 import (
 	"context"


### PR DESCRIPTION
* use tempdir for working directory
* add start and finish log lines for daisy
* upload result to daisy-outs rather than parsing test binary path
* don't fatal if tests failed, upload result anyway
* move metadata function to `utils` package