### PR TITLE
add line coverage for guest agent

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -32,6 +32,12 @@ jobs:
     vars:
       timestamp: ((.:timestamp))
       repo-name: guest-agent
+  - task: guest-agent-gotest-coverage
+    file: guest-test-infra/concourse/tasks/gotest.yaml
+    input_mapping:
+      repo: guest-agent
+  - load_var: coverage-percent
+    file: gotest/coverage.txt
   - task: generate-package-version
     file: guest-test-infra/concourse/tasks/generate-package-version.yaml
     input_mapping: {repo: guest-agent}
@@ -77,6 +83,11 @@ jobs:
       name: package-version/version
       tag: package-version/version
       commitish: guest-agent/.git/ref
+  - task: guest-agent-publish-coverage
+    file: guest-test-infra/concourse/tasks/publish-coverage.yaml
+    vars:
+      package_name: "google-guest-agent"
+      coverage_percent: ((.:coverage-percent))
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml

--- a/concourse/tasks/gotest.yaml
+++ b/concourse/tasks/gotest.yaml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/gcp-guest/gotest
+    tag: latest
+
+inputs:
+- name: repo
+
+outputs:
+- name: gotest
+
+params:
+  ARTIFACTS: ./gotest/
+
+run:
+  path: /main.sh
+  args:
+  - repo

--- a/concourse/tasks/publish-coverage.yaml
+++ b/concourse/tasks/publish-coverage.yaml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/gcp-guest/concourse-metrics
+    tag: latest
+
+inputs:
+- name: credentials
+
+params:
+  GOOGLE_APPLICATION_CREDENTIALS: "credentials/credentials.json"
+
+run:
+  path: /publish-coverage
+  args:
+  - --metric-path=golang/coverage/percent
+  - --package-name=((package_name))
+  - --coverage-percent=((coverage_percent))

--- a/container_images/concourse-metrics/Dockerfile
+++ b/container_images/concourse-metrics/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /
 # this needs to be run from root of googlecloudplatform/guest-test-infra
 COPY . /
 RUN CGO_ENABLED=0 go build -o /publish-job-result ./container_images/concourse-metrics/cmd/publish-job-result/main.go
+RUN CGO_ENABLED=0 go build -o /publish-coverage ./container_images/concourse-metrics/cmd/publish-coverage/main.go
 RUN apk --update add ca-certificates
 
 RUN chmod +x /publish-job-result
@@ -14,6 +15,8 @@ RUN chmod +x /publish-job-result
 FROM scratch
 
 COPY --from=0 publish-job-result /publish-job-result
+COPY --from=0 publish-coverage /publish-coverage
+
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # for debugging

--- a/container_images/concourse-metrics/cmd/publish-coverage/main.go
+++ b/container_images/concourse-metrics/cmd/publish-coverage/main.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3"
+	"github.com/GoogleCloudPlatform/guest-test-infra/container_images/concourse-metrics/pkg/requests"
+)
+
+var (
+	metricPath      = flag.String("metric-path", "", "Path of the custom metric name to use (custom.googleapis.com/[metric-path]).")
+	packageName     = flag.String("package-name", "", "Name of package.")
+	coveragePercent = flag.Int64("coverage", 0, "Line coverage value.")
+	projectID       = flag.String("project-id", "", "GCP project Id.")
+)
+
+func main() {
+	ctx := context.Background()
+
+	flag.Parse()
+
+	c, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		fmt.Printf("Error creating a new Cloud Monitoring metric client: %+v.\n", err)
+		os.Exit(1)
+	}
+	defer c.Close()
+
+	req, err := requests.BuildCoverageRequest(requests.CoverageArgs{
+		MetricPath:      *metricPath,
+		PackageName:     *packageName,
+		CoveragePercent: *coveragePercent,
+	})
+	if err != nil {
+		fmt.Printf("Error creating request: %+v.\n", err)
+		os.Exit(1)
+	}
+
+	err = c.CreateTimeSeries(ctx, req)
+	if err != nil {
+		fmt.Printf("Failed to write time series data: %+v.\n", err)
+		os.Exit(1)
+	}
+}

--- a/container_images/concourse-metrics/pkg/requests/requests.go
+++ b/container_images/concourse-metrics/pkg/requests/requests.go
@@ -120,3 +120,52 @@ func BuildJobResultRequest(input JobResultArgs) (*monitoringpb.CreateTimeSeriesR
 		}},
 	}, nil
 }
+
+// CoverageArgs defines the required and optional arguments for building a new
+// coverage request (in the form of a cloud monitoring time series request).
+type CoverageArgs struct {
+	EndTimestamp    *int64 // Optional - will default to now in ms.
+	MetricPath      string
+	PackageName     string
+	CoveragePercent int64
+	ProjectID       string
+}
+
+// BuildCoverageRequest builds a new job result request object to submit to gcp cloud monitoring.
+func BuildCoverageRequest(input CoverageArgs) (*monitoringpb.CreateTimeSeriesRequest, error) {
+	// Provide a default for the endTimestamp if one was not provided.
+	var endTimestamp int64
+	if input.EndTimestamp == nil {
+		endTimestamp = time.Now().UnixNano() / 1000000
+	} else {
+		endTimestamp = *input.EndTimestamp
+	}
+
+	return &monitoringpb.CreateTimeSeriesRequest{
+		Name: "projects/" + input.ProjectID,
+		TimeSeries: []*monitoringpb.TimeSeries{{
+			Metric: &metricpb.Metric{
+				Type: "custom.googleapis.com/" + input.MetricPath,
+			},
+			Resource: &monitoredres.MonitoredResource{
+				Type: "generic_task",
+				Labels: map[string]string{
+					"package_name": input.PackageName,
+				},
+			},
+			Points: []*monitoringpb.Point{{
+				Interval: &monitoringpb.TimeInterval{
+					EndTime: &timestamp.Timestamp{
+						Seconds: endTimestamp / 1000,
+					},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_Int64Value{
+						// Int64 value here is the coverage (in percent of statements).
+						Int64Value: input.CoveragePercent,
+					},
+				},
+			}},
+		}},
+	}, nil
+}

--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -36,7 +36,7 @@ fi
 cp /go-test.txt ${ARTIFACTS}/
 
 # $ARTIFACTS is provided by prow decoration containers
-go tool cover -func=/coverage.out | grep ^total | awk '{print $NF}' > ${ARTIFACTS}/coverage.txt
+go tool cover -func=/coverage.out | grep ^total | awk '{print $NF}' | tr -d '%' > ${ARTIFACTS}/coverage.txt
 cat /go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
 
 # Upload coverage results to Codecov.

--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -36,7 +36,7 @@ fi
 cp /go-test.txt ${ARTIFACTS}/
 
 # $ARTIFACTS is provided by prow decoration containers
-go tool cover -html=/coverage.out -o ${ARTIFACTS}/coverage.html
+go tool cover -func=/coverage.out | grep ^total | awk '{print $NF}' > ${ARTIFACTS}/coverage.txt
 cat /go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
 
 # Upload coverage results to Codecov.


### PR DESCRIPTION
* add new `publish-coverage` binary to the `concourse-metrics` container
* add gotest Concourse Task which invokes the gotest container originally written for prow
* add steps to `build-guest-agent` Concourse Job to produce and later publish coverage metrics