### PR TITLE
Created tasks to send an image publish message to ARLE autopush & prod

### DIFF
--- a/concourse/tasks/gcloud-release-image-autopush.yaml
+++ b/concourse/tasks/gcloud-release-image-autopush.yaml
@@ -19,6 +19,6 @@ run:
   args:
   - -exc
   - |
-    wf=$(cat ./compute-image-tools/daisy_workflows/build-publish/((wf)) | sed 's/\"/\\"/g' | tr -d '\n')
+    wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/((wf)) | tr -d '\n')
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     gcloud pubsub topics publish "projects/artifact-releaser-autopush/topics/gcp-guest-image-release-autopush" --message '{"type": "ImagePublish", "request": {"image_name": "((image_name))", "gcs_image_path": "((gcs_image_path))", "image_publish_template": "${wf}", "source_version": "((source_version))", "publish_version": "((publish_version))", "release_notes": "((release_notes))"}}'

--- a/concourse/tasks/gcloud-release-image-prod.yaml
+++ b/concourse/tasks/gcloud-release-image-prod.yaml
@@ -19,6 +19,6 @@ run:
   args:
   - -exc
   - |
-    wf=$(cat ./compute-image-tools/daisy_workflows/build-publish/((wf)) | sed 's/\"/\\"/g' | tr -d '\n')
+    wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/((wf)) | tr -d '\n')
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
     gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message '{"type": "ImagePublish", "request": {"image_name": "((image_name))", "gcs_image_path": "((gcs_image_path))", "image_publish_template": "${wf}", "source_version": "((source_version))", "publish_version": "((publish_version))", "release_notes": "((release_notes))"}}'


### PR DESCRIPTION
Sends a pubsub message to Artifact Releaser so that an image that has completed test and build steps in its pipeline can be signaled for release.

The message requires an image name, a gcs path to the built image, the workflow file to use in publishing, a source and publish version, and optional release notes.