### PR TITLE
Fix test flakes for Debian and Rocky Linux

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
@@ -22,7 +23,10 @@ const (
 func main() {
 	// These are placeholders until daisy supports guest attributes.
 	log.Printf("FINISHED-BOOTING")
-	defer func() { log.Printf("FINISHED-TEST") }()
+	defer func() {
+		log.Printf("FINISHED-TEST")
+		time.Sleep(1 * time.Second)
+	}()
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)

--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -33,9 +33,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		t.Skip("secure boot is not supported on Debian 9")
 	}
 
-  if strings.Contains(t.Image, "rocky-linux-8") {
-    t.Skip("secure boot is not supported on Rocky Linux")
-  }
+	if strings.Contains(t.Image, "rocky-linux-8") {
+		t.Skip("secure boot is not supported on Rocky Linux")
+	}
 
 	vm2, err := t.CreateTestVM("vm2")
 	if err != nil {

--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -33,6 +33,10 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		t.Skip("secure boot is not supported on Debian 9")
 	}
 
+  if strings.Contains(t.Image, "rocky-linux-8") {
+    t.Skip("secure boot is not supported on Rocky Linux")
+  }
+
 	vm2, err := t.CreateTestVM("vm2")
 	if err != nil {
 		return err


### PR DESCRIPTION
Until Rocky Linux supports secure boot, the second VM fails to boot and the test just times out.

```
BdsDxe: failed to load Boot0001 "UEFI Google PersistentDisk " from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0): Security Violation
```