### PR TITLE
Fix generate timestamp by using bash image instead of busybox's date

### DIFF
--- a/concourse/tasks/generate-timestamp.yaml
+++ b/concourse/tasks/generate-timestamp.yaml
@@ -4,13 +4,13 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: busybox
+    repository: bash
 
 outputs:
 - name: timestamp
 
 run:
-  path: sh
+  path: /usr/local/bin/bash
   args:
-  - -exc
-  - "timestamp=$(date '+%s%N'); echo $(($timestamp/1000000000)) | tee timestamp/timestamp; echo $(($timestamp/1000000)) > timestamp/timestamp-ms"
+  - -c
+  - "timestamp=$((${EPOCHREALTIME/./}/1000)); echo $(($timestamp/1000)) | tee timestamp/timestamp; echo $timestamp | tee timestamp/timestamp-ms"


### PR DESCRIPTION
TL;DR - busybox's date command doesn't support the '%N' nanoseconds option. This PR updates the generate-timestamp concourse task to use bash instead.

Tested (with a run on the cluster this time):
```
initializing
selected worker: concourse-worker-0
running /usr/local/bin/bash -c timestamp=$((${EPOCHREALTIME/./}/1000)); echo $(($timestamp/1000)) | tee timestamp/timestamp; echo $timestamp | tee timestamp/timestamp-ms
1630529100
1630529100797
```