### PR TITLE
Use golang:latest for cleanerupper

### DIFF
--- a/container_images/cleanerupper/Dockerfile
+++ b/container_images/cleanerupper/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13 as build
+FROM golang as build
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
The `cleanerupper` build is failing with the following message:

```
# golang.org/x/net/http2
/go/pkg/mod/golang.org/x/net@v0.0.0-20220127200216-cd36cc0744dd/http2/transport.go:417:45: undefined: os.ErrDeadlineExceeded
note: module requires Go 1.17
```

That occurred since in https://github.com/GoogleCloudPlatform/guest-test-infra/pull/424 we changed it to use 1.13. This PR changes the base layer to use Go latest.