### PR TITLE
add 30s sleep to CIT wrapper

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -69,6 +69,9 @@ func main() {
 		log.Fatalf("failed to download object: %v", err)
 	}
 
+	log.Printf("sleep 30s to allow environment to stabilize")
+	time.Sleep(30 * time.Second)
+
 	out, err := executeCmd(workDir+testPackage, workDir, testArguments)
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
some tests are exhibiting timing issues, especially tests which validate guest agent behavior. these have been difficult to reproduce, adding a blanket sleep before sleep execution to try to drive this category of flake down.