### PR TITLE
use workload id in linux image build

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -104,10 +104,6 @@ local imgbuildjob = {
       load_var: 'build-date',
       file: 'publish-version/version',
     },
-    {
-      task: 'get-credential',
-      file: 'guest-test-infra/concourse/tasks/get-credential.yaml',
-    },
   ] + tl.extra_tasks + [
     {
       task: 'daisy-build-' + tl.image,
@@ -261,10 +257,6 @@ local imgpublishjob = {
           {
             load_var: 'source-version',
             file: tl.image + '-gcs/version',
-          },
-          {
-            task: 'get-credential',
-            file: 'guest-test-infra/concourse/tasks/get-credential.yaml',
           },
           {
             task: 'generate-version',

--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -27,11 +27,7 @@
       // Currently all our daisy workflows are in this repo. No need to make this overrideable because
       // Concourse has 'input_mapping' to do that if needed.
       { name: 'compute-image-tools' },
-      { name: 'credentials' },
     ],
-    params: {
-      GOOGLE_APPLICATION_CREDENTIALS: 'credentials/credentials.json',
-    },
     run: {
       path: '/daisy',
       args:

--- a/concourse/templates/gcp-secret-manager.libsonnet
+++ b/concourse/templates/gcp-secret-manager.libsonnet
@@ -17,9 +17,6 @@
         tag: 'alpine',
       },
     },
-    inputs: [
-      { name: 'credentials' },
-    ],
     outputs: [
       { name: 'gcp-secret-manager' },
     ],
@@ -27,11 +24,10 @@
       path: 'sh',
       args: [
         '-exc',
-        'gcloud auth activate-service-account --key-file=$PWD/credentials/credentials.json;' +
-        'dir=$(dirname ./gcp-secret-manager/' + task.output_path + ');' +
+        'dir=$(dirname ./gcp-secret-manager/%s);' % task.output_path +
         'mkdir -p "$dir";' +
-        'gcloud secrets versions access ' + task.version + ' --secret=' + task.secret_name +
-        ' --project=' + task.project + ' > gcp-secret-manager/' + task.output_path,
+        'gcloud secrets versions access %s --secret=%s' % [task.version, task.secret_name] +
+        ' --project=%s > gcp-secret-manager/%s' % [task.project, task.output_path],
       ],
     },
   },


### PR DESCRIPTION
Remove references to service account keys in linux image build pipeline and jsonnet task templates. Because this is the only pipeline currently using the templated tasks, no need to make them support two modes, just prune credentials from them.