### PR TITLE
add logging for config

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -98,6 +98,10 @@ func main() {
 		log.Fatal("Must provide project, zone and images arguments")
 		return
 	}
+	log.Printf("Running in project %s zone %s", *project, *zone)
+	if *gcsPath != "" {
+		log.Printf("gcs_path set to %s", *gcsPath)
+	}
 
 	var regex *regexp.Regexp
 	if *filter != "" {
@@ -106,6 +110,7 @@ func main() {
 		if err != nil {
 			log.Fatal("-filter flag not valid:", err)
 		}
+		log.Printf("using -filter %s", *filter)
 	}
 
 	// Setup tests.
@@ -161,6 +166,7 @@ func main() {
 				image = fullimage
 			}
 
+			log.Printf("Add test workflow for test %s on image %s", testPackage.name, image)
 			test, err := imagetest.NewTestWorkflow(testPackage.name, image, *timeout)
 			if err != nil {
 				log.Fatalf("Failed to create test workflow: %v", err)

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -257,17 +257,20 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, project
 		if err != nil {
 			return fmt.Errorf("failed to find or create daisy bucket: %v", err)
 		}
-		gcsPath = fmt.Sprintf("gs://%s/", bucket)
+		gcsPath = fmt.Sprintf("gs://%s", bucket)
+	} else {
+		gcsPath = strings.TrimSuffix(gcsPath, "/")
 	}
+	gcsPrefix := fmt.Sprintf("%s/%s", gcsPath, time.Now().Format(time.RFC3339))
+	log.Printf("Storing artifacts and logs in %s", gcsPrefix)
 
-	run := time.Now().Format(time.RFC3339)
 	for _, ts := range tests {
 		if ts.wf == nil {
 			return fmt.Errorf("found nil workflow in finalize")
 		}
 
 		// $GCS_PATH/2021-04-20T11:44:08-07:00/image_validation/debian-10
-		ts.gcsPath = fmt.Sprintf("%s/%s/%s/%s", gcsPath, run, ts.Name, ts.ShortImage)
+		ts.gcsPath = fmt.Sprintf("%s/%s/%s", gcsPrefix, ts.Name, ts.ShortImage)
 		ts.wf.GCSPath = ts.gcsPath
 
 		ts.wf.DisableGCSLogging()


### PR DESCRIPTION
Add log statements for how the manager was invoked, to aid in troubleshooting. Also log the final gcs path, and correct a bug with repeated / separators in gcs paths.

Output as of this PR:
```
$ docker run cloud-image-tests -project liamh-testing -zone us-west1-a -images debian-10 -filter image_boot 

2021/08/06 20:32:30 Running in project liamh-testing zone us-west1-a
2021/08/06 20:32:30 using -filter image_boot
2021/08/06 20:32:30 Add test workflow for test image_boot on image projects/debian-cloud/global/images/family/debian-10
2021/08/06 20:32:30 imagetest: Done with setup
2021/08/06 20:32:31 Storing artifacts and logs in gs://liamh-testing-cloud-test-outputs/2021-08-06T20:32:31Z
2021/08/06 20:32:31 runTestWorkflow: running image_boot on debian-10 (ID 3lvs8)
```