### PR TITLE
Use gcloud-package-operation task for promoting to staging

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -1327,11 +1327,12 @@ jobs:
       fail_fast: true
       steps:
       - task: promote-deb-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: apt-transport-artifact-registry
-          environment: staging
+        params:
+          TYPE: promoteToStaging
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml

--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -491,41 +491,47 @@ jobs:
       fail_fast: true
       steps:
       - task: promote-deb9-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-oslogin-stretch
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-deb10-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-oslogin-buster
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-deb11-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-oslogin-bullseye
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el7-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-oslogin-el7
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el8-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-oslogin-el8
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el9-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-oslogin-el9
-          environment: staging
+        params:
+          TYPE: promoteToStaging
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -957,41 +963,47 @@ jobs:
     file: timestamp/timestamp-ms
   - in_parallel:
       - task: promote-deb9-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-stretch
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-deb10-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-buster
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-deb11-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-apt
           repo: gce-google-compute-engine-bullseye
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el7-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-el7
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el8-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: gguest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-el8
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-el9-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: gce-google-compute-engine-el9
-          environment: staging
+        params:
+          TYPE: promoteToStaging
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -1231,17 +1243,19 @@ jobs:
       fail_fast: true
       steps:
       - task: promote-yum-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: yum-plugin-artifact-registry
-          environment: staging
+        params:
+          TYPE: promoteToStaging
       - task: promote-dnf-staging
-        file: guest-test-infra/concourse/tasks/gcloud-promote-package.yaml
+        file: guest-test-infra/concourse/tasks/gcloud-package-operation.yaml
         vars:
           universe: cloud-yum
           repo: dnf-plugin-artifact-registry
-          environment: staging
+        params:
+          TYPE: promoteToStaging
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml


### PR DESCRIPTION
Previously some steps in our package build pipelines were using the `gcloud-promote-package` task to promote a package to staging, using this would require an engineer's time to manually call ARLE to release the package.

Instead, since promoting to staging isn't a protected action, we can use the `gcloud-package-operation` task with the `promoteToStaging` option so that the promotion to staging is done automatically without any manual action.