### PR TITLE
Migrating Enterprise Linux builds to use secret manager

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -149,19 +149,19 @@ local ELImgBuildJob(image, workflow) = imgbuildjob {
   else
     image,
 
+  // Add tasks to obtain ISO location and store it in .:iso_secret
   extra_tasks: [
     {
       task: 'get-secret-iso',
-      config: gcp_secret_manager.getsecrettask { secret_name: image },
+      config: gcp_secret_manager.getsecrettask { secret_name: isopath },
     },
     {
       load_var: 'iso_secret',
-      file: 'gcp-secret-manager/' + image,
+      file: 'gcp-secret-manager/' + isopath,
     },
   ],
 
   // Override build_task with an EL specific task.
-
   build_task: ELImgBuildTask(workflow, '((.:gcs-url))', '((.:iso_secret))'),
 };
 

--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -149,8 +149,20 @@ local ELImgBuildJob(image, workflow) = imgbuildjob {
   else
     image,
 
+  extra_tasks: [
+    {
+      task: 'get-secret-iso',
+      config: gcp_secret_manager.getsecrettask { secret_name: image },
+    },
+    {
+      load_var: 'iso_secret',
+      file: 'gcp-secret-manager/' + image,
+    },
+  ],
+
   // Override build_task with an EL specific task.
-  build_task: ELImgBuildTask(workflow, '((.:gcs-url))', '((iso-paths.%s))' % isopath),
+
+  build_task: ELImgBuildTask(workflow, '((.:gcs-url))', '((.:iso_secret))'),
 };
 
 local RHUAImgBuildJob(image, workflow) = imgbuildjob {


### PR DESCRIPTION
Migrating Enterprise Linux builds to use secret manager

/hold