### PR TITLE
fail on test compilation failure

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -26,7 +26,7 @@ RUN go mod download
 RUN go build -o /out/wrapper ./imagetest/cmd/wrapper/main.go
 RUN go build -o /out/manager ./imagetest/cmd/manager/main.go
 RUN cd imagetest/test_suites; for suite in *; do \
-  cd $suite; go test -c -tags cit; mv *.test /out; cd ..; \
+  cd $suite; go test -c -tags cit || exit 1; mv *.test /out || exit 1; cd ..; \
   done
 
 FROM alpine:edge


### PR DESCRIPTION
test suites can fail to compile but not fail the docker build because this run command will always exit with the status from `cd ..`. this change simply makes a compilation failure into a Docker build failure.

we also need an improvement to presubmits in this repo for test suites, to catch compilation errors.