### PR TITLE
Almalinux and debian test PubSub messages to Artifact Releaser

### DIFF
--- a/concourse/pipelines/artifact-releaser-autopush.yaml
+++ b/concourse/pipelines/artifact-releaser-autopush.yaml
@@ -134,25 +134,25 @@ jobs:
   - load_var: version
     file: publish-version/version
   - in_parallel:
-    steps:
-    - file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
-      task: publish-debian-10
-      vars:
-        topic: "projects/artifact-releaser-autopush/topics/gcp-guest-image-release-autopush"
-        image_name: "debian_10"
-        gcs_image_path: "gs://artifact-releaser-autopush-rtp/debian"
-        wf: "debian/debian_10.publish.json"
-        publish_version: ((.:version))
-        source_version: "v20211027"
-    - file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
-      task: publish-almalinux-8
-      vars:
-        topic: "projects/artifact-releaser-autopush/topics/gcp-guest-image-release-autopush"
-        image_name: "almalinux_8"
-        gcs_image_path: "gs://artifact-releaser-autopush-rtp/almalinux"
-        wf: "enterprise_linux/almalinux_8.publish.json"
-        publish_version: ((.:version))
-        source_version: "v20211027"
+      steps:
+      - file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
+        task: publish-debian-10
+        vars:
+          topic: "projects/artifact-releaser-autopush/topics/gcp-guest-image-release-autopush"
+          image_name: "debian_10"
+          gcs_image_path: "gs://artifact-releaser-autopush-rtp/debian"
+          wf: "debian/debian_10.publish.json"
+          publish_version: ((.:version))
+          source_version: "v20211027"
+      - file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
+        task: publish-almalinux-8
+        vars:
+          topic: "projects/artifact-releaser-autopush/topics/gcp-guest-image-release-autopush"
+          image_name: "almalinux_8"
+          gcs_image_path: "gs://artifact-releaser-autopush-rtp/almalinux"
+          wf: "enterprise_linux/almalinux_8.publish.json"
+          publish_version: ((.:version))
+          source_version: "v20211027"
 resources:
 - name: guest-test-infra
   source:


### PR DESCRIPTION
Added a new job that can be used to manually test the integration between Concourse and PubSub by releasing `debian-10` and `almalinux-8` images.