### PR TITLE
add producing the current timestamp in ms to the generate-timestamp Concourse task

### DIFF
--- a/concourse/tasks/generate-timestamp.yaml
+++ b/concourse/tasks/generate-timestamp.yaml
@@ -13,4 +13,4 @@ run:
   path: sh
   args:
   - -exc
-  - "timestamp=$(date '+%s'); echo $timestamp | tee timestamp/timestamp"
+  - "timestamp=$(date '+%s%N'); echo $(($timestamp/1000000000)) | tee timestamp/timestamp; echo $(($timestamp/1000000)) > timestamp/timestamp-ms"


### PR DESCRIPTION
Tests:
- Ran the new command locally on my dev machine to produce the following output:

```
linskeyd@linskey:~$ mkdir timestamp
linskeyd@linskey:~$ timestamp=$(date '+%s%N'); echo $(($timestamp/1000000000)) | tee timestamp/timestamp; echo $(($timestamp/1000000)) > timestamp/timestamp-ms
1629925995
linskeyd@linskey:~$ cat timestamp/timestamp
1629925995
linskeyd@linskey:~$ cat timestamp/timestamp-ms
1629925995514
linskeyd@linskey:~$ date +%s
1629926021
```