### PR TITLE
comment out guest-agent-publish-coverage since it is broken 

### DIFF
--- a/concourse/pipelines/guest-package-build.yaml
+++ b/concourse/pipelines/guest-package-build.yaml
@@ -97,11 +97,11 @@ jobs:
       name: package-version/version
       tag: package-version/version
       commitish: guest-agent/.git/ref
-  - task: guest-agent-publish-coverage
-    file: guest-test-infra/concourse/tasks/publish-coverage.yaml
-    vars:
-      package_name: "google-guest-agent"
-      coverage_percent: ((.:coverage-percent))
+#  - task: guest-agent-publish-coverage
+#    file: guest-test-infra/concourse/tasks/publish-coverage.yaml
+#    vars:
+#      package_name: "google-guest-agent"
+#      coverage_percent: ((.:coverage-percent))
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml


### PR DESCRIPTION
Will bring it back when we resolved the build issue on debian 11 arm64.