### PR TITLE
fix image_boot test

### DIFF
--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -29,7 +29,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err := vm.Reboot(); err != nil {
 		return err
 	}
-	vm.RunTests("TestGuestBoot|TestGuestReboot|TestGuestShutdownScript")
+	vm.RunTests("TestGuestBoot|TestGuestReboot$|TestGuestShutdownScript")
 
 	vm2, err := t.CreateTestVM("vm2")
 	if err != nil {


### PR DESCRIPTION
This test is reporting duplicate results. The `go test -run` parameter accepts /-separated *regular expressions* to match the components of the test name. Because of this, `go test -run TestGuestReboot` will run the test TestGuestReboot as well as TestGuestRebootOnHost. Add EOL anchor to prevent this overmatching.

Output after this change:
```
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="6" time="0">
	<testsuite name="image_boot-debian-10" tests="6" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="" name="TestGuestBoot" time="0"></testcase>
		<testcase classname="" name="TestGuestReboot" time="0"></testcase>
		<testcase classname="" name="TestGuestShutdownScript" time="0"></testcase>
		<testcase classname="" name="TestGuestRebootOnHost" time="0"></testcase>
		<testcase classname="" name="TestGuestSecureBoot" time="0"></testcase>
		<testcase classname="" name="TestBootTime" time="0"></testcase>
	</testsuite>
</testsuites>
```