### PR TITLE
Modify zone of 'daisy-build-images-debian' to us-central1-a for arm compatibility

### DIFF
--- a/concourse/tasks/daisy-build-images-debian.yaml
+++ b/concourse/tasks/daisy-build-images-debian.yaml
@@ -12,7 +12,7 @@ run:
   path: /daisy
   args:
   - -project=gce-image-builder
-  - -zone=us-central1-c
+  - -zone=us-central1-a
   - -var:build_date=((build_date))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/


### PR DESCRIPTION
Modify zone of 'daisy-build-images-debian' to us-central1-a for arm compatibility.
There are many "zone" settings in the whole chain of ARM build process. This one is missed in the previous PR.