### PR TITLE
CIT: listening socket test

### DIFF
--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -1,11 +1,11 @@
-// +build cit
-
 package security
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -14,6 +14,10 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
+var (
+	runtest = flag.Bool("runtest", false, "really run the test")
 )
 
 var securitySettingMap = map[string]int{
@@ -53,6 +57,15 @@ const (
 	minInterval                  = 1
 	sysctlBase                   = "/proc/sys/"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *runtest {
+		os.Exit(m.Run())
+	} else {
+		os.Exit(0)
+	}
+}
 
 // TestKernelSecuritySettings Checks that the given parameter has the given value in sysctl.
 func TestKernelSecuritySettings(t *testing.T) {

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -427,9 +427,6 @@ func validateSockets(listening, allowed []string) error {
 		case address == "::1", address == "[::1]":
 			// IPv6 localhost address, not global.
 			continue
-		case strings.HasPrefix(address, "fe80:"), strings.HasPrefix(address, "[fe80:"):
-			// IPv6 link-local address, not global.
-			continue
 		case isInSlice(port, allowed):
 			// Whitelisted global listening port.
 			continue

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -424,10 +424,10 @@ func validateSockets(listening, allowed []string) error {
 		case strings.HasPrefix(address, "127."):
 			// IPv4 loopback addresses, not global.
 			continue
-		case address == "::1":
+		case address == "::1", address == "[::1]":
 			// IPv6 localhost address, not global.
 			continue
-		case strings.HasPrefix(address, "fe80::"):
+		case strings.HasPrefix(address, "fe80:"), strings.HasPrefix(address, "[fe80:"):
 			// IPv6 link-local address, not global.
 			continue
 		case isInSlice(port, allowed):

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -395,7 +395,7 @@ func TestSockets(t *testing.T) {
 		case fields[0] == "udp" && fields[1] == "UNCONN":
 			listenUDP = append(listenUDP, listen)
 		default:
-			t.Fatal("ss command format mismatch %q", line)
+			t.Fatalf("ss command format mismatch %q", line)
 		}
 	}
 	if len(listenTCP) == 0 && len(listenUDP) == 0 {


### PR DESCRIPTION
Rewrite the legacy listening socket test 
* Replace `netstat` from net-utils with `ss` utility from iproute2
* Use field separators instead of regular expressions
* Fail test if format from `ss` command doesn't match expectation