### PR TITLE
add RH8 port exemption

### DIFF
--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -394,11 +394,22 @@ func TestSockets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
+
 	if strings.Contains(image, "-sap") {
-		// SAP Images are permitted to have 'rpcbind' listening on port 111
+		// All SAP Images are permitted to have 'rpcbind' listening on
+		// port 111
 		allowedTCP = append(allowedTCP, "111")
+		allowedUDP = append(allowedUDP, "111")
 	}
-	if !strings.Contains(image, "7-sap") {
+
+	if strings.Contains(image, "rhel-8") && strings.Contains(image, "-sap") {
+		// RHEL 8 SAP Images are permitted to have 'systemd-resolve'
+		// listening on port 5355
+		allowedTCP = append(allowedTCP, "5355")
+		allowedUDP = append(allowedUDP, "5355")
+	}
+
+	if !(strings.Contains(image, "rhel-7") && strings.Contains(image, "-sap")) {
 		// Skip UDP check on RHEL-7-SAP images which have old rpcbind
 		// which listens to random UDP ports.
 		if err := validateSockets(listenUDP, allowedUDP); err != nil {


### PR DESCRIPTION
Continue changes from #273 

Test results:
```xml
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="20" time="0">
	<testsuite name="security-rhel-7-9-sap-v20211020" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-rhel-7-9-sap-v20211020" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-rhel-7-9-sap-v20211020" name="TestAutomaticUpdates" time="0.08"></testcase>
		<testcase classname="security-rhel-7-9-sap-v20211020" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-rhel-7-9-sap-v20211020" name="TestSockets" time="0.04"></testcase>
	</testsuite>
	<testsuite name="security-rhel-7-6-sap-v20211020" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-rhel-7-6-sap-v20211020" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-rhel-7-6-sap-v20211020" name="TestAutomaticUpdates" time="0.04"></testcase>
		<testcase classname="security-rhel-7-6-sap-v20211020" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-rhel-7-6-sap-v20211020" name="TestSockets" time="0.04"></testcase>
	</testsuite>
	<testsuite name="security-rhel-7-7-sap-v20211020" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-rhel-7-7-sap-v20211020" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-rhel-7-7-sap-v20211020" name="TestAutomaticUpdates" time="0.02"></testcase>
		<testcase classname="security-rhel-7-7-sap-v20211020" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-rhel-7-7-sap-v20211020" name="TestSockets" time="0.03"></testcase>
	</testsuite>
	<testsuite name="security-rhel-8-2-sap-v20211020" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-rhel-8-2-sap-v20211020" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-rhel-8-2-sap-v20211020" name="TestAutomaticUpdates" time="0.08"></testcase>
		<testcase classname="security-rhel-8-2-sap-v20211020" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-rhel-8-2-sap-v20211020" name="TestSockets" time="0.27"></testcase>
	</testsuite>
	<testsuite name="security-rhel-8-1-sap-v20211020" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-rhel-8-1-sap-v20211020" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-rhel-8-1-sap-v20211020" name="TestAutomaticUpdates" time="0.01"></testcase>
		<testcase classname="security-rhel-8-1-sap-v20211020" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-rhel-8-1-sap-v20211020" name="TestSockets" time="0.08"></testcase>
	</testsuite>
</testsuites>
```