### PR TITLE
Image test mtu

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
 	imageboot "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/image_boot"
 	imagevalidation "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/image_validation"
-	network "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/network"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/network"
 )
 
 var (

--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
 	imageboot "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/image_boot"
 	imagevalidation "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/image_validation"
+	network "github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/network"
 )
 
 var (
@@ -50,6 +51,10 @@ func main() {
 		{
 			imageboot.Name,
 			imageboot.TestSetup,
+		},
+		{
+			network.Name,
+			network.TestSetup,
 		},
 	}
 

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	gceMTU                 = 1460
-	defaultInterface       = "eth0"
-	defaultDebianInterface = "ens4"
+	gceMTU            = 1460
+	defaultInterface  = "eth0"
+	debian10Interface = "ens4"
+	ubuntuInterface   = "ens4"
 )
 
 var (
@@ -40,7 +41,9 @@ func TestDefaultMTU(t *testing.T) {
 
 	switch {
 	case strings.Contains(image, "debian-10"):
-		networkInterface = defaultDebianInterface
+		networkInterface = debian10Interface
+	case strings.Contains(image, "ubuntu"):
+		networkInterface = ubuntuInterface
 	default:
 		networkInterface = defaultInterface
 	}

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -45,27 +45,23 @@ func TestDefaultMTU(t *testing.T) {
 		networkInterface = defaultInterface
 	}
 
-	isDefault, err := isDefaultGCEMTU(networkInterface)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if !isDefault {
+	if err := isDefaultGCEMTU(networkInterface); err != nil {
 		t.Fatal(err.Error())
 	}
 }
 
-func isDefaultGCEMTU(interfaceName string) (bool, error) {
+func isDefaultGCEMTU(interfaceName string) error {
 	ifs, err := net.Interfaces()
 	if err != nil {
-		return false, fmt.Errorf("can't get network interface")
+		return err
 	}
 	for _, i := range ifs {
 		if i.Name == interfaceName {
 			if i.MTU != gceMTU {
-				return false, fmt.Errorf("expected MTU %d on interface %s, got MTU %s", gceMTU, i.Name, i.MTU)
+				return fmt.Errorf("expected MTU %d on interface %s, got MTU %d", gceMTU, i.Name, i.MTU)
 			}
-			return true, nil
+			return nil
 		}
 	}
-	return false, fmt.Errorf("can't find network interface %s", interfaceName)
+	return fmt.Errorf("can't find network interface %s", interfaceName)
 }

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -12,10 +12,9 @@ import (
 )
 
 const (
-	gceMTU            = 1460
-	defaultInterface  = "eth0"
-	debian10Interface = "ens4"
-	ubuntuInterface   = "ens4"
+	gceMTU                      = 1460
+	defaultInterface            = "eth0"
+	defaultPredictableInterface = "ens4"
 )
 
 var (
@@ -40,10 +39,8 @@ func TestDefaultMTU(t *testing.T) {
 	}
 
 	switch {
-	case strings.Contains(image, "debian-10"):
-		networkInterface = debian10Interface
-	case strings.Contains(image, "ubuntu"):
-		networkInterface = ubuntuInterface
+	case strings.Contains(image, "debian-10") || strings.Contains(image, "ubuntu"):
+		networkInterface = defaultPredictableInterface
 	default:
 		networkInterface = defaultInterface
 	}

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -1,0 +1,71 @@
+package network
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
+const (
+	gceMTU                 = 1460
+	defaultInterface       = "eth0"
+	defaultDebianInterface = "ens4"
+)
+
+var (
+	runtest = flag.Bool("runtest", false, "really run the test")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *runtest {
+		os.Exit(m.Run())
+	} else {
+		os.Exit(0)
+	}
+}
+
+func TestDefaultMTU(t *testing.T) {
+	var networkInterface string
+
+	image, err := utils.GetMetadata("image")
+	if err != nil {
+		t.Fatalf("couldn't get image from metadata")
+	}
+
+	switch {
+	case strings.Contains(image, "debian-10"):
+		networkInterface = defaultDebianInterface
+	default:
+		networkInterface = defaultInterface
+	}
+
+	isDefault, err := isDefaultGCEMTU(networkInterface)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !isDefault {
+		t.Fatal(err.Error())
+	}
+}
+
+func isDefaultGCEMTU(interfaceName string) (bool, error) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return false, fmt.Errorf("can't get network interface")
+	}
+	for _, i := range ifs {
+		if i.Name == interfaceName {
+			if i.MTU != gceMTU {
+				return false, fmt.Errorf("expected MTU %d on interface %s, got MTU %s", gceMTU, i.Name, i.MTU)
+			}
+			return true, nil
+		}
+	}
+	return false, fmt.Errorf("can't find network interface %s", interfaceName)
+}

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -1,0 +1,16 @@
+package network
+
+import "github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+
+// Name is the name of the test package. It must match the directory name.
+var Name = "network"
+
+// TestSetup sets up the test workflow.
+func TestSetup(t *imagetest.TestWorkflow) error {
+	vm, err := t.CreateTestVM("vm")
+	if err != nil {
+		return err
+	}
+	vm.RunTests("TestDefaultMTU")
+	return nil
+}

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -7,10 +7,6 @@ var Name = "network"
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm, err := t.CreateTestVM("vm")
-	if err != nil {
-		return err
-	}
-	vm.RunTests("TestDefaultMTU")
-	return nil
+	_, err := t.CreateTestVM("vm")
+	return err
 }


### PR DESCRIPTION
➜  manager git:(image-test-mtu) /out/manager -project hanga-testing -zone us-west1-c -images projects/debian-cloud/global/images/debian-10-buster-v20210316
2021/04/23 23:22:09 imagetest: Done with setup
runTestWorkflow: running image_validation on debian-10-buster-v20210316 (ID vnzzl)
runTestWorkflow: running image_boot on debian-10-buster-v20210316 (ID m1bd9)
runTestWorkflow: running network on debian-10-buster-v20210316 (ID pxn2g)
```
<testsuites name="" errors="0" failures="0" tests="0" time="0">
	<testsuite name="network-debian-10-buster-v20210316" tests="1" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="" name="TestDefaultMTU" time="0"></testcase>
	</testsuite>
	<testsuite name="image_validation-debian-10-buster-v20210316" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="" name="TestHostname" time="0"></testcase>
		<testcase classname="" name="TestFQDN" time="0.01"></testcase>
		<testcase classname="" name="TestHostKeysGeneratedOnce" time="0.03"></testcase>
		<testcase classname="" name="TestCustomHostname" time="0.01"></testcase>
	</testsuite>
	<testsuite name="image_boot-debian-10-buster-v20210316" tests="2" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="" name="TestGuestBoot" time="0"></testcase>
		<testcase classname="" name="TestGuestReboot" time="0"></testcase>
	</testsuite>
</testsuites>
```