### PR TITLE
CIT: Emit per-testcase errors on workflow failure

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -26,7 +26,9 @@ RUN go mod download
 RUN go build -o /out/wrapper ./imagetest/cmd/wrapper/main.go
 RUN go build -o /out/manager ./imagetest/cmd/manager/main.go
 RUN cd imagetest/test_suites; for suite in *; do \
-  cd $suite; go test -c -tags cit; mv *.test /out; cd ..; \
+  cd $suite; go test -c -tags cit || exit 1; \
+  ./"${suite}.test" -test.list '.*' > /out/"${suite}_tests.txt" || exit 1; \
+  mv "${suite}.test" /out || exit 1; cd ..; \
   done
 
 FROM alpine:edge

--- a/imagetest/junit.go
+++ b/imagetest/junit.go
@@ -70,7 +70,7 @@ type junitFailure struct {
 }
 
 // converts `go test` outputs to a jUnit testSuite
-func convertToTestSuite(results []string) *testSuite {
+func convertToTestSuite(results []string, classname string) *testSuite {
 	ts := &testSuite{}
 	for _, testResult := range results {
 		tcs, err := convertToTestCase(testResult)
@@ -79,6 +79,8 @@ func convertToTestSuite(results []string) *testSuite {
 		}
 		ts.TestCase = append(ts.TestCase, tcs...)
 		for _, tc := range tcs {
+			tc.Classname = classname
+
 			ts.Tests++
 			if tc.Skipped != nil {
 				ts.Skipped++

--- a/imagetest/junit_test.go
+++ b/imagetest/junit_test.go
@@ -71,7 +71,7 @@ func TestConvertToTestSuite(t *testing.T) {
 		},
 	}
 	for idx, tt := range tests {
-		ts := convertToTestSuite(tt.results)
+		ts := convertToTestSuite(tt.results, "")
 		switch {
 		case ts.XMLName != tt.ts.XMLName:
 			fallthrough

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -463,26 +463,59 @@ func runTestWorkflow(ctx context.Context, test *TestWorkflow) testResult {
 // gets result struct and converts to a jUnit TestSuite
 func parseResult(res testResult) *testSuite {
 	ret := &testSuite{}
+	ret.Name = fmt.Sprintf("%s-%s", res.testWorkflow.Name, res.testWorkflow.ShortImage)
 
 	switch {
 	case res.skipped:
-		ret.Tests = 1
-		ret.Skipped = 1
+		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
+			tc := &testCase{}
+			tc.Classname = ret.Name
+			tc.Name = test
+			tc.Skipped = &junitSkipped{res.testWorkflow.SkippedMessage()}
+			ret.TestCase = append(ret.TestCase, tc)
+
+			ret.Tests++
+			ret.Skipped++
+		}
 	case res.workflowSuccess:
 		// Workflow completed without error. Only in this case do we try to parse the result.
 		ret = convertToTestSuite(res.results)
 	default:
-		ret.Tests = 1
-		ret.Errors = 1
+		var status string
 		if res.err != nil {
-			ret.SystemErr = res.err.Error()
+			status = res.err.Error()
 		} else {
-			ret.SystemErr = "Unknown status"
+			status = "Unknown status"
+		}
+		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
+			tc := &testCase{}
+			tc.Classname = ret.Name
+			tc.Name = test
+			tc.Failure = &junitFailure{status, "Failure"}
+			ret.TestCase = append(ret.TestCase, tc)
+
+			ret.Tests++
+			ret.Failures++
 		}
 	}
 
 	ret.Name = fmt.Sprintf("%s-%s", res.testWorkflow.Name, res.testWorkflow.ShortImage)
 	return ret
+}
+
+func getTestsBySuiteName(name string) []string {
+	b, err := ioutil.ReadFile(fmt.Sprintf("/%s_tests.txt", name))
+	if err != nil {
+		log.Fatalf("unable to parse tests list: %v", err)
+		return []string{} // NOT nil
+	}
+	var res []string
+	for _, testname := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(testname, "Test") {
+			res = append(res, testname)
+		}
+	}
+	return res
 }
 
 func (t *TestWorkflow) getLastStepForVM(vmname string) (*daisy.Step, error) {

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -463,13 +463,13 @@ func runTestWorkflow(ctx context.Context, test *TestWorkflow) testResult {
 // gets result struct and converts to a jUnit TestSuite
 func parseResult(res testResult) *testSuite {
 	ret := &testSuite{}
-	ret.Name = fmt.Sprintf("%s-%s", res.testWorkflow.Name, res.testWorkflow.ShortImage)
+	name := fmt.Sprintf("%s-%s", res.testWorkflow.Name, res.testWorkflow.ShortImage)
 
 	switch {
 	case res.skipped:
 		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
 			tc := &testCase{}
-			tc.Classname = ret.Name
+			tc.Classname = name
 			tc.Name = test
 			tc.Skipped = &junitSkipped{res.testWorkflow.SkippedMessage()}
 			ret.TestCase = append(ret.TestCase, tc)
@@ -479,7 +479,7 @@ func parseResult(res testResult) *testSuite {
 		}
 	case res.workflowSuccess:
 		// Workflow completed without error. Only in this case do we try to parse the result.
-		ret = convertToTestSuite(res.results)
+		ret = convertToTestSuite(res.results, name)
 	default:
 		var status string
 		if res.err != nil {
@@ -489,7 +489,7 @@ func parseResult(res testResult) *testSuite {
 		}
 		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
 			tc := &testCase{}
-			tc.Classname = ret.Name
+			tc.Classname = name
 			tc.Name = test
 			tc.Failure = &junitFailure{status, "Failure"}
 			ret.TestCase = append(ret.TestCase, tc)
@@ -499,7 +499,7 @@ func parseResult(res testResult) *testSuite {
 		}
 	}
 
-	ret.Name = fmt.Sprintf("%s-%s", res.testWorkflow.Name, res.testWorkflow.ShortImage)
+	ret.Name = name
 	return ret
 }
 


### PR DESCRIPTION
Currently CIT emits a per-test-*suite* error status when the entire test suite failed. This is not well handled by our existing jUnit-aware tools (testgrid and spyglass), so switch to emitting per-test-case errors. This is accomplished by generating a list of known tests per suite at build time, and reading the file during workflow result parsing. 

Test workflow failure today:
```
<testsuites name="" errors="1" failures="0" disabled="0" skipped="0" tests="1" time="0">
	<testsuite name="ssh-debian-10" tests="1" failures="0" errors="1" disabled="0" skipped="0" time="0">
		<system-err>error validating workflow: must provide workflow field &#39;Project&#39;</system-err>
	</testsuite>
</testsuites>
```

Test output after this PR:
```
<testsuites name="" errors="0" failures="4" disabled="0" skipped="0" tests="4" time="0">
	<testsuite name="ssh-debian-10" tests="4" failures="4" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="ssh-debian-10" name="TestEmptyTest" time="0">
			<failure type="Failure">error validating workflow: must provide workflow field &#39;Project&#39;</failure>
		</testcase>
		<testcase classname="ssh-debian-10" name="TestSSH" time="0">
			<failure type="Failure">error validating workflow: must provide workflow field &#39;Project&#39;</failure>
		</testcase>
		<testcase classname="ssh-debian-10" name="TestHostKeysAreUnique" time="0">
			<failure type="Failure">error validating workflow: must provide workflow field &#39;Project&#39;</failure>
		</testcase>
		<testcase classname="ssh-debian-10" name="TestMatchingKeysInGuestAttributes" time="0">
			<failure type="Failure">error validating workflow: must provide workflow field &#39;Project&#39;</failure>
		</testcase>
	</testsuite>
</testsuites>
```

