### PR TITLE
add project pools and locking

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -60,7 +60,14 @@ func (t *TestWorkflow) SkippedMessage() string {
 	return t.skippedMessage
 }
 
-// CreateTestVM creates the necessary steps to create a VM with the specified name to the workflow.
+// LockProject indicates this test modifies project-level data and must have
+// exclusive use of the project.
+func (t *TestWorkflow) LockProject() {
+	t.lockProject = true
+}
+
+// CreateTestVM adds the necessary steps to create a VM with the specified
+// name to the workflow.
 func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	parts := strings.Split(name, ".")
 	vmname := strings.ReplaceAll(parts[0], "_", "-")


### PR DESCRIPTION
* enable providing multiple test projects to stripe tests across via `-test_projects` flag
* enable tests to declare a write lock on a project via `t.LockProject()` fixture
* (minor) improve error message from ssh-key fixture