### PR TITLE
fix metadata script test

### DIFF
--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -36,11 +36,12 @@ func TestStartupScriptFailed(t *testing.T) {
 func TestDaemonScript(t *testing.T) {
 	bytes, err := ioutil.ReadFile(daemonOutputPath)
 	if err != nil {
-		t.Fatalf("failed to read deamon script output %v", err)
+		t.Fatalf("failed to read daemon script PID file: %v", err)
 	}
-	pid := string(bytes)
+	pid := strings.TrimSpace(string(bytes))
 	cmd := exec.Command("ps", "-p", pid)
-	if err := cmd.Run(); err != nil {
-		t.Fatal("daemon script stop running")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Logf("command \"ps -p %s\" failed: %v, output was: %s", pid, err, out)
+		t.Fatalf("Daemon process not running")
 	}
 }


### PR DESCRIPTION
* Strip whitespace from PID argument of `ps` command
* Log command output for debug purposes

This test was failing because the command was really `["ps", "-p", "123\n"]`, with error message:

```
error: process ID list syntax error

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
```