### PR TITLE
skip network test in package testing

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -133,9 +133,10 @@ jobs:
           dest-image: rhel-8-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent-((.:package-version))-g1.el8.x86_64.rpm
   - task: guest-agent-image-tests
-    file: guest-test-infra/concourse/tasks/image-test.yaml
+    file: guest-test-infra/concourse/tasks/image-test-args.yaml
     vars:
       images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/centos-8-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/centos-8-((.:build-id))
+      extra-args: "-filter='^[^n]'"
   - in_parallel:
       fail_fast: true
       steps:

--- a/concourse/tasks/image-test-args.yaml
+++ b/concourse/tasks/image-test-args.yaml
@@ -1,0 +1,23 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/gcp-guest/cloud-image-tests
+    tag: latest
+
+inputs:
+- name: credentials
+- name: guest-test-infra
+
+
+params:
+  GOOGLE_APPLICATION_CREDENTIALS: "credentials/credentials.json"
+
+run:
+  path: /manager
+  args:
+  - -project=gcp-guest
+  - -zone=us-west1-a
+  - -images=((images))
+  - ((extra-args))


### PR DESCRIPTION
Add a filter to skip the network tests during package builds until we complete project migration for network tests