### PR TITLE
disable oslogin in ssh test

### DIFF
--- a/imagetest/test_suites/ssh/setup.go
+++ b/imagetest/test_suites/ssh/setup.go
@@ -28,6 +28,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 	vm2.AddUser(user, publicKey)
+	vm2.AddMetadata("enable-oslogin", "false")
 	vm2.RunTests("TestEmptyTest")
 	return nil
 }


### PR DESCRIPTION
ssh test relies on guest-agent picking up the ssh key and creating a user. guest-agent won't touch metadata ssh keys if oslogin is enabled, so verify oslogin is disabled on target vm during test.