### PR TITLE
Add RHUI builds

### DIFF
--- a/concourse/tasks/certbot-rhui.yaml
+++ b/concourse/tasks/certbot-rhui.yaml
@@ -1,0 +1,46 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: certbot/dns-google
+
+inputs:
+- name: credentials
+- name: gcp-secret-manager
+
+outputs:
+- name: tls-output
+
+params:
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    # Generating a CSR is the best way to bypass certbot's usual behavior and just get a cert.
+    openssl req \
+      -key $PWD/gcp-secret-manager/rhui_tls_key \
+      -subj "/O=Google Compute Engine/CN=rhui.googlecloud.com" \
+      -addext "subjectAltName = DNS:rhui.googlecloud.com" \
+      -addext "subjectAltName = DNS:staging-rhui.googlecloud.com" \
+      -out rhui.csr
+    certbot certonly \
+      --manual \
+      # Email to associate with cert, for rotations/revocations.
+      --email "bigcluster-guest-team@google.com" \
+      --no-eff-email
+      # The input and output values.
+      --csr $PWD/rhui.csr \
+      --key-path $PWD/gcp-secret-manager/rhui_tls_key \
+      --cert-path $PWD/tls-output/rhui.crt \
+      # Using ACME dns-01 and our public ACME endpoint.
+      --preferred-challenges "dns-01" \
+      --server "https://dv.acme-v02.api.pki.goog/directory" \
+      --eab-kid `cat gcp-secret-manager/eab-kid` \
+      --eab-hmac-key `cat gcp-secret-manager/eab-hmac-key` \
+      # Using dns-google plugin to automatically satisfy dns-01 challenge.
+      --dns-google \
+      --dns-google-credentials $PWD/credentials/credentials.json

--- a/concourse/templates/gcp-secret-manager.libsonnet
+++ b/concourse/templates/gcp-secret-manager.libsonnet
@@ -1,0 +1,36 @@
+{
+  local tl = self,
+
+  get_secret:: {
+    local task = self,
+
+    secret_name:: error 'must set secret_name in gcp-secret-manager template',
+    project:: 'gcp-guest',
+    version:: 'latest',
+
+    platform: 'linux',
+    image_resource: {
+      type: 'docker-image',
+      source: {
+        repository: 'google/cloud-sdk',
+        tag: 'alpine',
+      },
+    },
+    inputs: [
+      { name: 'credentials' },
+    ],
+    outputs: [
+      { name: 'gcp-secret-manager' },
+    ],
+    run: {
+      path: 'sh',
+      args: [
+        '-exc',
+        // Note: the following is a single string.
+        'gcloud auth activate-service-account --key-file=$PWD/credentials/credentials.json;' +
+        'gcloud secrets versions access ' + task.version + ' --secret=' + task.secret_name +
+        ' --project=' + task.project + ' > gcp-secret-manager/' + task.secret_name,
+      ],
+    },
+  },
+}


### PR DESCRIPTION
Add image builds for RHUA and CDS nodes
Introduce a daisy task template for gcloud-get-secret, as we sometimes want to layer in additional inputs to produce a cumulative output, and this isn't possible with external task files