### PR TITLE
lock go version

### DIFF
--- a/container_images/gocheck/Dockerfile
+++ b/container_images/gocheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang
+FROM golang:1.13
 
 ENV GOOGLE_APPLICATION_CREDENTIALS /etc/compute-image-tools-test-service-account/creds.json
 


### PR DESCRIPTION
Latest go image in Docker registry has changes that are incompatible with our version of go. See failing presubmit on GoogleCloudPlatform/guest-agent#133