### PR TITLE
specify zone=us-central1-a for debian-11-worker-arm64

### DIFF
--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -57,7 +57,6 @@ jobs:
     vars:
       wf: "debian/debian_10_worker.wf.json"
       gcs_url: ((.:gcs-url))
-      google_cloud_repo: "stable"
       build_date: ((.:build-date))
   on_success:
     task: success

--- a/concourse/tasks/daisy-build-images-debian.yaml
+++ b/concourse/tasks/daisy-build-images-debian.yaml
@@ -14,7 +14,6 @@ run:
   - -project=gce-image-builder
   - -zone=us-central1-c
   - -var:build_date=((build_date))
-  - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -33,6 +33,7 @@
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
+          "zone": "us-central1-a",
           "version": "${version}"
         }
       }

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -35,6 +35,10 @@
     "machine_type": {
       "Value": "e2-standard-2",
       "Description": "machine type"
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -57,6 +61,7 @@
             "version": "${version}"
           },
           "machineType": "${machine_type}",
+          "zone": "${zone}",
           "name": "inst-build-pkg",
           "StartupScript": "startup.sh",
           "Scopes": ["https://www.googleapis.com/auth/devstorage.read_write"]


### PR DESCRIPTION
Only us-central1-a supports arm64 VM now. Specify it.

Also deprecate google_cloud_repo for debian-worker completely.