### PR TITLE
add rhui publish tasks

### DIFF
--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -12,7 +12,7 @@ local common = import '../templates/common.libsonnet';
 
     platform: 'linux',
     image_resource: {
-      type: 'docker-image',
+      type: 'registry-image',
       source: { repository: 'gcr.io/compute-image-tools/gce_image_publish' },
     },
     inputs: [
@@ -47,7 +47,7 @@ local common = import '../templates/common.libsonnet';
 
       platform: 'linux',
       image_resource: {
-        type: 'docker-image',
+        type: 'registry-image',
         source: { repository: 'google/cloud-sdk', tag: 'alpine' },
       },
       inputs: [{ name: 'compute-image-tools' }],

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -31,8 +31,12 @@
   gcsimgresource:: {
     local resource = self,
 
-    regexp:: '%s/%s-v([0-9]+).tar.gz' % [self.gcs_dir, self.image],
-    gcs_dir:: error 'must set gcs_dir in gcsimgresource template',
+    regexp:: if self.gcs_dir != '' then
+      '%s/%s-v([0-9]+).tar.gz' % [self.gcs_dir, self.image]
+    else
+      error 'must set regexp or gcs_dir in gcsimgresource',
+
+    gcs_dir:: '',
     image:: error 'must set image in gcsimgresource template',
     bucket:: tl.prod_bucket,
 

--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -17,7 +17,7 @@
     // Start of output.
     platform: 'linux',
     image_resource: {
-      type: 'docker-image',
+      type: 'registry-image',
       source: {
         repository: 'gcr.io/compute-image-tools/daisy',
         tag: 'latest',

--- a/concourse/templates/gcp-secret-manager.libsonnet
+++ b/concourse/templates/gcp-secret-manager.libsonnet
@@ -11,7 +11,7 @@
 
     platform: 'linux',
     image_resource: {
-      type: 'docker-image',
+      type: 'registry-image',
       source: {
         repository: 'google/cloud-sdk',
         tag: 'alpine',


### PR DESCRIPTION
* add RHUI image publish jobs (prod-only for now)
* remove jsonnet functions for various Concourse objects in favor of templates
* use registry-image consistently

output after this minor refactor was confirmed to match the output from before the refactor except for ordering and the changes listed here.