### PR TITLE
Partner images export pipelines.

### DIFF
--- a/concourse/pipelines/partner-image-export.yaml
+++ b/concourse/pipelines/partner-image-export.yaml
@@ -1,0 +1,1042 @@
+---
+resource_types:
+- name: gcs
+  type: registry-image
+  source:
+    repository: frodenas/gcs-resource
+
+resources:
+- name: compute-image-tools
+  type: git
+  source:
+    uri: https://github.com/GoogleCloudPlatform/compute-image-tools.git
+    branch: master
+- name: guest-test-infra
+  type: git
+  source:
+    uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
+    branch: master
+- name: cos-81-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/cos/cos-81-lts-v([0-9]+).tar.gz"
+- name: cos-85-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/cos/cos-85-lts-v([0-9]+).tar.gz"
+- name: cos-89-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/cos/cos-89-lts-v([0-9]+).tar.gz"
+- name: cos-dev
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/cos/cos-dev-v([0-9]+).tar.gz"
+- name: fedora-33
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/fedora/fedora-33-v([0-9]+).tar.gz"
+- name: fedora-coreos-next
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/fedora/fedora-coreos-next-v([0-9]+).tar.gz"
+- name: fedora-coreos-stable
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/fedora/fedora-coreos-stable-v([0-9]+).tar.gz"
+- name: fedora-coreos-testing
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/fedora/fedora-coreos-testing-v([0-9]+).tar.gz"
+- name: freebsd-11
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/freebsd/freebsd-11-v([0-9]+).tar.gz"
+- name: freebsd-12
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/freebsd/freebsd-12-v([0-9]+).tar.gz"
+- name: freebsd-13
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/freebsd/freebsd-13-v([0-9]+).tar.gz"
+- name: opensuse-leap-15
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/suse/opensuse-leap-15-v([0-9]+).tar.gz"
+- name: sles-12
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/suse/sles-12-v([0-9]+).tar.gz"
+- name: sles-15
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/suse/sles-15-v([0-9]+).tar.gz"
+- name: ubuntu-1804-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/ubuntu/ubuntu-1804-lts-v([0-9]+).tar.gz"
+- name: ubuntu-2004-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/ubuntu/ubuntu-2004-lts-v([0-9]+).tar.gz"
+- name: ubuntu-pro-1604-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/ubuntu/ubuntu-pro-1604-lts-v([0-9]+).tar.gz"
+- name: ubuntu-pro-1804-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/ubuntu/ubuntu-pro-1804-lts-v([0-9]+).tar.gz"
+- name: ubuntu-pro-2004-lts
+  type: gcs
+  source:
+    bucket: gce-image-archive
+    json_key: |
+      ((gcs-key.credential))
+    regexp: "partner/ubuntu/ubuntu-pro-2004-lts-v([0-9]+).tar.gz"
+
+jobs:
+# Export jobs
+# Cos 81
+- name: export-cos-81-lts
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "cos-81-lts"
+  - put: cos-81-lts-gcs
+    params:
+      file: build-id-dir/cos-81-lts*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: cos-81-lts-gcs/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-cos-81-lts
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/cos_81_lts_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Cos 85
+- name: export-cos-85-lts
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "cos-85-lts"
+  - put: cos-85-lts-gcs
+    params:
+      file: build-id-dir/cos-85-lts*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: cos-85-lts-gcs/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-cos-85-lts
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/cos_85_lts_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Cos 89
+- name: export-cos-89-lts
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "cos-89-lts"
+  - put: cos-89-lts-gcs
+    params:
+      file: build-id-dir/cos-89-lts*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: cos-89-lts-gcs/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-cos-89-lts
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/cos_89_lts_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Cos dev
+- name: export-cos-dev
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "cos-dev"
+  - put: cos-dev-gcs
+    params:
+      file: build-id-dir/cos-dev*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: cos-dev-gcs/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-cos-dev
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/cos_dev_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Fedora 33
+- name: export-fedora-33
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "fedora-33"
+  - put: fedora-33-gcs
+    params:
+      file: build-id-dir/fedora-33*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: fedora-33-gcs/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-fedora-33
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/fedora_33_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Fedora CoreOS Next
+- name: export-fedora-coreos-next
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "fedora-coreos-next"
+  - put: fedora-coreos-next-gcs
+    params:
+      file: build-id-dir/fedora-coreos-next*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: fedora-coreos-next/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-fedora-coreos-next
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/fedora_coreos_next_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Fedora CoreOS Stable
+- name: export-fedora-coreos-stable
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "fedora-coreos-stable"
+  - put: fedora-coreos-stable-gcs
+    params:
+      file: build-id-dir/fedora-coreos-stable*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: fedora-coreos-stable/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-fedora-coreos-stable
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/fedora_coreos_stable_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Fedora CoreOS Testing
+- name: export-fedora-coreos-testing
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "fedora-coreos-testing"
+  - put: fedora-coreos-testing-gcs
+    params:
+      file: build-id-dir/fedora-coreos-testing*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: fedora-coreos-testing/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-fedora-coreos-testing
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/fedora_coreos_testing_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# FreeBSD 11
+- name: export-freebsd-11
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "freebsd-11"
+  - put: freebsd-11-gcs
+    params:
+      file: build-id-dir/freebsd-11*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: freebsd-11/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-freebsd-11
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/freebsd_11_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# FreeBSD 12
+- name: export-freebsd-12
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "freebsd-12"
+  - put: freebsd-12-gcs
+    params:
+      file: build-id-dir/freebsd-12*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: freebsd-12/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-freebsd-12
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/freebsd_12_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# FreeBSD 13
+- name: export-freebsd-13
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "freebsd-13"
+  - put: freebsd-13-gcs
+    params:
+      file: build-id-dir/freebsd-13*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: freebsd-13/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-freebsd-13
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/freebsd_13_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# openSUSE Leap 15
+- name: export-opensuse-leap-15
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "opensuse-leap-15"
+  - put: opensuse-leap-15-gcs
+    params:
+      file: build-id-dir/opensuse-leap-15*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: opensuse-leap-15/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-opensuse-leap-15
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/opensuse_leap_15_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# SLES 12
+- name: export-sles-12
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "sles-12"
+  - put: sles-12-gcs
+    params:
+      file: build-id-dir/sles-12*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: sles-12/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-sles-12
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/sles_12_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# SLES 15
+- name: export-sles-15
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "sles-15"
+  - put: sles-15-gcs
+    params:
+      file: build-id-dir/sles-15*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: sles-15/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-sles-15
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/sles_15_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Ubuntu 18.04
+- name: export-ubuntu-1804
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "ubuntu-1804"
+  - put: ubuntu-1804-gcs
+    params:
+      file: build-id-dir/ubuntu-1804*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: ubuntu-1804/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-ubuntu-1804
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/ubuntu_1804_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Ubuntu 20.04
+- name: export-ubuntu-2004
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "ubuntu-2004"
+  - put: ubuntu-2004-gcs
+    params:
+      file: build-id-dir/ubuntu-2004*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: ubuntu-2004/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-ubuntu-2004
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/ubuntu_2004_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Ubuntu Pro 16.04
+- name: export-ubuntu-pro-1604
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "ubuntu-pro-1604"
+  - put: ubuntu-pro-1604-gcs
+    params:
+      file: build-id-dir/ubuntu-pro-1604*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: ubuntu-pro-1604/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-ubuntu-pro-1604
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/ubuntu_pro_1604_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Ubuntu Pro 18.04
+- name: export-ubuntu-pro-1804
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "ubuntu-pro-1804"
+  - put: ubuntu-pro-1804-gcs
+    params:
+      file: build-id-dir/ubuntu-pro-1804*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: ubuntu-pro-1804/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-ubuntu-pro-1804
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/ubuntu_pro_1804_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+# Ubuntu Pro 20.04
+- name: export-ubuntu-pro-2004
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "ubuntu-pro-2004"
+  - put: ubuntu-pro-2004-gcs
+    params:
+      file: build-id-dir/ubuntu-pro-2004*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: ubuntu-pro-2004/url
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: daisy-export-ubuntu-pro-2004
+    file: guest-test-infra/concourse/tasks/daisy-export-images-partner.yaml
+    vars:
+      wf: "partner/ubuntu_pro_2004_export.wf.json"
+      gcs_url: ((.:gcs-url))
+      build_date: ((.:build-date))
+
+
+# Images for OS Loging staging tests.
+# COS 81 LTS
+- name: publish-oslogin-cos-81-lts
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: cos-81-lts-gcs
+    passed: [export-cos-81-lts]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: cos-81-lts-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-cos-81-lts
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/cos"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/cos_81_lts.publish.json"
+      environment: "oslogin_staging"
+# COS 85 LTS
+- name: publish-oslogin-cos-85-lts
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: cos-85-lts-gcs
+    passed: [export-cos-85-lts]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: cos-85-lts-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-cos-85-lts
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/cos"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/cos_85_lts.publish.json"
+      environment: "oslogin_staging"
+# COS 89 LTS
+- name: publish-oslogin-cos-89-lts
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: cos-89-lts-gcs
+    passed: [export-cos-89-lts]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: cos-89-lts-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-cos-89-lts
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/cos"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/cos_89_lts.publish.json"
+      environment: "oslogin_staging"
+# COS Dev
+- name: publish-oslogin-cos-dev
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: cos-dev-gcs
+    passed: [export-cos-dev]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: cos-dev-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-cos-dev
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/cos"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/cos_dev.publish.json"
+      environment: "oslogin_staging"
+# openSUSE Leap 15
+- name: publish-oslogin-opensuse-leap-15
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: opensuse-leap-15-gcs
+    passed: [export-opensuse-leap-15]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: opensuse-leap-15-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-opensuse-leap-15
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/suse"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/opensuse_leap_15.publish.json"
+      environment: "oslogin_staging"
+# SLES 12
+- name: publish-oslogin-sles-12
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: sles-12-gcs
+    passed: [export-sles-12]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: sles-12-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-sles-12
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/suse"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/sles_12.publish.json"
+      environment: "oslogin_staging"
+# SLES 15
+- name: publish-oslogin-sles-15
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: sles-15-gcs
+    passed: [export-sles-15]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: sles-15-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-sles-15
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/suse"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/sles_15.publish.json"
+      environment: "oslogin_staging"
+# Ubuntu 18.04
+- name: publish-oslogin-ubuntu-1804
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: ubuntu-1804-gcs
+    passed: [export-ubuntu-1804]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: ubuntu-1804-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-ubuntu-1804
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/ubuntu"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/ubuntu_1804.publish.json"
+      environment: "oslogin_staging"
+# Ubuntu 20.04
+- name: publish-oslogin-ubuntu-2004
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: ubuntu-2004-gcs
+    passed: [export-ubuntu-2004]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: ubuntu-2004-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-ubuntu-2004
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/ubuntu"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/ubuntu_2004.publish.json"
+      environment: "oslogin_staging"
+# Ubuntu Pro 16.04
+- name: publish-oslogin-ubuntu-pro-1604
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: ubuntu-pro-1604-gcs
+    passed: [export-ubuntu-pro-1604]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: ubuntu-1604-pro-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-ubuntu-pro-1604
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/ubuntu"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/ubuntu_pro_1604.publish.json"
+      environment: "oslogin_staging"
+# Ubuntu Pro 18.04
+- name: publish-oslogin-ubuntu-pro-1804
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: ubuntu-pro-1804-gcs
+    passed: [export-ubuntu-pro-1804]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: ubuntu-1804-pro-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-ubuntu-pro-1804- export-sles-15archive/partner/ubuntu"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/ubuntu_pro_1804.publish.json"
+      environment: "oslogin_staging"
+# Ubuntu Pro 20.04
+- name: publish-oslogin-ubuntu-pro-2004
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - get: ubuntu-pro-2004-gcs
+    passed: [export-ubuntu-pro-2004]
+    trigger: true
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: ubuntu-2004-pro-gcs/version
+  - task: get-credential
+    file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-ubuntu-pro-2004
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/ubuntu"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "partner/ubuntu_pro_2004.publish.json"
+      environment: "oslogin_staging"
+
+# Groups
+groups:
+- name: cos
+  jobs:
+  - export-cos-81-lts
+  - export-cos-85-lts
+  - export-cos-89-lts
+  - export-cos-dev
+  - publish-oslogin-cos-81-lts
+  - publish-oslogin-cos-85-lts
+  - publish-oslogin-cos-89-lts
+  - publish-oslogin-cos-dev
+- name: fedora
+  jobs:
+  - export-fedora-33
+  - export-fedora-coreos-next
+  - export-fedora-coreos-stable
+  - export-fedora-coreos-testing
+- name: freebsd
+  jobs:
+  - export-freebsd-11
+  - export-freebsd-12
+  - export-freebsd-13
+- name: suse
+  jobs:
+  - export-opensuse-leap-15
+  - export-sles-12
+  - export-sles-15
+  - publish-oslogin-opensuse-leap-15
+  - publish-oslogin-sles-12
+  - publish-oslogin-sles-15
+- name: ubuntu
+  jobs:
+  - export-ubuntu-1804
+  - export-ubuntu-2004
+  - export-ubuntu-pro-1604
+  - export-ubuntu-pro-1804
+  - export-ubuntu-pro-2004
+  - publish-oslogin-ubuntu-1804
+  - publish-oslogin-ubuntu-2004
+  - publish-oslogin-ubuntu-pro-1604
+  - publish-oslogin-ubuntu-pro-1804
+  - publish-oslogin-ubuntu-pro-2004

--- a/concourse/pipelines/partner-image-export.yaml
+++ b/concourse/pipelines/partner-image-export.yaml
@@ -967,6 +967,9 @@ jobs:
   - load_var: publish-version
     file: publish-version/version # produced from generate-version task
   - task: publish-ubuntu-pro-1804
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://gce-image-archive/partner/ubuntu"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
       wf: "partner/ubuntu_pro_1804.publish.json"

--- a/concourse/pipelines/partner-image-export.yaml
+++ b/concourse/pipelines/partner-image-export.yaml
@@ -1,3 +1,4 @@
+# Export partner images and publish relevant images for OS Login staging tests.
 ---
 resource_types:
 - name: gcs
@@ -965,7 +966,7 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-version.yaml
   - load_var: publish-version
     file: publish-version/version # produced from generate-version task
-  - task: publish-ubuntu-pro-1804- export-sles-15archive/partner/ubuntu"
+  - task: publish-ubuntu-pro-1804
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
       wf: "partner/ubuntu_pro_1804.publish.json"

--- a/concourse/pipelines/partner-image-export.yaml
+++ b/concourse/pipelines/partner-image-export.yaml
@@ -17,133 +17,133 @@ resources:
   source:
     uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
     branch: master
-- name: cos-81-lts
+- name: cos-81-lts-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/cos/cos-81-lts-v([0-9]+).tar.gz"
-- name: cos-85-lts
+- name: cos-85-lts-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/cos/cos-85-lts-v([0-9]+).tar.gz"
-- name: cos-89-lts
+- name: cos-89-lts-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/cos/cos-89-lts-v([0-9]+).tar.gz"
-- name: cos-dev
+- name: cos-dev-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/cos/cos-dev-v([0-9]+).tar.gz"
-- name: fedora-33
+- name: fedora-33-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/fedora/fedora-33-v([0-9]+).tar.gz"
-- name: fedora-coreos-next
+- name: fedora-coreos-next-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/fedora/fedora-coreos-next-v([0-9]+).tar.gz"
-- name: fedora-coreos-stable
+- name: fedora-coreos-stable-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/fedora/fedora-coreos-stable-v([0-9]+).tar.gz"
-- name: fedora-coreos-testing
+- name: fedora-coreos-testing-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/fedora/fedora-coreos-testing-v([0-9]+).tar.gz"
-- name: freebsd-11
+- name: freebsd-11-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/freebsd/freebsd-11-v([0-9]+).tar.gz"
-- name: freebsd-12
+- name: freebsd-12-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/freebsd/freebsd-12-v([0-9]+).tar.gz"
-- name: freebsd-13
+- name: freebsd-13-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/freebsd/freebsd-13-v([0-9]+).tar.gz"
-- name: opensuse-leap-15
+- name: opensuse-leap-15-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/suse/opensuse-leap-15-v([0-9]+).tar.gz"
-- name: sles-12
+- name: sles-12-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/suse/sles-12-v([0-9]+).tar.gz"
-- name: sles-15
+- name: sles-15-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/suse/sles-15-v([0-9]+).tar.gz"
-- name: ubuntu-1804-lts
+- name: ubuntu-1804-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/ubuntu/ubuntu-1804-lts-v([0-9]+).tar.gz"
-- name: ubuntu-2004-lts
+- name: ubuntu-2004-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/ubuntu/ubuntu-2004-lts-v([0-9]+).tar.gz"
-- name: ubuntu-pro-1604-lts
+- name: ubuntu-pro-1604-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/ubuntu/ubuntu-pro-1604-lts-v([0-9]+).tar.gz"
-- name: ubuntu-pro-1804-lts
+- name: ubuntu-pro-1804-gcs
   type: gcs
   source:
     bucket: gce-image-archive
     json_key: |
       ((gcs-key.credential))
     regexp: "partner/ubuntu/ubuntu-pro-1804-lts-v([0-9]+).tar.gz"
-- name: ubuntu-pro-2004-lts
+- name: ubuntu-pro-2004-gcs
   type: gcs
   source:
     bucket: gce-image-archive

--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -19,3 +19,5 @@ jobs:
     file: guest-test-infra/concourse/pipelines/dev-image-build.yaml
   - set_pipeline: bare-metal-image-build
     file: guest-test-infra/concourse/pipelines/bare-metal-image-build.yaml
+  - set_pipeline: partner-image-export
+    file: guest-test-infra/concourse/pipelines/partner-image-export.yaml

--- a/concourse/tasks/daisy-export-images-partner.yaml
+++ b/concourse/tasks/daisy-export-images-partner.yaml
@@ -1,0 +1,25 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/compute-image-tools/daisy
+    tag: latest
+
+inputs:
+- name: compute-image-tools
+- name: credentials
+- name: publish-version
+
+params:
+  GOOGLE_APPLICATION_CREDENTIALS: "credentials/credentials.json"
+
+run:
+  path: /daisy
+  args:
+  - -project=gce-image-builder
+  - -zone=us-central1-c
+  - -var:build_date=((build_date))
+  - -var:gcs_url=((gcs_url))
+  - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
+  - ./compute-image-tools/daisy_workflows/build-publish/((wf))


### PR DESCRIPTION
These workflows simply export a set of partner images to GCS and then publish some of those images to a staging project used for OS Login staging tests.