### PR TITLE
gotest: Allow clients to specify extra test args.

### DIFF
--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -21,16 +21,17 @@ BUILD_DIR=$1
 if [[ -n $BUILD_DIR ]]; then
   cd $BUILD_DIR || exit 1
 fi
+shift
 
 echo "Pulling Linux imports..."
 go get -d -t ./... || exit 1
 echo "Pulling Windows imports..."
 GOOS=windows go get -d -t ./... || exit 1
 
-go test -v -coverprofile=/coverage.out ./... >/go-test.txt
+go test -v -coverprofile=/coverage.out "$@" ./... >/go-test.txt
 RET=$?
 if [[ $RET -ne 0 ]]; then
-  echo "go test -coverprofile=/coverage.out ./... returned ${RET}"
+  echo "go test -coverprofile=/coverage.out $@ ./... returned ${RET}"
 fi
 cp /go-test.txt ${ARTIFACTS}/
 


### PR DESCRIPTION
This updates `gotest` so that arguments after the test directory are passed to `go test`. The current motivation: Allow the tests we're onboarding to tune parallelism and timeout.


## Pass multiple arguments

```
docker run -e ARTIFACTS=/tmp/artifacts -v /tmp/artifacts:/tmp/artifacts \
    -v ~/daisy:/daisy gotest /daisy/cli_tools/common/assert/ -test.parallel=30 -test.timeout=5s
+ BUILD_DIR=/daisy/cli_tools/common/assert/
+ [[ -n /daisy/cli_tools/common/assert/ ]]
+ cd /daisy/cli_tools/common/assert/
+ shift
+ echo 'Pulling Linux imports...'
Pulling Linux imports...
+ go get -d -t ./...
go: downloading github.com/stretchr/testify v1.6.1
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
+ echo 'Pulling Windows imports...'
+ GOOS=windows
+ go get -d -t ./...
Pulling Windows imports...
+ go test -v -coverprofile=/coverage.out -test.parallel=30 -test.timeout=5s ./...
+ RET=0
+ [[ 0 -ne 0 ]]
+ cp /go-test.txt /tmp/artifacts/
+ go tool cover -html=/coverage.out -o /tmp/artifacts/coverage.html
+ cat /go-test.txt
+ go-junit-report
Done
+ echo Done
+ exit 0
```

## Passing a command that gotest doesn't recognize

```
docker run -e ARTIFACTS=/tmp/artifacts -v /tmp/artifacts:/tmp/artifacts \
  -v ~/daisy:/daisy gotest /daisy/cli_tools/common/assert/ --baz
Pulling Linux imports...
+ BUILD_DIR=/daisy/cli_tools/common/assert/
+ [[ -n /daisy/cli_tools/common/assert/ ]]
+ cd /daisy/cli_tools/common/assert/
+ shift
+ echo 'Pulling Linux imports...'
+ go get -d -t ./...
go: downloading github.com/stretchr/testify v1.6.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+ echo 'Pulling Windows imports...'
+ GOOS=windows
+ go get -d -t ./...
Pulling Windows imports...
+ go test -v -coverprofile=/coverage.out --baz ./...
+ RET=1
+ [[ 1 -ne 0 ]]
+ echo 'go test -coverprofile=/coverage.out --baz ./... returned 1'
+ cp /go-test.txt /tmp/artifacts/
go test -coverprofile=/coverage.out --baz ./... returned 1
+ go tool cover -html=/coverage.out -o /tmp/artifacts/coverage.html
+ cat /go-test.txt
+ go-junit-report
Done
+ echo Done
+ exit 1
```