### PR TITLE
Instrument the linux-image-build pipeline with job metrics

### DIFF
--- a/concourse/pipelines/linux-image-build.yaml
+++ b/concourse/pipelines/linux-image-build.yaml
@@ -159,6 +159,10 @@ jobs:
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -184,6 +188,22 @@ jobs:
       iso: ((iso-paths.almalinux-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-almalinux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-almalinux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # centos
 - name: build-centos-7
   plan:
@@ -191,6 +211,10 @@ jobs:
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -216,12 +240,32 @@ jobs:
       iso: ((iso-paths.centos-7))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-centos-8
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -247,12 +291,32 @@ jobs:
       iso: ((iso-paths.centos-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-centos-stream-8
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -278,6 +342,22 @@ jobs:
       iso: ((iso-paths.centos-stream-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-stream-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-centos-stream-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rhel
 - name: build-rhel-7
   plan:
@@ -285,6 +365,10 @@ jobs:
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -310,12 +394,32 @@ jobs:
       iso: ((iso-paths.rhel-7))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-8
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -341,12 +445,32 @@ jobs:
       iso: ((iso-paths.rhel-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-7-byos
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -372,12 +496,32 @@ jobs:
       iso: ((iso-paths.rhel-7))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-8-byos
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -403,12 +547,32 @@ jobs:
       iso: ((iso-paths.rhel-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-7-6-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -434,12 +598,32 @@ jobs:
       iso: ((iso-paths.rhel-7-6))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-6-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-6-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-7-7-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -465,12 +649,32 @@ jobs:
       iso: ((iso-paths.rhel-7-7))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-7-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-7-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-7-9-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -496,12 +700,32 @@ jobs:
       iso: ((iso-paths.rhel-7-9))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-9-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-7-9-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-8-1-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -527,12 +751,32 @@ jobs:
       iso: ((iso-paths.rhel-8-1))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-1-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-1-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-8-2-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -558,12 +802,32 @@ jobs:
       iso: ((iso-paths.rhel-8-2))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-2-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-2-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-rhel-8-4-sap
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -589,6 +853,22 @@ jobs:
       iso: ((iso-paths.rhel-8-4))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-4-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rhel-8-4-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rocky-linux
 - name: build-rocky-linux-8
   plan:
@@ -596,6 +876,10 @@ jobs:
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -621,6 +905,22 @@ jobs:
       iso: ((iso-paths.rocky-linux-8))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rocky-linux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-rocky-linux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # debian
 - name: build-debian-9
   plan:
@@ -628,6 +928,10 @@ jobs:
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -652,12 +956,32 @@ jobs:
       gcs_url: ((.:gcs-url))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-9"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-9"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-debian-10
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -682,12 +1006,32 @@ jobs:
       gcs_url: ((.:gcs-url))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-10"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-10"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: build-debian-11
   plan:
   - get: daily-time
     trigger: true
   - get: compute-image-tools
   - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -712,6 +1056,22 @@ jobs:
       gcs_url: ((.:gcs-url))
       google_cloud_repo: "stable"
       build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-11"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "build-debian-11"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 
 # Publish to testing
 # almalinux
@@ -719,6 +1079,10 @@ jobs:
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: almalinux-8-gcs
     passed: [build-almalinux-8]
     trigger: false
@@ -745,11 +1109,31 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/almalinux-8-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-almalinux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-almalinux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # centos
 - name: publish-to-testing-centos-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-7-gcs
     passed: [build-centos-7]
     trigger: true
@@ -776,10 +1160,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/centos-7-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-centos-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-8-gcs
     passed: [build-centos-8]
     trigger: true
@@ -806,10 +1210,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/centos-8-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-centos-stream-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-stream-8-gcs
     passed: [build-centos-stream-8]
     trigger: true
@@ -836,11 +1260,31 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/centos-stream-8-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-stream-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-centos-stream-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rhel
 - name: publish-to-testing-rhel-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-gcs
     passed: [build-rhel-7]
     trigger: true
@@ -867,10 +1311,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-7-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-gcs
     passed: [build-rhel-8]
     trigger: true
@@ -897,10 +1361,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-8-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-7-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-byos-gcs
     passed: [build-rhel-7-byos]
     trigger: true
@@ -927,10 +1411,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-7-byos-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-8-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-byos-gcs
     passed: [build-rhel-8-byos]
     trigger: true
@@ -957,10 +1461,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-8-byos-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-7-6-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-6-sap-gcs
     passed: [build-rhel-7-6-sap]
     trigger: true
@@ -987,10 +1511,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-7-6-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-6-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-6-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-7-7-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-7-sap-gcs
     passed: [build-rhel-7-7-sap]
     trigger: true
@@ -1017,10 +1561,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-7-7-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-7-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-7-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-7-9-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-9-sap-gcs
     passed: [build-rhel-7-9-sap]
     trigger: true
@@ -1047,10 +1611,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-7-9-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-9-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-7-9-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-8-1-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-1-sap-gcs
     passed: [build-rhel-8-1-sap]
     trigger: true
@@ -1077,10 +1661,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-8-1-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-1-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-1-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-8-2-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-2-sap-gcs
     passed: [build-rhel-8-2-sap]
     trigger: true
@@ -1107,10 +1711,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-8-2-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-2-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-2-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-rhel-8-4-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-4-sap-gcs
     passed: [build-rhel-8-4-sap]
     trigger: true
@@ -1137,11 +1761,31 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rhel-8-4-sap-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-4-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rhel-8-4-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rocky-linux
 - name: publish-to-testing-rocky-linux-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rocky-linux-8-gcs
     passed: [build-rocky-linux-8]
     trigger: true
@@ -1168,11 +1812,31 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/rocky-linux-8-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rocky-linux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-rocky-linux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # debian
 - name: publish-to-testing-debian-9
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-9-gcs
     passed: [build-debian-9]
     trigger: true
@@ -1199,10 +1863,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/debian-9-stretch-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-9"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-9"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-debian-10
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-gcs
     passed: [build-debian-10]
     trigger: true
@@ -1229,10 +1913,30 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/debian-10-buster-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-10"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-10"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-testing-debian-11
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-11-gcs
     passed: [build-debian-11]
     trigger: true
@@ -1259,6 +1963,22 @@ jobs:
     attempts: 3
     vars:
       images: projects/bct-prod-images/global/images/debian-11-bullseye-((.:publish-version))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-11"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-testing-debian-11"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 
 # Publish to staging
 # almalinux
@@ -1266,6 +1986,10 @@ jobs:
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: almalinux-8-gcs
     passed: [publish-to-testing-almalinux-8]
     trigger: false
@@ -1287,10 +2011,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/almalinux_8.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-almalinux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-almalinux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-centos-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-7-gcs
     passed: [publish-to-testing-centos-7]
     trigger: false
@@ -1312,10 +2056,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_7.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-centos-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-8-gcs
     passed: [publish-to-testing-centos-8]
     trigger: false
@@ -1337,10 +2101,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_8.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-centos-stream-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-stream-8-gcs
     passed: [publish-to-testing-centos-stream-8]
     trigger: false
@@ -1362,11 +2146,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_stream_8.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-stream-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-centos-stream-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rhel
 - name: publish-to-staging-rhel-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-gcs
     passed: [publish-to-testing-rhel-7]
     trigger: false
@@ -1388,10 +2192,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-7-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-byos-gcs
     passed: [publish-to-testing-rhel-7-byos]
     trigger: false
@@ -1413,10 +2237,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_byos.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-8-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-byos-gcs
     passed: [publish-to-testing-rhel-8-byos]
     trigger: false
@@ -1438,10 +2282,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_byos.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-gcs
     passed: [publish-to-testing-rhel-8]
     trigger: false
@@ -1463,10 +2327,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-7-6-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-6-sap-gcs
     passed: [publish-to-testing-rhel-7-6-sap]
     trigger: false
@@ -1488,10 +2372,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_6_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-6-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-6-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-7-7-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-7-sap-gcs
     passed: [publish-to-testing-rhel-7-7-sap]
     trigger: false
@@ -1513,10 +2417,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_7_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-7-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-7-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-7-9-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-9-sap-gcs
     passed: [publish-to-testing-rhel-7-9-sap]
     trigger: false
@@ -1538,10 +2462,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_9_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-9-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-7-9-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-8-1-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-1-sap-gcs
     passed: [publish-to-testing-rhel-8-1-sap]
     trigger: false
@@ -1563,10 +2507,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_1_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-1-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-1-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-8-2-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-2-sap-gcs
     passed: [publish-to-testing-rhel-8-2-sap]
     trigger: false
@@ -1588,10 +2552,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_2_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-2-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-2-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-rhel-8-4-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-4-sap-gcs
     passed: [publish-to-testing-rhel-8-4-sap]
     trigger: false
@@ -1613,11 +2597,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_4_sap.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-4-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rhel-8-4-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rocky-linux
 - name: publish-to-staging-rocky-linux-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rocky-linux-8-gcs
     passed: [publish-to-testing-rocky-linux-8]
     trigger: false
@@ -1639,11 +2643,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rocky_linux_8.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rocky-linux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-rocky-linux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # debian
 - name: publish-to-staging-debian-9
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-9-gcs
     passed: [publish-to-testing-debian-9]
     trigger: false
@@ -1665,10 +2689,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_9.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-9"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-9"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-debian-10
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-gcs
     passed: [publish-to-testing-debian-10]
     trigger: false
@@ -1690,10 +2734,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-10"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-10"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-staging-debian-11
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-11-gcs
     passed: [publish-to-testing-debian-11]
     trigger: false
@@ -1715,6 +2779,22 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_11.publish.json"
       environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-11"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-staging-debian-11"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 
 # Publish to OS Login staging project
 # almalinux
@@ -1722,6 +2802,10 @@ jobs:
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: almalinux-8-gcs
     passed: [publish-to-testing-almalinux-8]
     trigger: false
@@ -1743,10 +2827,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/almalinux_8.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-almalinux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-almalinux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-centos-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-7-gcs
     passed: [publish-to-testing-centos-7]
     trigger: false
@@ -1768,10 +2872,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_7.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-centos-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-8-gcs
     passed: [publish-to-testing-centos-8]
     trigger: false
@@ -1793,10 +2917,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_8.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-centos-stream-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-stream-8-gcs
     passed: [publish-to-testing-centos-stream-8]
     trigger: false
@@ -1818,11 +2962,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_stream_8.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-stream-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-centos-stream-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rhel
 - name: publish-to-oslogin-staging-rhel-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-gcs
     passed: [publish-to-testing-rhel-7]
     trigger: false
@@ -1844,10 +3008,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-7-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-byos-gcs
     passed: [publish-to-testing-rhel-7-byos]
     trigger: false
@@ -1869,10 +3053,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_byos.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-8-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-byos-gcs
     passed: [publish-to-testing-rhel-8-byos]
     trigger: false
@@ -1894,10 +3098,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_byos.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-gcs
     passed: [publish-to-testing-rhel-8]
     trigger: false
@@ -1919,10 +3143,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-7-6-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-6-sap-gcs
     passed: [publish-to-testing-rhel-7-6-sap]
     trigger: false
@@ -1944,10 +3188,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_6_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-6-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-6-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-7-7-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-7-sap-gcs
     passed: [publish-to-testing-rhel-7-7-sap]
     trigger: false
@@ -1969,10 +3233,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_7_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-7-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-7-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-7-9-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-9-sap-gcs
     passed: [publish-to-testing-rhel-7-9-sap]
     trigger: false
@@ -1994,10 +3278,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_9_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-9-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-7-9-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-8-1-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-1-sap-gcs
     passed: [publish-to-testing-rhel-8-1-sap]
     trigger: false
@@ -2019,10 +3323,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_1_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-1-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-1-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-8-2-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-2-sap-gcs
     passed: [publish-to-testing-rhel-8-2-sap]
     trigger: false
@@ -2044,10 +3368,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_2_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-2-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-2-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-rhel-8-4-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-4-sap-gcs
     passed: [publish-to-testing-rhel-8-4-sap]
     trigger: false
@@ -2069,11 +3413,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_4_sap.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-4-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rhel-8-4-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rocky-linux
 - name: publish-to-oslogin-staging-rocky-linux-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rocky-linux-8-gcs
     passed: [publish-to-testing-rocky-linux-8]
     trigger: false
@@ -2095,11 +3459,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rocky_linux_8.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rocky-linux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-rocky-linux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # debian
 - name: publish-to-oslogin-staging-debian-9
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-9-gcs
     passed: [publish-to-testing-debian-9]
     trigger: false
@@ -2121,10 +3505,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_9.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-9"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-9"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-debian-10
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-gcs
     passed: [publish-to-testing-debian-10]
     trigger: false
@@ -2146,10 +3550,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-10"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-10"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-oslogin-staging-debian-11
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-11-gcs
     passed: [publish-to-testing-debian-11]
     trigger: false
@@ -2171,6 +3595,22 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_11.publish.json"
       environment: "oslogin-staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-11"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-oslogin-staging-debian-11"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 
 # Publish to prod
 # almalinux
@@ -2178,6 +3618,10 @@ jobs:
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: almalinux-8-gcs
     passed: [publish-to-testing-almalinux-8]
     trigger: false
@@ -2198,11 +3642,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/almalinux_8.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-almalinux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-almalinux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # centos
 - name: publish-to-prod-centos-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-7-gcs
     passed: [publish-to-testing-centos-7]
     trigger: false
@@ -2223,10 +3687,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_7.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-centos-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-8-gcs
     passed: [publish-to-testing-centos-8]
     trigger: false
@@ -2247,10 +3731,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_8.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-centos-stream-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: centos-stream-8-gcs
     passed: [publish-to-testing-centos-stream-8]
     trigger: false
@@ -2271,11 +3775,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/centos_stream_8.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-stream-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-centos-stream-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rhel
 - name: publish-to-prod-rhel-7
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-gcs
     passed: [publish-to-testing-rhel-7]
     trigger: false
@@ -2297,10 +3821,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-gcs
     passed: [publish-to-testing-rhel-8]
     trigger: false
@@ -2322,10 +3866,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-7-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-byos-gcs
     passed: [publish-to-testing-rhel-7-byos]
     trigger: false
@@ -2347,10 +3911,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_byos.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-8-byos
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-byos-gcs
     passed: [publish-to-testing-rhel-8-byos]
     trigger: false
@@ -2372,10 +3956,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_byos.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-byos"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-byos"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-7-6-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-6-sap-gcs
     passed: [publish-to-testing-rhel-7-6-sap]
     trigger: false
@@ -2397,10 +4001,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_6_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-6-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-6-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-7-7-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-7-sap-gcs
     passed: [publish-to-testing-rhel-7-7-sap]
     trigger: false
@@ -2422,10 +4046,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_7_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-7-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-7-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-7-9-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-7-9-sap-gcs
     passed: [publish-to-testing-rhel-7-9-sap]
     trigger: false
@@ -2447,10 +4091,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_7_9_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-9-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-7-9-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-8-1-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-1-sap-gcs
     passed: [publish-to-testing-rhel-8-1-sap]
     trigger: false
@@ -2472,10 +4136,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_1_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-1-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-1-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-8-2-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-2-sap-gcs
     passed: [publish-to-testing-rhel-8-2-sap]
     trigger: false
@@ -2497,10 +4181,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_2_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-2-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-2-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-rhel-8-4-sap
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rhel-8-4-sap-gcs
     passed: [publish-to-testing-rhel-8-4-sap]
     trigger: false
@@ -2522,11 +4226,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rhel_8_4_sap.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-4-sap"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rhel-8-4-sap"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # rocky-linux
 - name: publish-to-prod-rocky-linux-8
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: rocky-linux-8-gcs
     passed: [publish-to-testing-rocky-linux-8]
     trigger: false
@@ -2548,11 +4272,31 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "enterprise_linux/rocky_linux_8.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rocky-linux-8"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-rocky-linux-8"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 # debian
 - name: publish-to-prod-debian-9
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-9-gcs
     passed: [publish-to-testing-debian-9]
     trigger: false
@@ -2574,10 +4318,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_9.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-9"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-9"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-debian-10
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-10-gcs
     passed: [publish-to-testing-debian-10]
     trigger: false
@@ -2599,10 +4363,30 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_10.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-10"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-10"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 - name: publish-to-prod-debian-11
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
   - get: debian-11-gcs
     passed: [publish-to-testing-debian-11]
     trigger: false
@@ -2624,6 +4408,22 @@ jobs:
       publish_version: ((.:publish-version))
       wf: "debian/debian_11.publish.json"
       environment: "prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-11"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "linux-image-build"
+      job: "publish-to-prod-debian-11"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
 
 groups:
 - name: debian


### PR DESCRIPTION
See #238 for context; applying the same instrumentation to each pipeline. This PR is for the linux-image-build pipeline.