### PR TITLE
cds image build: correct input

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -243,7 +243,7 @@ local CDSImgBuildJob(image, workflow) = imgbuildjob {
 
   // Append var to Daisy build task
   build_task: RHUIImgBuildTask(workflow, '((.:gcs-url))') {
-    inputs: [
+    inputs+: [
       { name: 'gcp-secret-manager' },
     ],
     vars+: [


### PR DESCRIPTION
append rather than overwriting; the workflow itself is in compute-image-tools