### PR TITLE
CIT fixups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
-	golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e // indirect
+	golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e
 	google.golang.org/api v0.42.0
 	google.golang.org/genproto v0.0.0-20210317182105-75c7a8546eb9 // indirect
 )

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -16,6 +16,7 @@ package imagetest
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
 	"google.golang.org/api/compute/v1"
@@ -25,7 +26,7 @@ const (
 	createVMsStepName        = "create-vms"
 	createDisksStepName      = "create-disks"
 	createNetworkStepName    = "create-networks"
-	createSubNetworkStepName = "create-sub-networks"
+	createSubnetworkStepName = "create-sub-networks"
 	successMatch             = "FINISHED-TEST"
 )
 
@@ -36,18 +37,63 @@ type TestVM struct {
 	instance     *daisy.Instance
 }
 
-// AddMetadata adds the specified key:value pair to metadata during VM creation.
-func (t *TestVM) AddMetadata(key, value string) {
-	createVMStep := t.testWorkflow.wf.Steps[createVMsStepName]
-	for _, vm := range createVMStep.CreateInstances.Instances {
-		if vm.Name == t.name {
-			if vm.Metadata == nil {
-				vm.Metadata = make(map[string]string)
-			}
-			vm.Metadata[key] = value
-			return
+// Skip marks a test workflow to be skipped.
+func (t *TestWorkflow) Skip(message string) {
+	t.skipped = true
+	t.skippedMessage = message
+}
+
+// SkippedMessage returns the skip reason message for the workflow.
+func (t *TestWorkflow) SkippedMessage() string {
+	return t.skippedMessage
+}
+
+// CreateTestVM creates the necessary steps to create a VM with the specified name to the workflow.
+func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
+	parts := strings.Split(name, ".")
+	vmname := strings.ReplaceAll(parts[0], "_", "-")
+
+	createDisksStep, err := t.appendCreateDisksStep(vmname)
+	if err != nil {
+		return nil, err
+	}
+
+	// createDisksStep doesn't depend on any other steps.
+	createVMStep, i, err := t.appendCreateVMStep(vmname, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
+		return nil, err
+	}
+
+	waitStep, err := t.addWaitStep(vmname, vmname, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := t.wf.AddDependency(waitStep, createVMStep); err != nil {
+		return nil, err
+	}
+
+	if createNetworksStep, ok := t.wf.Steps[createNetworkStepName]; ok {
+		if err := t.wf.AddDependency(createVMStep, createNetworksStep); err != nil {
+			return nil, err
 		}
 	}
+
+	return &TestVM{name: vmname, testWorkflow: t, instance: i}, nil
+}
+
+// AddMetadata adds the specified key:value pair to metadata during VM creation.
+func (t *TestVM) AddMetadata(key, value string) {
+	if t.instance.Metadata == nil {
+		t.instance.Metadata = make(map[string]string)
+	}
+	t.instance.Metadata[key] = value
+
+	return
 }
 
 // RunTests runs only the named tests on the testVM.
@@ -79,6 +125,7 @@ func (t *TestVM) SetStartupScript(script string) {
 // Reboot stops the VM, waits for it to shutdown, then starts it again. Your
 // test package must handle being run twice.
 func (t *TestVM) Reboot() error {
+	// TODO: better solution than a shared counter for name collisions.
 	t.testWorkflow.counter++
 	stepSuffix := fmt.Sprintf("%s-%d", t.name, t.testWorkflow.counter)
 
@@ -126,16 +173,16 @@ func (t *TestVM) Reboot() error {
 }
 
 // ResizeDiskAndReboot resize the disk of the current test VMs and reboot
-func (t *TestVM) ResizeDiskAndReboot(vmname string, diskSize int) error {
+func (t *TestVM) ResizeDiskAndReboot(diskSize int) error {
 	t.testWorkflow.counter++
 	stepSuffix := fmt.Sprintf("%s-%d", t.name, t.testWorkflow.counter)
 
-	lastStep, err := t.testWorkflow.getLastStepForVM(vmname)
+	lastStep, err := t.testWorkflow.getLastStepForVM(t.name)
 	if err != nil {
 		return fmt.Errorf("failed resolve last step")
 	}
 
-	diskResizeStep, err := t.testWorkflow.addDiskResizeStep(stepSuffix, vmname, diskSize)
+	diskResizeStep, err := t.testWorkflow.addDiskResizeStep(stepSuffix, t.name, diskSize)
 	if err != nil {
 		return err
 	}
@@ -149,13 +196,8 @@ func (t *TestVM) ResizeDiskAndReboot(vmname string, diskSize int) error {
 
 // EnableSecureBoot make the current test VMs in workflow with secure boot.
 func (t *TestVM) EnableSecureBoot() {
-	for _, i := range t.testWorkflow.wf.Steps[createVMsStepName].CreateInstances.Instances {
-		if i.Name == t.name {
-			i.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{
-				EnableSecureBoot: true,
-			}
-			break
-		}
+	t.instance.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{
+		EnableSecureBoot: true,
 	}
 }
 
@@ -163,39 +205,110 @@ func (t *TestVM) EnableSecureBoot() {
 // subnetwork. If subnetwork is empty, not using subnetwork, in this case
 // network has to be in auto mode VPC.
 func (t *TestVM) SetCustomNetwork(networkName, subnetworkName string) error {
-	for _, n := range *(t.testWorkflow.wf.Steps[createNetworkStepName].CreateNetworks) {
-		if n.Name == networkName && *n.AutoCreateSubnetworks == false && subnetworkName == "" {
-			return fmt.Errorf("network %s with custom mode must provide subnetwork", networkName)
-		}
+	// If no subnet is provided, check the network is in auto mode.
+	createNetworksStep, ok := t.testWorkflow.wf.Steps[createNetworkStepName]
+	if !ok {
+		return fmt.Errorf("Missing create-networks step")
 	}
-	for _, i := range t.testWorkflow.wf.Steps[createVMsStepName].CreateInstances.Instances {
-		if i.Name == t.name {
-			networkInterface := compute.NetworkInterface{
-				Network:    networkName,
-				Subnetwork: subnetworkName,
-				AccessConfigs: []*compute.AccessConfig{
-					{
-						Type: "ONE_TO_ONE_NAT",
-					},
-				},
-			}
 
-			i.NetworkInterfaces = []*compute.NetworkInterface{&networkInterface}
+	var found bool
+	for _, n := range *(createNetworksStep.CreateNetworks) {
+		if n.Name == networkName {
+			found = true
+			if subnetworkName == "" && *n.AutoCreateSubnetworks == false {
+				return fmt.Errorf("network %s is not auto mode, subnet is required", networkName)
+			}
 			break
 		}
 	}
+	if !found {
+		return fmt.Errorf("Couldn't find network %s", networkName)
+	}
+
+	// Add network config.
+	networkInterface := compute.NetworkInterface{
+		Network:    networkName,
+		Subnetwork: subnetworkName,
+		AccessConfigs: []*compute.AccessConfig{
+			{
+				Type: "ONE_TO_ONE_NAT",
+			},
+		},
+	}
+	t.instance.NetworkInterfaces = []*compute.NetworkInterface{&networkInterface}
+
 	return nil
 }
 
 // AddAliasIPRanges add alias ip range to current test VMs.
-func (t *TestVM) AddAliasIPRanges(aliasIPRange, rangeName string) {
-	for _, i := range t.testWorkflow.wf.Steps[createVMsStepName].CreateInstances.Instances {
-		if i.Name == t.name {
-			i.NetworkInterfaces[0].AliasIpRanges = append(i.NetworkInterfaces[0].AliasIpRanges, &compute.AliasIpRange{
-				IpCidrRange:         aliasIPRange,
-				SubnetworkRangeName: rangeName,
-			})
-			break
+func (t *TestVM) AddAliasIPRanges(aliasIPRange, rangeName string) error {
+	// TODO: If we haven't set any NetworkInterface struct, does it make sense to support adding alias IPs?
+	if t.instance.NetworkInterfaces == nil {
+		return fmt.Errorf("Must call SetCustomNetwork prior to AddAliasIPRanges")
+	}
+	t.instance.NetworkInterfaces[0].AliasIpRanges = append(t.instance.NetworkInterfaces[0].AliasIpRanges, &compute.AliasIpRange{
+		IpCidrRange:         aliasIPRange,
+		SubnetworkRangeName: rangeName,
+	})
+
+	return nil
+}
+
+// Network represent network used by vm in setup.go.
+type Network struct {
+	name         string
+	testWorkflow *TestWorkflow
+	network      *daisy.Network
+}
+
+// Subnetwork represent subnetwork used by vm in setup.go.
+type Subnetwork struct {
+	name         string
+	testWorkflow *TestWorkflow
+	subnetwork   *daisy.Subnetwork
+	network      *Network
+}
+
+// CreateNetwork creates custom network. Using SetCustomNetwork method provided by
+// TestVM to config network on vm
+func (t *TestWorkflow) CreateNetwork(networkName string, autoCreateSubnetworks bool) (*Network, error) {
+	createNetworkStep, network, err := t.appendCreateNetworkStep(networkName, autoCreateSubnetworks)
+	if err != nil {
+		return nil, err
+	}
+
+	createVMsStep, ok := t.wf.Steps[createVMsStepName]
+	if ok {
+		if err := t.wf.AddDependency(createVMsStep, createNetworkStep); err != nil {
+			return nil, err
 		}
 	}
+
+	return &Network{networkName, t, network}, nil
+}
+
+// CreateSubnetwork creates custom subnetwork. Using SetCustomNetwork method
+// provided by TestVM to config network on vm
+func (n *Network) CreateSubnetwork(name string, ipRange string) (*Subnetwork, error) {
+	createSubnetworksStep, subnetwork, err := n.testWorkflow.appendCreateSubnetworksStep(name, ipRange, n.name)
+	if err != nil {
+		return nil, err
+	}
+	createNetworkStep, ok := n.testWorkflow.wf.Steps[createNetworkStepName]
+	if !ok {
+		return nil, fmt.Errorf("create-network step missing")
+	}
+	if err := n.testWorkflow.wf.AddDependency(createSubnetworksStep, createNetworkStep); err != nil {
+		return nil, err
+	}
+
+	return &Subnetwork{name, n.testWorkflow, subnetwork, n}, nil
+}
+
+// AddSecondaryRange add secondary IP range to Subnetwork
+func (s Subnetwork) AddSecondaryRange(rangeName, ipRange string) {
+	s.subnetwork.SecondaryIpRanges = append(s.subnetwork.SecondaryIpRanges, &compute.SubnetworkSecondaryRange{
+		IpCidrRange: ipRange,
+		RangeName:   rangeName,
+	})
 }

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -204,30 +204,20 @@ func (t *TestVM) EnableSecureBoot() {
 // SetCustomNetwork set current test VMs in workflow using provided network and
 // subnetwork. If subnetwork is empty, not using subnetwork, in this case
 // network has to be in auto mode VPC.
-func (t *TestVM) SetCustomNetwork(networkName, subnetworkName string) error {
-	// If no subnet is provided, check the network is in auto mode.
-	createNetworksStep, ok := t.testWorkflow.wf.Steps[createNetworkStepName]
-	if !ok {
-		return fmt.Errorf("Missing create-networks step")
-	}
-
-	var found bool
-	for _, n := range *(createNetworksStep.CreateNetworks) {
-		if n.Name == networkName {
-			found = true
-			if subnetworkName == "" && *n.AutoCreateSubnetworks == false {
-				return fmt.Errorf("network %s is not auto mode, subnet is required", networkName)
-			}
-			break
+func (t *TestVM) SetCustomNetwork(network *Network, subnetwork *Subnetwork) error {
+	var subnetworkName string
+	if subnetwork == nil {
+		subnetworkName = ""
+		if !*network.network.AutoCreateSubnetworks {
+			return fmt.Errorf("network %s is not auto mode, subnet is required", network.name)
 		}
-	}
-	if !found {
-		return fmt.Errorf("Couldn't find network %s", networkName)
+	} else {
+		subnetworkName = subnetwork.name
 	}
 
 	// Add network config.
 	networkInterface := compute.NetworkInterface{
-		Network:    networkName,
+		Network:    network.name,
 		Subnetwork: subnetworkName,
 		AccessConfigs: []*compute.AccessConfig{
 			{

--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -127,13 +127,11 @@ func TestAddAliasIPRanges(t *testing.T) {
 	if err := tvm.AddAliasIPRanges("aliasIPRange", "rangeName"); err == nil {
 		t.Fatalf("shouldn't be able to set alias IP without calling setcustomnetwork")
 	}
-	if err := tvm.SetCustomNetwork("network", ""); err == nil {
-		t.Errorf("shouldn't be able to set non-existent network")
-	}
-	if _, err := twf.CreateNetwork("network", true); err != nil {
+	network, err := twf.CreateNetwork("network", true)
+	if err != nil {
 		t.Errorf("failed to create network: %v", err)
 	}
-	if err := tvm.SetCustomNetwork("network", ""); err != nil {
+	if err := tvm.SetCustomNetwork(network, nil); err != nil {
 		t.Errorf("failed to set custom network: %v", err)
 	}
 	if err := tvm.AddAliasIPRanges("aliasIPRange", "rangeName"); err != nil {
@@ -155,14 +153,11 @@ func TestSetCustomNetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create test vm: %v", err)
 	}
-	if err := tvm.SetCustomNetwork("fake", ""); err == nil {
-		t.Errorf("should have gotten an error using nonexistent network")
-	}
-	_, err = twf.CreateNetwork("network", true)
+	network, err := twf.CreateNetwork("network", true)
 	if err != nil {
 		t.Errorf("failed to create network: %v", err)
 	}
-	if err := tvm.SetCustomNetwork("network", ""); err != nil {
+	if err := tvm.SetCustomNetwork(network, nil); err != nil {
 		t.Errorf("failed to set custom network: %v", err)
 	}
 }
@@ -183,14 +178,14 @@ func TestSetCustomNetworkAndSubnetwork(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create network: %v", err)
 	}
-	if err := tvm.SetCustomNetwork("network", ""); err == nil {
+	if err := tvm.SetCustomNetwork(network, nil); err == nil {
 		t.Errorf("should have gotten an error using no subnet with custom mode network.")
 	}
-	_, err = network.CreateSubnetwork("subnet", "ipRange")
+	subnet, err := network.CreateSubnetwork("subnet", "ipRange")
 	if err != nil {
 		t.Errorf("failed to create subnetwork: %v", err)
 	}
-	if err := tvm.SetCustomNetwork("network", "subnet"); err != nil {
+	if err := tvm.SetCustomNetwork(network, subnet); err != nil {
 		t.Errorf("failed to set custom network and subnetwork: %v", err)
 	}
 }

--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -1,0 +1,284 @@
+package imagetest
+
+import (
+	"testing"
+)
+
+// TestAddMetadata tests that *TestVM.AddMetadata succeeds and that it
+// populates the instance.Metadata map.
+func TestAddMetadata(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	tvm.AddMetadata("key", "val")
+	if tvm.instance.Metadata == nil {
+		t.Errorf("failed to set VM metadata")
+	}
+	if val, ok := tvm.instance.Metadata["key"]; !ok || val != "val" {
+		t.Errorf("invalid metadata set")
+	}
+	tvm.AddMetadata("key", "val2")
+	if val, ok := tvm.instance.Metadata["key"]; !ok || val != "val2" {
+		t.Errorf("invalid metadata set")
+	}
+}
+
+// TestReboot tests that *TestVM.Reboot succeeds and that the appropriate stop
+// and new final wait steps are created in the workflow.
+func TestReboot(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if twf.counter != 0 {
+		t.Errorf("step counter not starting at 0")
+	}
+	if err := tvm.Reboot(); err != nil {
+		t.Errorf("failed to reboot: %v", err)
+	}
+	if twf.counter != 1 {
+		t.Errorf("step counter not incremented")
+	}
+	if _, ok := twf.wf.Steps["stop-vm-1"]; !ok {
+		t.Errorf("wait-vm-1 step missing")
+	}
+	lastStep, err := twf.getLastStepForVM("vm")
+	if err != nil {
+		t.Errorf("failed to get last step for vm: %v", err)
+	}
+	if lastStep.WaitForInstancesSignal == nil {
+		t.Error("not wait step")
+	}
+	if step, ok := twf.wf.Steps["wait-started-vm-1"]; !ok || step != lastStep {
+		t.Error("not wait-started-vm-1 step")
+	}
+}
+
+// TestResizeDiskAndReboot tests that *TestVM.ResizeDiskAndReboot succeeds and
+// that the appropriate resize and new final wait steps are created in the
+// workflow.
+func TestResizeDiskAndReboot(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if err := tvm.ResizeDiskAndReboot(200); err != nil {
+		t.Errorf("failed to reboot: %v", err)
+	}
+	if _, ok := twf.wf.Steps["resize-disk-vm-1"]; !ok {
+		t.Errorf("wait-vm-1 step missing")
+	}
+	step, err := twf.getLastStepForVM("vm")
+	if err != nil {
+		t.Errorf("failed to get last step for vm: %v", err)
+	}
+	if step.WaitForInstancesSignal == nil {
+		t.Error("not wait step")
+	}
+	if twf.wf.Steps["wait-started-vm-2"] != step {
+		t.Error("not wait-started-vm-2 step")
+	}
+}
+
+// TestEnableSecureBoot tests that *TestVM.EnableSecureBoot succeeds and
+// populates the ShieldedInstanceConfig struct.
+func TestEnableSecureBoot(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if tvm.instance.ShieldedInstanceConfig != nil {
+		t.Errorf("VM didn't have nil SIC at creation")
+	}
+	tvm.EnableSecureBoot()
+	if tvm.instance.ShieldedInstanceConfig == nil {
+		t.Errorf("VM SIC is nil")
+	}
+}
+
+// TestAddAliasIPRanges tests that *TestVM.AddAliasIPRanges succeeds and that
+// it fails if *TestVM.SetCustomNetwork hasn't been called first.
+func TestAddAliasIPRanges(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if err := tvm.AddAliasIPRanges("aliasIPRange", "rangeName"); err == nil {
+		t.Fatalf("shouldn't be able to set alias IP without calling setcustomnetwork")
+	}
+	if err := tvm.SetCustomNetwork("network", ""); err == nil {
+		t.Errorf("shouldn't be able to set non-existent network")
+	}
+	if _, err := twf.CreateNetwork("network", true); err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if err := tvm.SetCustomNetwork("network", ""); err != nil {
+		t.Errorf("failed to set custom network: %v", err)
+	}
+	if err := tvm.AddAliasIPRanges("aliasIPRange", "rangeName"); err != nil {
+		t.Fatalf("error adding alias IP range: %v", err)
+	}
+	if tvm.instance.NetworkInterfaces[0].AliasIpRanges == nil {
+		t.Errorf("VM alias IP is nil")
+	}
+}
+
+// TestSetCustomNetwork tests that *TestVM.SetCustomNetwork succeeds and that
+// it fails if testworkflow.CreateNetwork has not been called first.
+func TestSetCustomNetwork(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if err := tvm.SetCustomNetwork("fake", ""); err == nil {
+		t.Errorf("should have gotten an error using nonexistent network")
+	}
+	_, err = twf.CreateNetwork("network", true)
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if err := tvm.SetCustomNetwork("network", ""); err != nil {
+		t.Errorf("failed to set custom network: %v", err)
+	}
+}
+
+// TestSetCustomNetworkAndSubnetwork tests that *TestVM.SetCustomNetwork
+// succeeds with a subnet argument and that it fails if
+// *Network.CreateSubnetwork has not been called first.
+func TestSetCustomNetworkAndSubnetwork(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	tvm, err := twf.CreateTestVM("vm")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	network, err := twf.CreateNetwork("network", false)
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if err := tvm.SetCustomNetwork("network", ""); err == nil {
+		t.Errorf("should have gotten an error using no subnet with custom mode network.")
+	}
+	_, err = network.CreateSubnetwork("subnet", "ipRange")
+	if err != nil {
+		t.Errorf("failed to create subnetwork: %v", err)
+	}
+	if err := tvm.SetCustomNetwork("network", "subnet"); err != nil {
+		t.Errorf("failed to set custom network and subnetwork: %v", err)
+	}
+}
+
+// TestAddSecondaryRange tests that AddSecondaryRange populates the
+// subnet.SecondaryIpRanges struct.
+func TestAddSecondaryRange(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	network, err := twf.CreateNetwork("network", false)
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	subnet, err := network.CreateSubnetwork("subnet", "ipRange")
+	if err != nil {
+		t.Errorf("failed to create subnetwork: %v", err)
+	}
+	if subnet.subnetwork.SecondaryIpRanges != nil {
+		t.Errorf("Subnet didn't have nil secondary ranges at creation")
+	}
+	subnet.AddSecondaryRange("rangeName", "ipRange")
+	if subnet.subnetwork.SecondaryIpRanges == nil {
+		t.Errorf("Subnet has nil secondary range")
+	}
+}
+
+// TestCreateNetworkDependenciesReverse tests that the create-vms step depends
+// on the create-networks step if they are created in order.
+func TestCreateNetworkDependencies(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	if _, err = twf.CreateNetwork("network", false); err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if _, err = twf.CreateTestVM("vm"); err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if _, ok := twf.wf.Dependencies[createNetworkStepName]; ok {
+		t.Errorf("network step has unnecessary dependencies")
+	}
+	deps, ok := twf.wf.Dependencies[createVMsStepName]
+	if !ok {
+		t.Errorf("create-vms step missing dependencies")
+	}
+	var found bool
+	for _, dep := range deps {
+		if dep == createNetworkStepName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("create-vms step does not depend on create-networks step")
+	}
+}
+
+// TestCreateNetworkDependenciesReverse tests that the create-vms step depends
+// on the create-networks step if they are created in reverse.
+func TestCreateNetworkDependenciesReverse(t *testing.T) {
+	twf, err := NewTestWorkflow("name", "image", "30m")
+	if err != nil {
+		t.Errorf("failed to create test workflow: %v", err)
+	}
+	if _, err = twf.CreateTestVM("vm"); err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if _, err = twf.CreateNetwork("network", false); err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if _, ok := twf.wf.Dependencies[createNetworkStepName]; ok {
+		t.Errorf("network step has unnecessary dependencies")
+	}
+	deps, ok := twf.wf.Dependencies[createVMsStepName]
+	if !ok {
+		t.Errorf("create-vms step missing dependencies")
+	}
+	var found bool
+	for _, dep := range deps {
+		if dep == createNetworkStepName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("create-vms step does not depend on create-networks step")
+	}
+}

--- a/imagetest/test_suites/disk/setup.go
+++ b/imagetest/test_suites/disk/setup.go
@@ -16,5 +16,5 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err != nil {
 		return err
 	}
-	return vm.ResizeDiskAndReboot(vmName, resizeDiskSize)
+	return vm.ResizeDiskAndReboot(resizeDiskSize)
 }

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -27,17 +27,17 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err != nil {
 		return err
 	}
-	subNetwork, err := network.CreateSubNetwork(subnetworkName, primaryIPRange)
+	subnetwork, err := network.CreateSubnetwork(subnetworkName, primaryIPRange)
 	if err != nil {
 		return err
 	}
-	subNetwork.AddSecondaryRange(rangeName, secondaryIPRange)
+	subnetwork.AddSecondaryRange(rangeName, secondaryIPRange)
 
 	vm2, err := t.CreateTestVM(vm2)
 	if err != nil {
 		return err
 	}
-	if err := vm2.SetCustomNetwork(networkName, ""); err != nil {
+	if err := vm2.SetCustomNetwork(network, subnetwork); err != nil {
 		return err
 	}
 	vm2.AddAliasIPRanges(aliasIPRange, rangeName)

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -52,80 +52,13 @@ type TestWorkflow struct {
 	counter int
 }
 
-// Network represent network used by vm in setup.go.
-type Network struct {
-	name         string
-	testWorkflow *TestWorkflow
-}
-
-// SubNetwork represent subnetwork used by vm in setup.go.
-type SubNetwork struct {
-	name         string
-	testWorkflow *TestWorkflow
-}
-
-// AddSecondaryRange add secondary IP range to SubNetwork
-func (s SubNetwork) AddSecondaryRange(rangeName, ipRange string) {
-	for _, subnetwork := range *s.testWorkflow.wf.Steps[createSubNetworkStepName].CreateSubnetworks {
-		if subnetwork.Name == s.name {
-			subnetwork.SecondaryIpRanges = append(subnetwork.SecondaryIpRanges, &compute.SubnetworkSecondaryRange{
-				IpCidrRange: ipRange,
-				RangeName:   rangeName,
-			})
-		}
-	}
-}
-
 // SingleVMTest configures one VM running tests.
 func SingleVMTest(t *TestWorkflow) error {
 	_, err := t.CreateTestVM("vm")
 	return err
 }
 
-// Skip marks a test workflow to be skipped.
-func (t *TestWorkflow) Skip(message string) {
-	t.skipped = true
-	t.skippedMessage = message
-}
-
-// SkippedMessage returns the skip reason message for the workflow.
-func (t *TestWorkflow) SkippedMessage() string {
-	return t.skippedMessage
-}
-
-// CreateTestVM creates the necessary steps to create a VM with the specified name to the workflow.
-func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
-	parts := strings.Split(name, ".")
-	vmname := strings.ReplaceAll(parts[0], "_", "-")
-
-	createDisksStep, err := t.appendCreateDisksStep(vmname)
-	if err != nil {
-		return nil, err
-	}
-
-	// createDisksStep doesn't depend on any other steps.
-	createVMStep, err := t.appendCreateVMStep(vmname, name)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
-		return nil, err
-	}
-
-	waitStep, err := t.addWaitStep(vmname, vmname, false)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := t.wf.AddDependency(waitStep, createVMStep); err != nil {
-		return nil, err
-	}
-
-	return &TestVM{name: vmname, testWorkflow: t}, nil
-}
-
-func (t *TestWorkflow) appendCreateVMStep(name, hostname string) (*daisy.Step, error) {
+func (t *TestWorkflow) appendCreateVMStep(name, hostname string) (*daisy.Step, *daisy.Instance, error) {
 	attachedDisk := &compute.AttachedDisk{Source: name}
 
 	instance := &daisy.Instance{}
@@ -153,12 +86,12 @@ func (t *TestWorkflow) appendCreateVMStep(name, hostname string) (*daisy.Step, e
 		var err error
 		createVMStep, err = t.wf.NewStep(createVMsStepName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		createVMStep.CreateInstances = createInstances
 	}
 
-	return createVMStep, nil
+	return createVMStep, instance, nil
 }
 
 func (t *TestWorkflow) appendCreateDisksStep(diskname string) (*daisy.Step, error) {
@@ -249,7 +182,7 @@ func (t *TestWorkflow) addStartStep(stepname, vmname string) (*daisy.Step, error
 	return startInstancesStep, nil
 }
 
-func (t *TestWorkflow) appendCreateNetworkStep(networkName string, autoCreateSubnetworks bool) (*daisy.Step, error) {
+func (t *TestWorkflow) appendCreateNetworkStep(networkName string, autoCreateSubnetworks bool) (*daisy.Step, *daisy.Network, error) {
 	network := &daisy.Network{
 		Network: compute.Network{
 			Name: networkName,
@@ -267,15 +200,15 @@ func (t *TestWorkflow) appendCreateNetworkStep(networkName string, autoCreateSub
 		var err error
 		createNetworkStep, err = t.wf.NewStep(createNetworkStepName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		createNetworkStep.CreateNetworks = createNetworks
 	}
 
-	return createNetworkStep, nil
+	return createNetworkStep, network, nil
 }
 
-func (t *TestWorkflow) appendCreateSubnetworksStep(name, ipRange, networkName string) (*daisy.Step, error) {
+func (t *TestWorkflow) appendCreateSubnetworksStep(name, ipRange, networkName string) (*daisy.Step, *daisy.Subnetwork, error) {
 	subnetwork := &daisy.Subnetwork{
 		Subnetwork: compute.Subnetwork{
 			Name:        name,
@@ -286,65 +219,21 @@ func (t *TestWorkflow) appendCreateSubnetworksStep(name, ipRange, networkName st
 	createSubnetworks := &daisy.CreateSubnetworks{}
 	*createSubnetworks = append(*createSubnetworks, subnetwork)
 
-	createSubnetworksStep, ok := t.wf.Steps[createSubNetworkStepName]
+	createSubnetworksStep, ok := t.wf.Steps[createSubnetworkStepName]
 	if ok {
 		// append to existing step.
 		*createSubnetworksStep.CreateSubnetworks = append(*createSubnetworksStep.CreateSubnetworks, subnetwork)
 	} else {
 		var err error
-		createSubnetworksStep, err = t.wf.NewStep(createSubNetworkStepName)
+		createSubnetworksStep, err = t.wf.NewStep(createSubnetworkStepName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		createSubnetworksStep.CreateSubnetworks = createSubnetworks
 	}
 
-	return createSubnetworksStep, nil
-}
-
-// CreateSubNetwork creates custom subnetwork. Using SetCustomNetwork method
-// provided by TestVM to config network on vm
-func (n Network) CreateSubNetwork(name string, ipRange string) (*SubNetwork, error) {
-	createSubnetworksStep, err := n.testWorkflow.appendCreateSubnetworksStep(name, ipRange, n.name)
-	if err != nil {
-		return nil, err
-	}
-	firstStep, ok := n.testWorkflow.wf.Steps[createVMsStepName]
-	if !ok {
-		return nil, fmt.Errorf("failed resolve first step")
-	}
-	createNetworkStep, ok := n.testWorkflow.wf.Steps[createNetworkStepName]
-	if !ok {
-		return nil, fmt.Errorf("create-network step missing")
-	}
-	if err := n.testWorkflow.wf.AddDependency(createSubnetworksStep, createNetworkStep); err != nil {
-		return nil, err
-	}
-	if err := n.testWorkflow.wf.AddDependency(firstStep, createSubnetworksStep); err != nil {
-		return nil, err
-	}
-
-	return &SubNetwork{name, n.testWorkflow}, nil
-}
-
-// CreateNetwork creates custom network. Using SetCustomNetwork method provided by
-// TestVM to config network on vm
-func (t *TestWorkflow) CreateNetwork(networkName string, autoCreateSubnetworks bool) (*Network, error) {
-	createNetworkStep, err := t.appendCreateNetworkStep(networkName, autoCreateSubnetworks)
-	if err != nil {
-		return nil, err
-	}
-
-	firstStep, ok := t.wf.Steps[createVMsStepName]
-	if !ok {
-		return nil, fmt.Errorf("failed resolve first step")
-	}
-	if err := t.wf.AddDependency(firstStep, createNetworkStep); err != nil {
-		return nil, err
-	}
-
-	return &Network{networkName, t}, nil
+	return createSubnetworksStep, subnetwork, nil
 }
 
 // finalizeWorkflows adds the final necessary data to each workflow for it to

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -194,7 +194,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, err := twf.appendCreateVMStep("vmname", "")
+	step, _, err := twf.appendCreateVMStep("vmname", "")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if !ok || step != stepFromWF {
 		t.Error("step was not correctly added to workflow")
 	}
-	step2, err := twf.appendCreateVMStep("vmname2", "")
+	step2, _, err := twf.appendCreateVMStep("vmname2", "")
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, err := twf.appendCreateVMStep("vmname", "vmname.example.com")
+	step, _, err := twf.appendCreateVMStep("vmname", "vmname.example.com")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -328,30 +328,6 @@ func TestGetLastStepForVMWhenMultipleReboot(t *testing.T) {
 		t.Errorf("failed to reboot: %v", err)
 	}
 	if err := tvm.Reboot(); err != nil {
-		t.Errorf("failed to reboot: %v", err)
-	}
-	step, err := twf.getLastStepForVM("vm")
-	if err != nil {
-		t.Errorf("failed to get last step for vm: %v", err)
-	}
-	if step.WaitForInstancesSignal == nil {
-		t.Error("not wait step")
-	}
-	if twf.wf.Steps["wait-started-vm-2"] != step {
-		t.Error("not wait-started-vm-2 step")
-	}
-}
-
-func TestResizeDiskAndReboot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
-	if err != nil {
-		t.Errorf("failed to create test workflow: %v", err)
-	}
-	tvm, err := twf.CreateTestVM("vm")
-	if err != nil {
-		t.Errorf("failed to create test vm: %v", err)
-	}
-	if err := tvm.ResizeDiskAndReboot("vm", 200); err != nil {
 		t.Errorf("failed to reboot: %v", err)
 	}
 	step, err := twf.getLastStepForVM("vm")


### PR DESCRIPTION
* move all new network fixtures to fixtures.go
* maintain a convenience pointer in fixture structs
* use convenience pointer instead of name matching loops
* require fixture structs in SetCustomNetwork, reducing necessary safety checks
* add tests for new network fixtures