### PR TITLE
fix metric name by removing additional quotes

### DIFF
--- a/concourse/tasks/publish-job-result.yaml
+++ b/concourse/tasks/publish-job-result.yaml
@@ -23,4 +23,4 @@ run:
   - --task=publish-job-result
   - --result-state=((result_state))
   - --start-timestamp=((start_timestamp))
-  - --metric-path="concourse/job/duration"
+  - --metric-path=concourse/job/duration


### PR DESCRIPTION
Manual testing -> removed credentials input and attempted to run the task, encountered permission error with no input validation error:
```
linskeyd@linskey:~/gh/guest-test-infra$ fly -t main e -c concourse/tasks/publish-job-result.yaml --var=pipeline="linskeyd-gce" --var=job="test-job-three" --var=result_state="success" --var=start_timestamp="1633565564795"
executing build 4535 at http://localhost:8080/builds/4535 
initializing
selected worker: concourse-worker-0
running /publish-job-result --project-id=gcp-guest --zone=us-west1-a --pipeline=linskeyd-gce --job=test-job-three --task=publish-job-result --result-state=success --start-timestamp=1633565564795 --metric-path=concourse/job/duration
Failed to write time series data: rpc error: code = PermissionDenied desc = Permission monitoring.timeSeries.create denied (or the resource may not exist)..
```