### PR TITLE
Instrument the dev-image-build pipeline with success/failure/duration metrics

### DIFF
--- a/concourse/pipelines/dev-image-build.yaml
+++ b/concourse/pipelines/dev-image-build.yaml
@@ -72,6 +72,10 @@ jobs:
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -96,10 +100,34 @@ jobs:
       gcs_url: ((.:gcs-url))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-centos-7-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -123,10 +151,34 @@ jobs:
       wf: "linux_dev/centos_7_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-7-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-7-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-centos-8-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -150,10 +202,34 @@ jobs:
       wf: "linux_dev/centos_8_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-8-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-8-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-debian-9-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -177,10 +253,34 @@ jobs:
       wf: "linux_dev/debian_9_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-debian-9-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-debian-9-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-debian-10-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -204,10 +304,34 @@ jobs:
       wf: "linux_dev/debian_10_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-10-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-centos-10-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-ubuntu-1604-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -231,10 +355,34 @@ jobs:
       wf: "linux_dev/ubuntu_1604_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-ubuntu-1604-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-ubuntu-1604-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: build-ubuntu-1804-dev
   plan:
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -258,12 +406,36 @@ jobs:
       wf: "linux_dev/ubuntu_1804_dev.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-ubuntu-1804-dev"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "build-ubuntu-1804-dev"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 
 # Publish to dev stage
 - name: publish-debian-staging
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-9-dev-gcs
     passed: [build-debian-9-dev]
     trigger: false
@@ -290,11 +462,35 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "linux_dev/debian_staging.publish.json"
       environment: "test"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-debian-staging"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-debian-staging"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 
 - name: publish-to-testing-debian-10-worker
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-worker-gcs
     passed: [build-debian-10-worker]
     trigger: false
@@ -316,10 +512,34 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10_worker.publish.json"
       environment: "test"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-testing-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-testing-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: publish-to-staging-debian-10-worker
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-worker-gcs
     passed: [build-debian-10-worker]
     trigger: false
@@ -341,10 +561,34 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10_worker.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-staging-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-staging-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 - name: publish-to-prod-debian-10-worker
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-worker-gcs
     passed: [publish-to-staging-debian-10-worker]
     trigger: false
@@ -366,6 +610,26 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10_worker.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-prod-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "dev-image-build"
+      job: "publish-to-prod-debian-10-worker"
+      task: "publish-job-result"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+      metric_path: "concourse/job/duration"
 
 groups:
 - name: debian

--- a/concourse/pipelines/dev-image-build.yaml
+++ b/concourse/pipelines/dev-image-build.yaml
@@ -106,20 +106,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-debian-10-worker"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-debian-10-worker"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-centos-7-dev
   plan:
   - get: compute-image-tools
@@ -157,20 +153,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-7-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-7-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-centos-8-dev
   plan:
   - get: compute-image-tools
@@ -208,20 +200,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-8-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-8-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-debian-9-dev
   plan:
   - get: compute-image-tools
@@ -259,20 +247,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-debian-9-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-debian-9-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-debian-10-dev
   plan:
   - get: compute-image-tools
@@ -310,20 +294,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-10-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-centos-10-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-ubuntu-1604-dev
   plan:
   - get: compute-image-tools
@@ -361,20 +341,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-ubuntu-1604-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-ubuntu-1604-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: build-ubuntu-1804-dev
   plan:
   - get: compute-image-tools
@@ -412,20 +388,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "build-ubuntu-1804-dev"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "build-ubuntu-1804-dev"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 
 # Publish to dev stage
 - name: publish-debian-staging
@@ -468,20 +440,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "publish-debian-staging"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "publish-debian-staging"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 
 - name: publish-to-testing-debian-10-worker
   plan:
@@ -518,20 +486,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-testing-debian-10-worker"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-testing-debian-10-worker"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: publish-to-staging-debian-10-worker
   plan:
   - get: guest-test-infra
@@ -567,20 +531,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-staging-debian-10-worker"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-staging-debian-10-worker"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 - name: publish-to-prod-debian-10-worker
   plan:
   - get: guest-test-infra
@@ -616,20 +576,16 @@ jobs:
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-prod-debian-10-worker"
-      task: "publish-job-result"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
       pipeline: "dev-image-build"
       job: "publish-to-prod-debian-10-worker"
-      task: "publish-job-result"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-      metric_path: "concourse/job/duration"
 
 groups:
 - name: debian

--- a/concourse/tasks/publish-job-result.yaml
+++ b/concourse/tasks/publish-job-result.yaml
@@ -23,4 +23,4 @@ run:
   - --task=publish-job-result
   - --result-state=((result_state))
   - --start-timestamp=((start_timestamp))
-  - --metric-path=((metric_path))
+  - --metric-path="concourse/job/duration"


### PR DESCRIPTION
```
fly validate-pipeline --config concourse/pipelines/dev-image-build.yaml 
looks good
```

Tested that the same success/failure handlers work in my dev pipeline in Concourse.

The config lines are a bit repetitive; looked to see if there is a way to reduce clutter by referencing vars available in the pipeline overall (rather than directly re-specifying the same ones each time). Turned up "Parameterizing a task file with vars" [here](https://concourse-ci.org/jobs.html#schema.step.task-step.vars) which will check in with a credential manager to try and resolve implicit vars. The only thing I found to make this less explicit was a 'dummy' var source (which lets you specify static values at the top of a pipeline). That would at least let us reduce the duplicated entries which are the same between different jobs.