### PR TITLE
add new ssh test, remove ssh keys and user should  remove in sudoer group 

### DIFF
--- a/imagetest/test_suites/ssh/setup.go
+++ b/imagetest/test_suites/ssh/setup.go
@@ -22,7 +22,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	vm.AddMetadata("block-project-ssh-keys", "true")
 	vm.AddMetadata("enable-guest-attributes", "true")
-	vm.RunTests("TestSSHInstanceKey|TestHostKeysAreUnique|TestMatchingKeysInGuestAttributes")
+	vm.RunTests("TestSSHInstanceKey|TestSSHInstanceKeyRemoved|TestHostKeysAreUnique|TestMatchingKeysInGuestAttributes")
 
 	vm2, err := t.CreateTestVM("vm2")
 	if err != nil {


### PR DESCRIPTION
This test will test when ssh-keys removed, the user is removed in googler-sudoers group
Cover P5 column in Guest Feature List spreadsheet