### PR TITLE
fix prod publish arg name: source_gcs_path -> gcs_image_path

### DIFF
--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -314,7 +314,7 @@ jobs:
   - task: publish-debian-10-worker
     file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
     vars:
-      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      gcs_image_path: "gs://artifact-releaser-prod-rtp/debian-worker"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
       wf: "debian/debian_10_worker.publish.json"
@@ -359,7 +359,7 @@ jobs:
   - task: publish-debian-11-worker-arm64
     file: guest-test-infra/concourse/tasks/gcloud-publish-image.yaml
     vars:
-      source_gcs_path: "gs://artifact-releaser-prod-rtp/debian-worker"
+      gcs_image_path: "gs://artifact-releaser-prod-rtp/debian-worker"
       source_version: v((.:source-version))
       publish_version: ((.:publish-version))
       wf: "debian/debian_11_worker_arm64.publish.json"


### PR DESCRIPTION
For some reason, the arg for debian worker image publish was wrong for debian-10-worker. I copied it for debian-11-worker-arm64 so it was also wrong. Fix it for debian-10-worker, and also fix for debian-11-worker-arm64.