### PR TITLE
skip secure boot on d9 and rocky linux

### DIFF
--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -38,11 +38,13 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm2.RunTests("TestGuestRebootOnHost")
 
 	if strings.Contains(t.Image, "debian-9") {
-		t.Skip("secure boot is not supported on Debian 9")
+		// secure boot is not supported on Debian 9
+		return nil
 	}
 
 	if strings.Contains(t.Image, "rocky-linux-8") {
-		t.Skip("secure boot is not supported on Rocky Linux")
+		// secure boot is not supported on Rocky Linux
+		return nil
 	}
 
 	vm3, err := t.CreateTestVM("vm3")


### PR DESCRIPTION
t.Skip will cause the entire test suite to be skipped. since we don't want to run one of the tests, just don't set up that test in this case.