### PR TITLE
Concourse build for cli-tools-module-tests

### DIFF
--- a/concourse/pipelines/container-build.yaml
+++ b/concourse/pipelines/container-build.yaml
@@ -45,6 +45,18 @@ jobs:
     vars:
       destination: gcr.io/gcp-guest/gotest:latest
       context: guest-test-infra/container_images/gotest
+- name: build-cli-tools-module-tests-container
+  serial_groups: [serial]
+  plan:
+    - get: guest-test-infra
+      trigger: true
+    - task: get-credential
+      file: guest-test-infra/concourse/tasks/get-credential.yaml
+    - task: build-image
+      file: guest-test-infra/concourse/tasks/build-container-image.yaml
+      vars:
+        destination: gcr.io/gcp-guest/cli-tools-module-tests:latest
+        context: guest-test-infra/container_images/cli-tools-module-tests
 - name: build-gocheck-container
   serial_groups: [serial]
   plan:


### PR DESCRIPTION
I used the `gotest` stanza as an example.

Tested locally:

```
docker run --volume /home/ericedens/git/guest-test-infra:/guest-test-infra:ro \
  gcr.io/kaniko-project/executor \
  --dockerfile=Dockerfile \
  --context /guest-test-infra/container_images/cli-tools-module-tests \
  --no-push
```

.. . truncated output ...

```
Fetched 11.5 MB in 0s (43.5 MB/s)
Selecting previously unselected package libfuse2:amd64.
(Reading database ... 15559 files and directories currently installed.)
Preparing to unpack .../libfuse2_2.9.9-1+deb10u1_amd64.deb ...
Unpacking libfuse2:amd64 (2.9.9-1+deb10u1) ...
Selecting previously unselected package fuse.
Preparing to unpack .../fuse_2.9.9-1+deb10u1_amd64.deb ...
Unpacking fuse (2.9.9-1+deb10u1) ...
Selecting previously unselected package gcsfuse.
Preparing to unpack .../gcsfuse_0.37.0_amd64.deb ...
Unpacking gcsfuse (0.37.0) ...
Setting up libfuse2:amd64 (2.9.9-1+deb10u1) ...
Setting up fuse (2.9.9-1+deb10u1) ...
Setting up gcsfuse (0.37.0) ...
Processing triggers for libc-bin (2.28-10) ...
INFO[0026] Taking snapshot of full filesystem...        
INFO[0027] Skipping push to container registry due to --no-push flag 
```