### PR TITLE
emit finish signal to console multiple times

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -24,8 +24,10 @@ func main() {
 	// These are placeholders until daisy supports guest attributes.
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
-		log.Printf("FINISHED-TEST")
-		time.Sleep(1 * time.Second)
+		for f := 0; f < 5; f++ {
+			log.Printf("FINISHED-TEST")
+			time.Sleep(1 * time.Second)
+		}
 	}()
 
 	ctx := context.Background()


### PR DESCRIPTION
i don't really understand what the addition of the sleep was intended to accomplish. but hijacking that closure to repeatedly emit the FINISHED-TEST signal which is sometimes missed by Daisy, leading to test workflow timeouts (especially in reboot-based tests and especially on centos-8)