### PR TITLE
remove unused arg 'gcs-key.credential'

### DIFF
--- a/concourse/pipelines/bare-metal-image-build.yaml
+++ b/concourse/pipelines/bare-metal-image-build.yaml
@@ -20,29 +20,21 @@ resources:
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "rhel/rhel-7-metal-v([0-9]+).tar.gz"
 - name: rhel-8-metal-gcs
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "rhel/rhel-8-metal-v([0-9]+).tar.gz"
 - name: rhel-7-metal-dev-gcs
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "rhel/rhel-7-metal-dev-v([0-9]+).tar.gz"
 - name: rhel-8-metal-dev-gcs
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "rhel/rhel-8-metal-dev-v([0-9]+).tar.gz"
 
 jobs:

--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -20,15 +20,11 @@ resources:
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "debian-worker/debian-10-worker-v([0-9]+).tar.gz"
 - name: debian-11-worker-arm64-gcs
   type: gcs
   source:
     bucket: artifact-releaser-prod-rtp
-    json_key: |
-      ((gcs-key.credential))
     regexp: "debian-worker/debian-11-worker-arm64-v([0-9]+).tar.gz"
 
 jobs:


### PR DESCRIPTION
We are not reading credentials in a hard-coded way, so these args are not useful anymore.