### PR TITLE
Add compute-image-tools to artifact-releaser-autopush pipeline

### DIFF
--- a/concourse/pipelines/artifact-releaser-autopush.yaml
+++ b/concourse/pipelines/artifact-releaser-autopush.yaml
@@ -164,7 +164,7 @@ resources:
     uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
   type: git
 - name: compute-image-tools
-  type: git
   source:
     uri: https://github.com/GoogleCloudPlatform/compute-image-tools.git
     branch: master
+  type: git


### PR DESCRIPTION
The gcloud-publish-image task requires compute-image-tools to be populated, so added it as a resource and added it to the artifact-releaser-publish-images-autopush task.