### PR TITLE
fix folder path in docker

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -25,8 +25,8 @@ ENV GO111MODULE on
 RUN go mod download
 RUN go build -o /out/wrapper ./imagetest/cmd/wrapper/main.go
 RUN go build -o /out/manager ./imagetest/cmd/manager/main.go
-RUN for suite in ./imagetest/test_suites/*; do \
-  cd $suite; go test -c; mv *.test /out; cd ../../../; \
+RUN cd imagetest/test_suites; for suite in *; do \
+  cd $suite; go test -c; mv *.test /out; cd ..; \
   done
 
 FROM alpine:edge

--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -26,7 +26,7 @@ RUN go mod download
 RUN go build -o /out/wrapper ./imagetest/cmd/wrapper/main.go
 RUN go build -o /out/manager ./imagetest/cmd/manager/main.go
 RUN for suite in ./imagetest/test_suites/*; do \
-  cd $suite; go test -c; mv *.test /out; cd ..; \
+  cd $suite; go test -c; mv *.test /out; cd ../../../; \
   done
 
 FROM alpine:edge


### PR DESCRIPTION
Step 11/14 : RUN for suite in ./imagetest/test_suites/*; do   cd $suite; go test -c; mv *.test /out; cd ..;   done
 ---> Running in e3eb756765e3
/bin/sh: cd: line 1: can't cd to ./imagetest/test_suites/image_validation: No such file or directory
no Go files in /build/imagetest/test_suites
mv: can't rename '*.test': No such file or directory
Removing intermediate container e3eb756765e3
 ---> e447fabbf6b0
Step 12/14 : FROM alpine:edge
 ---> b0da5d0678e7
Step 13/14 : COPY --from=builder /out/* /
 ---> Using cache