### PR TITLE
use git resource rather than container wf

### DIFF
--- a/concourse/tasks/daisy-build-images.yaml
+++ b/concourse/tasks/daisy-build-images.yaml
@@ -9,7 +9,6 @@ image_resource:
 inputs:
 - name: compute-image-tools
 - name: credentials
-- name: publish-version
 
 params:
   GOOGLE_APPLICATION_CREDENTIALS: "credentials/credentials.json"
@@ -23,5 +22,6 @@ run:
   - -var:build_date=((build_date))
   - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
+  - -var:workflow_root=./compute-image-tools/daisy_workflows
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))


### PR DESCRIPTION
the daisy container has a copy of the workflows from compute-image-tools, which are used for the references within the build-publish workflows. this PR changes the reference so we are always consistently using the git resource from the pipeline 