### PR TITLE
Gcloud publish image change message to use double quotes

### DIFF
--- a/concourse/tasks/gcloud-publish-image.yaml
+++ b/concourse/tasks/gcloud-publish-image.yaml
@@ -21,4 +21,4 @@ run:
   - |
     wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/((wf)) | tr -d '\n')
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    gcloud pubsub topics publish "((topic))" --message '{"type": "ImagePublish", "request": {"image_name": "((image_name))", "gcs_image_path": "((gcs_image_path))", "image_publish_template": "${wf}", "source_version": "((source_version))", "publish_version": "((publish_version))", "release_notes": "((release_notes))"}}'
+    gcloud pubsub topics publish "((topic))" --message "{\"type\": \"ImagePublish\", \"request\": {\"image_name\": \"((image_name))\", \"gcs_image_path\": \"((gcs_image_path))\", \"image_publish_template\": \"${wf}\", \"source_version\": \"((source_version))\", \"publish_version\": \"((publish_version))\", \"release_notes\": \"((release_notes))\"}}"


### PR DESCRIPTION
Previously the gcloud message was only using single quotes so the local variable `wf` was not being substituted in the message body. Changed to use double quotes.