### PR TITLE
fix rhel 7.4 sap

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -25,7 +25,7 @@ var (
 	validate      = flag.Bool("validate", false, "validate all the test workflows and exit")
 	outPath       = flag.String("out_path", "junit.xml", "junit xml path")
 	images        = flag.String("images", "", "comma separated list of images to test")
-	timeout       = flag.String("timeout", "30m", "timeout for the test suite")
+	timeout       = flag.String("timeout", "60m", "timeout for the test suite")
 	parallelCount = flag.Int("parallel_count", 5, "TestParallelCount")
 	filter        = flag.String("filter", "", "only run tests matching filter")
 )

--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -25,7 +25,7 @@ var (
 	validate      = flag.Bool("validate", false, "validate all the test workflows and exit")
 	outPath       = flag.String("out_path", "junit.xml", "junit xml path")
 	images        = flag.String("images", "", "comma separated list of images to test")
-	timeout       = flag.String("timeout", "60m", "timeout for the test suite")
+	timeout       = flag.String("timeout", "30m", "timeout for the test suite")
 	parallelCount = flag.Int("parallel_count", 5, "TestParallelCount")
 	filter        = flag.String("filter", "", "only run tests matching filter")
 )

--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -58,27 +58,29 @@ func TestCustomHostname(t *testing.T) {
 
 // TestFQDN tests the 'fully qualified domain name', using the logic in the `hostname` utility.
 func TestFQDN(t *testing.T) {
+	image, err := utils.GetMetadata("image")
+	if err != nil {
+		t.Fatalf("couldn't get image from metadata")
+	}
+
+	if strings.Contains(image, "rhel-7-4-sap") {
+		t.Skip("hostname is not working well on RHEL 7-4-Sap")
+	}
+
 	metadataHostname, err := utils.GetMetadata("hostname")
 	if err != nil {
 		t.Fatalf("couldn't determine metadata hostname")
 	}
 
 	// This command is not safe on multi-NIC VMs. See HOSTNAME(1), section 'THE FQDN'.
-	cmd := exec.Command("/bin/hostname", "-a")
+	cmd := exec.Command("/bin/hostname", "-A")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("hostname command failed")
 	}
 	hostname := strings.TrimRight(string(out), " \n")
 
-	cmd = exec.Command("/bin/hostname", "-d")
-	out, err = cmd.Output()
-	if err != nil {
-		t.Fatalf("hostname command failed")
-	}
-	domain := strings.TrimRight(string(out), " \n")
-
-	if hostname+"."+domain != metadataHostname {
+	if hostname != metadataHostname {
 		t.Errorf("hostname does not match metadata. Expected: %q got: %q", metadataHostname, hostname)
 	}
 }

--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -64,14 +64,21 @@ func TestFQDN(t *testing.T) {
 	}
 
 	// This command is not safe on multi-NIC VMs. See HOSTNAME(1), section 'THE FQDN'.
-	cmd := exec.Command("/bin/hostname", "-A")
+	cmd := exec.Command("/bin/hostname", "-a")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("hostname command failed")
 	}
 	hostname := strings.TrimRight(string(out), " \n")
 
-	if hostname != metadataHostname {
+	cmd = exec.Command("/bin/hostname", "-d")
+	out, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("hostname command failed")
+	}
+	domain := strings.TrimRight(string(out), " \n")
+
+	if hostname+"."+domain != metadataHostname {
 		t.Errorf("hostname does not match metadata. Expected: %q got: %q", metadataHostname, hostname)
 	}
 }


### PR DESCRIPTION
```		
<testcase classname="" name="TestFQDN" time="0.04">
			<failure type="">    image_validation_test.go:75: hostname does not match metadata. Expected: &#34;vm1-image-validation-5615n.c.gcp-guest.internal&#34; got: &#34;&#34;</failure>

	<testsuite name="image_boot-debian-11-bullseye-v20210628" tests="1" failures="0" errors="1" disabled="0" skipped="0" time="0">
		<system-err>step &#34;wait-vm2&#34; did not complete within the specified timeout of 30m0s</system-err>
	</testsuite>
```