### PR TITLE
use golang:1.13 everywhere

### DIFF
--- a/container_images/cleanerupper/Dockerfile
+++ b/container_images/cleanerupper/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang as build
+FROM golang:1.13 as build
 
 WORKDIR /build
 COPY . .

--- a/container_images/concourse-metrics/Dockerfile
+++ b/container_images/concourse-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.13-alpine
 
 RUN apk add --no-cache git
 

--- a/container_images/gobuild/Dockerfile
+++ b/container_images/gobuild/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13.15
+FROM golang:1.13
 
 RUN apt-get update && apt-get install -y git && \
     rm -rf /var/cache/apt/archives

--- a/container_images/gointegtest/Dockerfile
+++ b/container_images/gointegtest/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang
+FROM golang:1.13
 RUN go get -u github.com/jstemmer/go-junit-report
 
 FROM gcr.io/compute-image-tools/daisy:latest

--- a/container_images/gotest/Dockerfile
+++ b/container_images/gotest/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13.15
+FROM golang:1.13
 
 RUN apt-get update && apt-get -y install bash ca-certificates curl libssl-dev wget && \
     rm -rf /var/cache/apt/archives

--- a/container_images/jsonnet-go/Dockerfile
+++ b/container_images/jsonnet-go/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang
+FROM golang:1.13
 
 RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 

--- a/container_images/validate-integtest/Dockerfile
+++ b/container_images/validate-integtest/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang
+FROM golang:1.13
 RUN go get -u github.com/jstemmer/go-junit-report
 
 FROM node

--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:alpine as builder
+FROM golang:1.13-alpine as builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
The `gointegtest` build is failing with the following message; this occurred since it doesn't pin the golang layer, and Go 1.18 deprecated `go get`

```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```


`go get no longer builds or installs packages in module-aware mode. `: https://tip.golang.org/doc/go1.18