### PR TITLE
add gcs_path parameter

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -27,6 +27,7 @@ var (
 	printwf       = flag.Bool("print", false, "print out the parsed test workflows and exit")
 	validate      = flag.Bool("validate", false, "validate all the test workflows and exit")
 	outPath       = flag.String("out_path", "junit.xml", "junit xml path")
+	gcsPath       = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
 	images        = flag.String("images", "", "comma separated list of images to test")
 	timeout       = flag.String("timeout", "30m", "timeout for the test suite")
 	parallelCount = flag.Int("parallel_count", 5, "TestParallelCount")
@@ -176,18 +177,18 @@ func main() {
 	ctx := context.Background()
 
 	if *printwf {
-		imagetest.PrintTests(ctx, testWorkflows, *project, *zone)
+		imagetest.PrintTests(ctx, testWorkflows, *project, *zone, *gcsPath)
 		return
 	}
 
 	if *validate {
-		if err := imagetest.ValidateTests(ctx, testWorkflows, *project, *zone); err != nil {
+		if err := imagetest.ValidateTests(ctx, testWorkflows, *project, *zone, *gcsPath); err != nil {
 			log.Printf("Validate failed: %v\n", err)
 		}
 		return
 	}
 
-	suites, err := imagetest.RunTests(ctx, testWorkflows, *project, *zone, *parallelCount)
+	suites, err := imagetest.RunTests(ctx, testWorkflows, *project, *zone, *gcsPath, *parallelCount)
 	if err != nil {
 		log.Fatalf("Failed to run tests: %v", err)
 	}

--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -197,7 +197,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to marshall result: %v", err)
 	}
-	outFile, err := os.Create(*outPath)
+	var outFile *os.File
+	if artifacts := os.Getenv("ARTIFACTS"); artifacts != "" {
+		outFile, err = os.Create(artifacts + "/junit.xml")
+	} else {
+		outFile, err = os.Create(*outPath)
+	}
 	if err != nil {
 		log.Fatalf("failed to create output file: %v", err)
 	}


### PR DESCRIPTION
* add gcs_path parameter
* only auto-detect daisy bucket if gcs_path not set
* move bucket handling to finalize

this change enables user to pass in desired gcs_path which is working directory for the daisy workflows. this also fixes -print and -validate, by populating gcs bucket in the common path in the finalize function.

Test with invalid GCS path:
```
$ docker run cloud-image-tests:latest -project liamh-testing -zone us-west1-b -images debian-10 -filter 'ssh|image_validation' -validate -gcs_path=fake
2021/08/06 00:39:36 imagetest: Done with setup
2021/08/06 00:39:36 Validating test image_validation on image debian-10
2021/08/06 00:39:36 Validate failed: error populating workflow: "fake/2021-08-06T00:39:36Z/image_validation/debian-10" is not a valid GCS path
```

Test with nonexistent bucket:
```
$ docker run cloud-image-tests:latest -project liamh-testing -zone us-west1-b -images debian-10 -filter 'ssh|image_validation' -validate -gcs_path=gs://fake
2021/08/06 00:39:42 imagetest: Done with setup
2021/08/06 00:39:42 Validating test image_validation on image debian-10
2021/08/06 00:39:44 Validate failed: step "copy-objects" validation error: error reading bucket "fake": googleapi: Error 403: liamh@google.com does not have storage.buckets.get access to the Google Cloud Storage bucket., forbidden
```
