### PR TITLE
build & publish windows-install-media

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -37,5 +37,7 @@ jobs:
     file: rendered/windows-image-build.json
   - set_pipeline: container-build
     file: rendered/container-build.json
+  - set_pipeline: windows-install-media-image-build
+    file: guest-test-infra/concourse/pipelines/windows-install-media-image-build.yaml
   - set_pipeline: artifact-releaser-autopush
     file: guest-test-infra/concourse/pipelines/artifact-releaser-autopush.yaml

--- a/concourse/pipelines/windows-install-media-image-build.yaml
+++ b/concourse/pipelines/windows-install-media-image-build.yaml
@@ -16,6 +16,11 @@ resources:
   source:
     uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
     branch: master
+- name: windows-install-media-gcs
+  type: gcs
+  source:
+    bucket: artifact-releaser-prod-rtp
+    regexp: "windows-install-media/windows-install-media-v([0-9]+).tar.gz"
 
 jobs:
 # Build jobs
@@ -31,6 +36,13 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
       prefix: "windows-install-media"
+  - put: windows-install-media-gcs
+    params:
+      file: build-id-dir/windows-install-media*
+    get_params:
+      skip_download: "true"
+  - load_var: gcs-url
+    file: windows-install-media-gcs/url
   - task: generate-build-date
     file: guest-test-infra/concourse/tasks/generate-version.yaml
   - load_var: build-date
@@ -38,28 +50,26 @@ jobs:
   - task: daisy-build-windows-install-media
     file: guest-test-infra/concourse/tasks/daisy-build-images-debian.yaml
     vars:
-      wf: "debian/debian_10_worker.wf.json"
+      wf: "windows_media/windows-install-media.wf.json"
       gcs_url: ((.:gcs-url))
-      google_cloud_repo: "stable"
-      build_date: ((.:build-date))
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "build-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "build-windows-install-media"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "build-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "build-windows-install-media"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
 # Publish jobs
-- name: publish-to-testing-debian-10-worker
+- name: publish-to-testing-windows-install-media
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
@@ -67,24 +77,24 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
-  - get: debian-10-worker-gcs
-    passed: [build-debian-10-worker]
+  - get: windows-install-media-gcs
+    passed: [build-windows-install-media]
     trigger: false
     params:
       skip_download: "true"
   - load_var: source-version
-    file: debian-10-worker-gcs/version
+    file: windows-install-media-gcs/version
   - task: generate-version
     file: guest-test-infra/concourse/tasks/generate-version.yaml
   - load_var: publish-version
     file: publish-version/version # produced from generate-version task
-  - task: publish-debian-10-worker
+  - task: publish-windows-install-media
     file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
     vars:
-      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/windows-install-media"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
-      wf: "debian/debian_10_worker.publish.json"
+      wf: "windows_media/windows-install-media.publish.json"
       environment: "test"
   on_success:
     task: success

--- a/concourse/pipelines/windows-install-media-image-build.yaml
+++ b/concourse/pipelines/windows-install-media-image-build.yaml
@@ -100,19 +100,19 @@ jobs:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-testing-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-testing-windows-install-media"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-testing-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-testing-windows-install-media"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-- name: publish-to-staging-debian-10-worker
+- name: publish-to-staging-windows-install-media
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
@@ -120,42 +120,42 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
-  - get: debian-10-worker-gcs
-    passed: [build-debian-10-worker]
+  - get: windows-install-media-gcs
+    passed: [build-windows-install-media]
     trigger: false
     params:
       skip_download: "true"
   - load_var: source-version
-    file: debian-10-worker-gcs/version
+    file: windows-install-media-gcs/version
   - task: generate-version
     file: guest-test-infra/concourse/tasks/generate-version.yaml
   - load_var: publish-version
     file: publish-version/version # produced from generate-version task
-  - task: publish-debian-10-worker
+  - task: publish-windows-install-media
     file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
     vars:
-      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/windows-install-media"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
-      wf: "debian/debian_10_worker.publish.json"
+      wf: "windows_media/windows-install-media.publish.json"
       environment: "staging"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-staging-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-staging-windows-install-media"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-staging-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-staging-windows-install-media"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))
-- name: publish-to-prod-debian-10-worker
+- name: publish-to-prod-windows-install-media
   plan:
   - get: guest-test-infra
   - get: compute-image-tools
@@ -163,40 +163,40 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
-  - get: debian-10-worker-gcs
-    passed: [publish-to-staging-debian-10-worker]
+  - get: windows-install-media-gcs
+    passed: [publish-to-staging-windows-install-media]
     trigger: false
     params:
       skip_download: "true"
   - load_var: source-version
-    file: debian-10-worker-gcs/version
+    file: windows-install-media-gcs/version
   - task: generate-version
     file: guest-test-infra/concourse/tasks/generate-version.yaml
   - load_var: publish-version
     file: publish-version/version # produced from generate-version task
-  - task: publish-debian-10-worker
+  - task: publish-windows-install-media
     file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
     vars:
-      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/windows-install-media"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
-      wf: "debian/debian_10_worker.publish.json"
+      wf: "windows_media/windows-install-media.publish.json"
       release_notes: ""
-      image_name: "debian_10_worker"
+      image_name: "windows_install_media"
       topic: "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-prod-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-prod-windows-install-media"
       result_state: "success"
       start_timestamp: ((.:start-timestamp-ms))
   on_failure:
     task: failure
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
     vars:
-      pipeline: "debian-worker-image-build"
-      job: "publish-to-prod-debian-10-worker"
+      pipeline: "windows-install-media-image-build"
+      job: "publish-to-prod-windows-install-media"
       result_state: "failure"
       start_timestamp: ((.:start-timestamp-ms))

--- a/concourse/pipelines/windows-install-media-image-build.yaml
+++ b/concourse/pipelines/windows-install-media-image-build.yaml
@@ -1,0 +1,192 @@
+---
+resource_types:
+- name: gcs
+  type: registry-image
+  source:
+    repository: frodenas/gcs-resource
+
+resources:
+- name: compute-image-tools
+  type: git
+  source:
+    uri: https://github.com/GoogleCloudPlatform/compute-image-tools.git
+    branch: master
+- name: guest-test-infra
+  type: git
+  source:
+    uri: https://github.com/GoogleCloudPlatform/guest-test-infra.git
+    branch: master
+
+jobs:
+# Build jobs
+- name: build-windows-install-media
+  plan:
+  - get: compute-image-tools
+  - get: guest-test-infra
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
+  - task: generate-build-id
+    file: guest-test-infra/concourse/tasks/generate-build-id.yaml
+    vars:
+      prefix: "windows-install-media"
+  - task: generate-build-date
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: build-date
+    file: publish-version/version
+  - task: daisy-build-windows-install-media
+    file: guest-test-infra/concourse/tasks/daisy-build-images-debian.yaml
+    vars:
+      wf: "debian/debian_10_worker.wf.json"
+      gcs_url: ((.:gcs-url))
+      google_cloud_repo: "stable"
+      build_date: ((.:build-date))
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "build-debian-10-worker"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "build-debian-10-worker"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+# Publish jobs
+- name: publish-to-testing-debian-10-worker
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
+  - get: debian-10-worker-gcs
+    passed: [build-debian-10-worker]
+    trigger: false
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: debian-10-worker-gcs/version
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-debian-10-worker
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "debian/debian_10_worker.publish.json"
+      environment: "test"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-testing-debian-10-worker"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-testing-debian-10-worker"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+- name: publish-to-staging-debian-10-worker
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
+  - get: debian-10-worker-gcs
+    passed: [build-debian-10-worker]
+    trigger: false
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: debian-10-worker-gcs/version
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-debian-10-worker
+    file: guest-test-infra/concourse/tasks/daisy-publish-images.yaml
+    vars:
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "debian/debian_10_worker.publish.json"
+      environment: "staging"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-staging-debian-10-worker"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-staging-debian-10-worker"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))
+- name: publish-to-prod-debian-10-worker
+  plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - task: generate-timestamp
+    file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
+  - load_var: start-timestamp-ms
+    file: timestamp/timestamp-ms
+  - get: debian-10-worker-gcs
+    passed: [publish-to-staging-debian-10-worker]
+    trigger: false
+    params:
+      skip_download: "true"
+  - load_var: source-version
+    file: debian-10-worker-gcs/version
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: publish-version
+    file: publish-version/version # produced from generate-version task
+  - task: publish-debian-10-worker
+    file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
+    vars:
+      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      source_version: v((.:source-version))
+      publish_version: ((.:publish-version))
+      wf: "debian/debian_10_worker.publish.json"
+      release_notes: ""
+      image_name: "debian_10_worker"
+      topic: "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod"
+  on_success:
+    task: success
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-prod-debian-10-worker"
+      result_state: "success"
+      start_timestamp: ((.:start-timestamp-ms))
+  on_failure:
+    task: failure
+    file: guest-test-infra/concourse/tasks/publish-job-result.yaml
+    vars:
+      pipeline: "debian-worker-image-build"
+      job: "publish-to-prod-debian-10-worker"
+      result_state: "failure"
+      start_timestamp: ((.:start-timestamp-ms))

--- a/concourse/tasks/daisy-build-images-debian.yaml
+++ b/concourse/tasks/daisy-build-images-debian.yaml
@@ -13,8 +13,6 @@ run:
   args:
   - -project=gce-image-builder
   - -zone=us-central1-c
-  - -var:build_date=((build_date))
-  - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))

--- a/concourse/tasks/daisy-build-images-debian.yaml
+++ b/concourse/tasks/daisy-build-images-debian.yaml
@@ -13,6 +13,8 @@ run:
   args:
   - -project=gce-image-builder
   - -zone=us-central1-c
+  - -var:build_date=((build_date))
+  - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))

--- a/concourse/tasks/daisy-build-windows-install-media.yaml
+++ b/concourse/tasks/daisy-build-windows-install-media.yaml
@@ -13,8 +13,6 @@ run:
   args:
   - -project=gce-image-builder
   - -zone=us-central1-c
-  - -var:build_date=((build_date))
-  - -var:google_cloud_repo=((google_cloud_repo))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
   - ./compute-image-tools/daisy_workflows/build-publish/((wf))

--- a/concourse/tasks/daisy-build-windows-install-media.yaml
+++ b/concourse/tasks/daisy-build-windows-install-media.yaml
@@ -1,0 +1,20 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: gcr.io/compute-image-tools/daisy
+
+inputs:
+- name: compute-image-tools
+
+run:
+  path: /daisy
+  args:
+  - -project=gce-image-builder
+  - -zone=us-central1-c
+  - -var:build_date=((build_date))
+  - -var:google_cloud_repo=((google_cloud_repo))
+  - -var:gcs_url=((gcs_url))
+  - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/
+  - ./compute-image-tools/daisy_workflows/build-publish/((wf))


### PR DESCRIPTION
This is missed on both previous build framework and current concourse. Add it to concourse to make it completely managed.