### PR TITLE
run ARM tests for guest agent based on test image

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -199,11 +199,19 @@ jobs:
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent-((.:package-version))-g1.el8.x86_64.rpm
           machine-type: e2-medium
           worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
-  - task: guest-agent-image-tests
-    file: guest-test-infra/concourse/tasks/image-test-args.yaml
-    vars:
-      images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
-      extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - task: guest-agent-image-tests-amd64
+        file: guest-test-infra/concourse/tasks/image-test-args.yaml
+        vars:
+          images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
+          extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
+      - task: guest-agent-image-tests-arm64
+        file: guest-test-infra/concourse/tasks/image-test-args.yaml
+        vars:
+          images: projects/gcp-guest/global/images/debian-11-arm64-((.:build-id))
+          extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
   - in_parallel:
       fail_fast: true
       steps:

--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -206,7 +206,6 @@ jobs:
         file: guest-test-infra/concourse/tasks/image-test-args.yaml
         vars:
           images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
-          machine-type: e2-medium
           extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
       - task: guest-agent-image-tests-arm64
         file: guest-test-infra/concourse/tasks/image-test-args.yaml

--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -206,11 +206,13 @@ jobs:
         file: guest-test-infra/concourse/tasks/image-test-args.yaml
         vars:
           images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
+          machine-type: e2-medium
           extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
       - task: guest-agent-image-tests-arm64
         file: guest-test-infra/concourse/tasks/image-test-args.yaml
         vars:
           images: projects/gcp-guest/global/images/debian-11-arm64-((.:build-id))
+          machine-type: t2a-standard-2
           extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
   - in_parallel:
       fail_fast: true

--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -149,40 +149,60 @@ jobs:
           source-image: projects/debian-cloud/global/images/family/debian-9
           dest-image: debian-9-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent_((.:package-version))-g1_amd64.deb
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
       - task: build-package-image-debian-10
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
           source-image: projects/debian-cloud/global/images/family/debian-10
           dest-image: debian-10-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent_((.:package-version))-g1_amd64.deb
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
       - task: build-package-image-debian-11
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
           source-image: projects/debian-cloud/global/images/family/debian-11
           dest-image: debian-11-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent_((.:package-version))-g1_amd64.deb
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
+      - task: build-package-image-debian-11-arm64
+        file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
+        vars:
+          source-image: projects/debian-cloud/global/images/family/debian-11-arm64
+          dest-image: debian-11-arm64-((.:build-id))
+          gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent_((.:package-version))-g1_arm64.deb
+          machine-type: t2a-standard-2
+          worker-image: projects/debian-cloud-testing/global/images/family/debian-11-arm64
       - task: build-package-image-centos-7
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
           source-image: projects/centos-cloud/global/images/family/centos-7
           dest-image: centos-7-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent-((.:package-version))-g1.el7.x86_64.rpm
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
       - task: build-package-image-rhel-7
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
           source-image: projects/rhel-cloud/global/images/family/rhel-7
           dest-image: rhel-7-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent-((.:package-version))-g1.el7.x86_64.rpm
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
       - task: build-package-image-rhel-8
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
           source-image: projects/rhel-cloud/global/images/family/rhel-8
           dest-image: rhel-8-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent-((.:package-version))-g1.el8.x86_64.rpm
+          machine-type: e2-medium
+          worker-image: projects/compute-image-tools/global/images/family/debian-10-worker
   - task: guest-agent-image-tests
     file: guest-test-infra/concourse/tasks/image-test-args.yaml
     vars:
-      images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
+      images: projects/gcp-guest/global/images/debian-9-((.:build-id)),projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id))
       extra-args: "-exclude=(image)|(disk)|(security)|(oslogin)"
   - in_parallel:
       fail_fast: true

--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -170,11 +170,11 @@ jobs:
       - task: build-package-image-debian-11-arm64
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:
-          source-image: projects/debian-cloud/global/images/family/debian-11-arm64
+          source-image: projects/debian-cloud-testing/global/images/family/debian-11-arm64
           dest-image: debian-11-arm64-((.:build-id))
           gcs-package-path: gs://gcp-guest-package-uploads/guest-agent/google-guest-agent_((.:package-version))-g1_arm64.deb
           machine-type: t2a-standard-2
-          worker-image: projects/debian-cloud-testing/global/images/family/debian-11-arm64
+          worker-image: projects/compute-image-tools/global/images/family/debian-11-worker-arm64
       - task: build-package-image-centos-7
         file: guest-test-infra/concourse/tasks/daisy-build-package-image.yaml
         vars:

--- a/concourse/tasks/daisy-build-package-image.yaml
+++ b/concourse/tasks/daisy-build-package-image.yaml
@@ -17,4 +17,6 @@ run:
   - -var:source_image=((source-image))
   - -var:gcs_package_path=((gcs-package-path))
   - -var:dest_image=((dest-image))
+  - -var:machine_type=((machine-type))
+  - -var:worker_image=((worker-image))
   - ./compute-image-tools/daisy_workflows/image_build/install_package/install_package.wf.json

--- a/concourse/tasks/image-test-args.yaml
+++ b/concourse/tasks/image-test-args.yaml
@@ -16,4 +16,5 @@ run:
   - -test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005
   - -images=((images))
   - -exclude=oslogin
+  - -machine-type=((machine-type))
   - ((extra-args))


### PR DESCRIPTION
Build the test image by installing the guest-agent arm64 lib, and run it.
To support that, we added machine-type and worker-image as the task args.