### PR TITLE
Container build for "daisy test runner"

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -119,6 +119,11 @@ local BuildContainerImage(image) = buildcontainerimgjob {
       dockerfile: 'dockerfiles/alpine/Dockerfile',
     },
     BuildContainerImage('daisy-builder'),
+    BuildContainerImage('daisy-test-runner') {
+      input: 'compute-daisy',
+      context: 'compute-daisy',
+      dockerfile: 'compute-daisy/daisy_test_runner.Dockerfile',
+    },
     BuildContainerImage('build-essential'),
     buildcontainerimgjob {
       image: 'daisy',

--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -119,9 +119,11 @@ local BuildContainerImage(image) = buildcontainerimgjob {
       dockerfile: 'dockerfiles/alpine/Dockerfile',
     },
     BuildContainerImage('daisy-builder'),
-    BuildContainerImage('daisy-test-runner') {
-      input: 'compute-daisy',
+    buildcontainerimgjob {
+      image: 'daisy-test-runner',
+      destination: 'gcr.io/compute-image-tools-test/test-runner:latest',
       context: 'compute-daisy',
+      input: 'compute-daisy',
       dockerfile: 'compute-daisy/daisy_test_runner.Dockerfile',
     },
     BuildContainerImage('build-essential'),


### PR DESCRIPTION
This adds a container build for daisy test runner. Daisy test runner is mainly used for e2e testing of Daisy itself, although there are some historical import/export tests that use it.

Current usages:
 1. Legacy import/export tests: [link](https://github.com/GoogleCloudPlatform/compute-image-tools/tree/1ebac650d703c1fc651f7b31ca05de1f73c8d670/daisy_integration_tests)
 2. New daisy e2e tests: [link](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/prowjobs/GoogleCloudPlatform/gcp-guest/compute-daisy.yaml)

## Testing

1. Checked out compute-daisy.
2. Executed `docker build -f daisy_test_runner.Dockerfile .`
5. Invoked the container as Prow would.