### PR TITLE
update cloud-image-tests container

### DIFF
--- a/container_images/cloud-image-tests/Dockerfile
+++ b/container_images/cloud-image-tests/Dockerfile
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2021 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,32 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM golang as builder
 
-set -e
+WORKDIR /go/src/
+COPY . .
+RUN chmod +x ./container_images/cloud-image-tests/build.sh
+RUN ./container_images/cloud-image-tests/build.sh
 
-export CGO_ENABLED=0 GOOS=linux
-cd test_manager
-mkdir /out
+FROM alpine
+COPY --from=builder /out/* /
 
-echo "Start Building"
-go get ./...
-cd testmanager
-go build -v -o /out/test_manager
-echo "go build exited with $?"
-cd ..
-cd test_wrapper
-go build -v -o /out/test_wrapper
-echo "go build exited with $?"
-cd ..
-
-cd test_suites
-for test_suite in *; do
-  go test -c ${test_suite} -o /out/${test_suite}.test
-  echo "go test -c exited with $?"
-done
-
-echo "All build output:"
-ls /out
-
-sync
-echo "Finish Building"
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
depends on #98 
depends on #100

rename entries to match new cloud image test layout.