### PR TITLE
Skip secure boot test on Rocky Linux which doesn't yet support it.

### DIFF
--- a/imagetest/test_suites/image_boot/image_boot_test.go
+++ b/imagetest/test_suites/image_boot/image_boot_test.go
@@ -56,8 +56,8 @@ func TestGuestSecureBoot(t *testing.T) {
 	}
 
 	if strings.Contains(image, "rocky-linux-8") {
-                t.Skip("secure boot is not yet supported on Rocky Linux")
-        }
+		t.Skip("secure boot is not yet supported on Rocky Linux")
+	}
 
 	if _, err := os.Stat(secureBootFile); os.IsNotExist(err) {
 		t.Fatal("efi var is missing")

--- a/imagetest/test_suites/image_boot/image_boot_test.go
+++ b/imagetest/test_suites/image_boot/image_boot_test.go
@@ -55,6 +55,10 @@ func TestGuestSecureBoot(t *testing.T) {
 		t.Skip("secure boot is not supported on Debian 9")
 	}
 
+	if strings.Contains(image, "rocky-linux-8") {
+                t.Skip("secure boot is not yet supported on Rocky Linux")
+        }
+
 	if _, err := os.Stat(secureBootFile); os.IsNotExist(err) {
 		t.Fatal("efi var is missing")
 	}


### PR DESCRIPTION
Note that Rocky Linux will support secure boot soon - just not yet.