### PR TITLE
reduce broken script test size

### DIFF
--- a/imagetest/test_suites/metadata/setup.go
+++ b/imagetest/test_suites/metadata/setup.go
@@ -34,8 +34,9 @@ echo "%s" > %s`
 	shutdownOutputPath = "/shutdown_out.txt"
 	shutdownContent    = "The shutdown script worked."
 	// max metadata value 256kb https://cloud.google.com/compute/docs/metadata/setting-custom-metadata#limitations
-	//metadataMaxLength = 256 * 1024
-	// Match length used in original BCT test for now.
+	// metadataMaxLength = 256 * 1024
+	// TODO(hopkiw): above is commented out until error handler is added to
+	// output scanner in the script runner. Use smaller size for now.
 	metadataMaxLength = 32768
 )
 


### PR DESCRIPTION
The metadata test for 'broken' scripts is not working. In BCT we test a 32k file, but referencing docs, we are trying a 256k file here. This PR puts it back to the working 32k size and we will investigate the underlying issue later.

Tests passing on Debian 10
```
2021/10/18 21:48:10 Running in project gcp-guest zone us-west1-b. Tests will run in projects: [compute-image-test-pool-004]
2021/10/18 21:48:10 using -filter metadata
2021/10/18 21:48:10 Add test workflow for test metadata on image projects/gcp-guest/global/images/debian-10-1634334134
2021/10/18 21:48:10 Done with setup
2021/10/18 21:48:11 Storing artifacts and logs in gs://gcp-guest-cloud-test-outputs/2021-10-18T21:48:11Z
2021/10/18 21:48:11 running test metadata/debian-10-1634334134 (ID 0zb2v) in project compute-image-test-pool-004

2021/10/18 21:53:48 finished test metadata/debian-10-1634334134 (ID 0zb2v) in project compute-image-test-pool-004
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="10" time="0">
	<testsuite name="metadata-debian-10-1634334134" tests="10" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="metadata-debian-10-1634334134" name="TestTokenFetch" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestMetaDataResponseHeaders" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestGetMetaDataUsingIP" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestShutdownScript" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestShutdownScriptFailed" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestShutdownUrlScript" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestShutdownScriptTime" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestStartupScript" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestStartupScriptFailed" time="0"></testcase>
		<testcase classname="metadata-debian-10-1634334134" name="TestDaemonScript" time="0.01"></testcase>
	</testsuite>
</testsuites>
```