### PR TITLE
remove unused arg 'google_cloud_repo' for debian-11-worker-arm64

### DIFF
--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -103,7 +103,6 @@ jobs:
     vars:
       wf: "debian/debian_11_worker_arm64.wf.json"
       gcs_url: ((.:gcs-url))
-      google_cloud_repo: "stable"
       build_date: ((.:build-date))
   on_success:
     task: success

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -32,7 +32,7 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "machine-type": "t2a-standard-2",
+          "machine_type": "t2a-standard-2",
           "version": "${version}"
         }
       }


### PR DESCRIPTION
For a new workflow, this arg is removed on daisy workflows of compute-image-tools. Don't pass it in.