### PR TITLE
add JSONnet containers

### DIFF
--- a/container_images/fly-validate-pipelines/main.sh
+++ b/container_images/fly-validate-pipelines/main.sh
@@ -23,4 +23,9 @@ find . -type f -iname '*.yaml'|while read yaml; do
   fly vp -c "$yaml"
 done
 
+find . -type f -iname '*.jsonnet'|while read jsonnet; do
+  jsonnet "$jsonnet" > temp.json
+  fly vp -c temp.json
+done
+
 echo Done

--- a/container_images/jsonnet-go/Dockerfile
+++ b/container_images/jsonnet-go/Dockerfile
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/gcp-guest/jsonnet-go
-FROM arbourd/concourse-fly
+FROM golang
 
-COPY --from=0 /usr/bin/jsonnet /usr/bin/jsonnet
+RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+
+FROM alpine
+
+COPY --from=0 /go/bin/jsonnet /usr/bin/jsonnet
 
 # Copy this Dockerfile for debugging.
 COPY Dockerfile Dockerfile
-COPY main.sh main.sh
-ENTRYPOINT ["./main.sh"]


### PR DESCRIPTION
`gcr.io/gcp-guest/jsonnet-go`: contains the jsonnet binary built from go source. contains a shell
`gcr.io/gcp-guest/fly-validate-pipelines`: update to include and use jsonnet for template expansion