### PR TITLE
use relative parent path for workflow_root

### DIFF
--- a/concourse/tasks/daisy-build-images.yaml
+++ b/concourse/tasks/daisy-build-images.yaml
@@ -22,6 +22,6 @@ run:
   - -var:build_date=((build_date))
   - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
-  - -var:workflow_root=./compute-image-tools/daisy_workflows
+  - -var:workflow_root=../../../compute-image-tools/daisy_workflows
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))


### PR DESCRIPTION
this variable is interpreted by daisy as relative to the directory with the workflow, so it needs to do parent relative directories to get back to the compute-image-tools/daisy_workflows root

there are unfortunately no quick variables to get you back to the root of a concourse task.