### PR TITLE
Daisy bin publish: Fix 'sh: illegal option -'

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -197,7 +197,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
               run: {
                 path: 'sh',
                 args: [
-                  '-exc ',
+                  '-exc',
                   'for f in darwin linux windows; do gsutil cp $f/daisy ' +
                   'gs://compute-image-tools/release/$f/daisy; done',
                 ],


### PR DESCRIPTION
This fixes the `upload-daisy-binaries` step which is currently failing with `sh: illegal option -`.

![Screenshot from 2022-02-24 15-11-31](https://user-images.githubusercontent.com/575626/155623163-c0051c2b-a1e3-48be-b0a0-66cdec523717.png)

