### PR TITLE
use new forked image resource

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -57,10 +57,13 @@ local publishresulttask = {
   // Start of output.
   platform: 'linux',
   image_resource: {
-    type: 'docker-image',
+    type: 'registry-image-forked',
     source: {
       repository: 'gcr.io/gcp-guest/concourse-metrics',
       tag: 'latest',
+      // Use workload id to pull image
+      google_auth: 'true',
+      debug: 'true',
     },
   },
   run: {
@@ -480,6 +483,11 @@ local ImgGroup(name, images) = {
       name: 'gcs',
       type: 'registry-image',
       source: { repository: 'frodenas/gcs-resource' },
+    },
+    {
+      name: 'registry-image-forked',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
     },
   ],
   resources: [


### PR DESCRIPTION
use the new forked registry-image resource to pull a private image for use in the pipeline. if this works, we will move all our internal-use tooling images to this resource type.