### PR TITLE
daisy binaries: use latest, ensure public

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -204,9 +204,11 @@ local BuildContainerImage(image) = buildcontainerimgjob {
               run: {
                 path: 'sh',
                 args: [
-                  '-exc',
-                  'for f in darwin linux windows; do gsutil cp $f/daisy ' +
-                  'gs://compute-image-tools/release/$f/daisy; done',
+                  '-exc ',
+                  'for f in darwin linux windows; do' +
+                  '  gsutil cp $f/daisy gs://compute-image-tools/latest/$f/daisy;' +
+                  '  gsutil acl ch -u AllUsers:R gs://compute-image-tools/latest/$f/daisy;' +
+                  'done',
                 ],
               },
             },


### PR DESCRIPTION
Currently this is invoked for every change in `compute-daisy`, so the correct location is `latest` rather than `release`. In a following PR I'll add the `release` target -- we'll probably want to talk offline whether `release` should use the same tagging mechanism that we used in `compute-image-tools`.

Also, this ensures that the release artifacts are public.

This was reported in https://github.com/GoogleCloudPlatform/compute-image-tools/issues/1868
