### PR TITLE
fix typo

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -134,7 +134,7 @@ local sqlimgbuildjob = {
   image:: error 'must set image in sqlimgbuildjob',
   base_image:: error 'must set base_image in sqlimgbuildjob',
   workflow:: error 'must set workflow in sqlimgbuildjob',
-  sqlimg_version:: error 'must set sql_version in sqlbuildjob',
+  sql_version:: error 'must set sql_version in sqlbuildjob',
 
   // Start of job.
   name: 'build-' + job.image,


### PR DESCRIPTION
sadly validate-pipelines didn't catch this, it must be slightly different than set-pipelines. the misnaming meant that when sql_version was passed in from the function, it added as a new field, which concourse didn't know. 