### PR TITLE
merge agent integ test

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -1,14 +1,19 @@
 ---
 jobs:
-- name: guest-agent-integration-test
+
+- name: build-guest-agent
   plan:
   - get: guest-agent
     trigger: true
     params:
       skip_download: true
+  - load_var: commit-sha
+    file: guest-agent/.git/ref
   - get: guest-test-infra
   - task: get-credential
     file: guest-test-infra/concourse/tasks/get-credential.yaml
+  - task: get-github-token
+    file: guest-test-infra/concourse/tasks/get-github-token.yaml
   - task: generate-timestamp
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: timestamp
@@ -23,21 +28,6 @@ jobs:
     vars:
       timestamp: ((.:timestamp))
       repo-name: guest-agent
-
-- name: build-guest-agent
-  plan:
-  - get: guest-agent
-    passed: [guest-agent-integration-test]
-    trigger: true
-    params:
-      skip_download: true
-  - load_var: commit-sha
-    file: guest-agent/.git/ref
-  - get: guest-test-infra
-  - task: get-credential
-    file: guest-test-infra/concourse/tasks/get-credential.yaml
-  - task: get-github-token
-    file: guest-test-infra/concourse/tasks/get-github-token.yaml
   - task: generate-package-version
     file: guest-test-infra/concourse/tasks/generate-package-version.yaml
     input_mapping: {repo: guest-agent}


### PR DESCRIPTION
merge guest-agent integration tests into the `build-guest-agent` job.

the principle for whether an action should be captured in a distinct `job` is largely whether or not we would want to run that job independently of others. in the case of guest-agent integration tests, we always want to run them as a prerequisite to building packages of this version, and never independently. therefore, merge these steps into the build-package job just as unit tests are already included.