### PR TITLE
Add pipeline for RHUIv4 release

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -37,5 +37,7 @@ jobs:
     file: rendered/windows-image-build.json
   - set_pipeline: container-build
     file: rendered/container-build.json
+  - set_pipeline: rhui-release
+    file: guest-test-infra/concourse/pipelines/rhui-release.yaml
   - set_pipeline: artifact-releaser-autopush
     file: guest-test-infra/concourse/pipelines/artifact-releaser-autopush.yaml

--- a/concourse/pipelines/rhui-release.yaml
+++ b/concourse/pipelines/rhui-release.yaml
@@ -22,9 +22,18 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - rhua-mig-staging-us-west1
+        - --region
+        - us-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-rhua
   - config:
       image_resource:
@@ -35,11 +44,64 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - rhua-mig-staging-us-west1
+        - --region
+        - us-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - cds-mig-staging-us-west1
+        - --region
+        - us-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-cds
-- name: wave-0-finished
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - cds-mig-staging-us-west1
+        - --region
+        - us-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-cds
+- name: wave-1
   plan:
   - get: cds-image
     passed:
@@ -53,11 +115,11 @@ jobs:
   plan:
   - get: cds-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - get: rhua-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - config:
       image_resource:
@@ -68,9 +130,18 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - rhua-mig-prod-europe-west1
+        - --region
+        - europe-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-rhua
   - config:
       image_resource:
@@ -81,19 +152,72 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - rhua-mig-prod-europe-west1
+        - --region
+        - europe-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - cds-mig-prod-europe-west1
+        - --region
+        - europe-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-cds
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - cds-mig-prod-europe-west1
+        - --region
+        - europe-west1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-cds
 - name: deploy-prod-us-central1
   plan:
   - get: cds-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - get: rhua-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - config:
       image_resource:
@@ -104,9 +228,18 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - rhua-mig-prod-us-central1
+        - --region
+        - us-central1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-rhua
   - config:
       image_resource:
@@ -117,19 +250,72 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - rhua-mig-prod-us-central1
+        - --region
+        - us-central1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - cds-mig-prod-us-central1
+        - --region
+        - us-central1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-cds
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - cds-mig-prod-us-central1
+        - --region
+        - us-central1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-cds
 - name: deploy-prod-asia-southeast1
   plan:
   - get: cds-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - get: rhua-image
     passed:
-    - wave-0-finished
+    - wave-1
     trigger: true
   - config:
       image_resource:
@@ -140,9 +326,18 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - rhua-mig-prod-asia-southeast1
+        - --region
+        - asia-southeast1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-rhua
   - config:
       image_resource:
@@ -153,15 +348,72 @@ jobs:
       platform: linux
       run:
         args:
-        - -exc
-        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra;
-        path: sh
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - rhua-mig-prod-asia-southeast1
+        - --region
+        - asia-southeast1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - rolling-action
+        - replace
+        - --quiet
+        - cds-mig-prod-asia-southeast1
+        - --region
+        - asia-southeast1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
     task: deploy-cds
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - compute
+        - instance-groups
+        - managed
+        - wait-until
+        - --version-target-reached
+        - --quiet
+        - cds-mig-prod-asia-southeast1
+        - --region
+        - asia-southeast1
+        - --project
+        - google.com:rhel-infra
+        path: gcloud
+    task: wait-cds
 resource_types:
+- name: registry-image-private
+  source:
+    repository: gcr.io/compute-image-tools/registry-image-forked
+  type: registry-image
 - name: gce-img
   source:
     repository: gcr.io/gcp-guest/gce-img-resource
-  type: registry-image
+  type: registry-image-private
 resources:
 - name: cds-image
   source:

--- a/concourse/pipelines/rhui-release.yaml
+++ b/concourse/pipelines/rhui-release.yaml
@@ -29,10 +29,8 @@ jobs:
         - replace
         - --quiet
         - rhua-mig-staging-us-west1
-        - --region
-        - us-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-rhua
   - config:
@@ -51,10 +49,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - rhua-mig-staging-us-west1
-        - --region
-        - us-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-rhua
   - config:
@@ -73,10 +69,8 @@ jobs:
         - replace
         - --quiet
         - cds-mig-staging-us-west1
-        - --region
-        - us-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-cds
   - config:
@@ -95,10 +89,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - cds-mig-staging-us-west1
-        - --region
-        - us-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-cds
 - name: wave-1
@@ -137,10 +129,8 @@ jobs:
         - replace
         - --quiet
         - rhua-mig-prod-europe-west1
-        - --region
-        - europe-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=europe-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-rhua
   - config:
@@ -159,10 +149,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - rhua-mig-prod-europe-west1
-        - --region
-        - europe-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=europe-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-rhua
   - config:
@@ -181,10 +169,8 @@ jobs:
         - replace
         - --quiet
         - cds-mig-prod-europe-west1
-        - --region
-        - europe-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=europe-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-cds
   - config:
@@ -203,10 +189,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - cds-mig-prod-europe-west1
-        - --region
-        - europe-west1
-        - --project
-        - google.com:rhel-infra
+        - --region=europe-west1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-cds
 - name: deploy-prod-us-central1
@@ -235,10 +219,8 @@ jobs:
         - replace
         - --quiet
         - rhua-mig-prod-us-central1
-        - --region
-        - us-central1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-central1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-rhua
   - config:
@@ -257,10 +239,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - rhua-mig-prod-us-central1
-        - --region
-        - us-central1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-central1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-rhua
   - config:
@@ -279,10 +259,8 @@ jobs:
         - replace
         - --quiet
         - cds-mig-prod-us-central1
-        - --region
-        - us-central1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-central1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-cds
   - config:
@@ -301,10 +279,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - cds-mig-prod-us-central1
-        - --region
-        - us-central1
-        - --project
-        - google.com:rhel-infra
+        - --region=us-central1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-cds
 - name: deploy-prod-asia-southeast1
@@ -333,10 +309,8 @@ jobs:
         - replace
         - --quiet
         - rhua-mig-prod-asia-southeast1
-        - --region
-        - asia-southeast1
-        - --project
-        - google.com:rhel-infra
+        - --region=asia-southeast1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-rhua
   - config:
@@ -355,10 +329,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - rhua-mig-prod-asia-southeast1
-        - --region
-        - asia-southeast1
-        - --project
-        - google.com:rhel-infra
+        - --region=asia-southeast1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-rhua
   - config:
@@ -377,10 +349,8 @@ jobs:
         - replace
         - --quiet
         - cds-mig-prod-asia-southeast1
-        - --region
-        - asia-southeast1
-        - --project
-        - google.com:rhel-infra
+        - --region=asia-southeast1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: deploy-cds
   - config:
@@ -399,10 +369,8 @@ jobs:
         - --version-target-reached
         - --quiet
         - cds-mig-prod-asia-southeast1
-        - --region
-        - asia-southeast1
-        - --project
-        - google.com:rhel-infra
+        - --region=asia-southeast1
+        - --project=google.com:rhel-infra
         path: gcloud
     task: wait-cds
 resource_types:
@@ -412,6 +380,7 @@ resource_types:
   type: registry-image
 - name: gce-img
   source:
+    google_auth: true
     repository: gcr.io/gcp-guest/gce-img-resource
   type: registry-image-private
 resources:

--- a/concourse/pipelines/rhui-release.yaml
+++ b/concourse/pipelines/rhui-release.yaml
@@ -1,0 +1,175 @@
+jobs:
+- name: manual-trigger
+  plan:
+  - get: cds-image
+    trigger: false
+  - get: rhua-image
+    trigger: false
+- name: deploy-staging-us-west1
+  plan:
+  - get: cds-image
+    passed: [ ]
+    trigger: true
+  - get: rhua-image
+    passed: [ ]
+    trigger: true
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-staging-us-west1 --region=us-west1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-cds
+- name: wave-0-finished
+  plan:
+  - get: cds-image
+    passed:
+    - deploy-staging-us-west1
+    trigger: true
+  - get: rhua-image
+    passed:
+    - deploy-staging-us-west1
+    trigger: true
+- name: deploy-prod-europe-west1
+  plan:
+  - get: cds-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - get: rhua-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-europe-west1 --region=europe-west1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-cds
+- name: deploy-prod-us-central1
+  plan:
+  - get: cds-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - get: rhua-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-us-central1 --region=us-central1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-cds
+- name: deploy-prod-asia-southeast1
+  plan:
+  - get: cds-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - get: rhua-image
+    passed:
+    - wave-0-finished
+    trigger: true
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet rhua-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet rhua-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-rhua
+  - config:
+      image_resource:
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+        type: registry-image
+      platform: linux
+      run:
+        args:
+        - -exc
+        - gcloud compute instance-groups managed rolling-action replace --quiet cds-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra; gcloud compute instance-groups managed wait-until --version-target-reached --quiet cds-mig-prod-asia-southeast1 --region=asia-southeast1 --project=google.com:rhel-infra;
+        path: sh
+    task: deploy-cds
+resource_types:
+- name: gce-img
+  source:
+    repository: gcr.io/gcp-guest/gce-img-resource
+  type: registry-image
+resources:
+- name: cds-image
+  source:
+    family: cds
+    project: google.com:rhel-infra
+  type: gce-img
+- name: rhua-image
+  source:
+    family: rhua
+    project: google.com:rhel-infra
+  type: gce-img


### PR DESCRIPTION
This adds a new pipeline for deploying updated CDS and RHUA images to the RHUIv4 infra. It uses Concourse's [gated pipeline pattern](https://concourse-ci.org/gated-pipeline-patterns.html) to support the following features:
1. The pipeline requires a manual invocation (we can remove this later to implement continuous delivery)
2. Jobs are combined into waves. All of the regions in a wave deploy in parallel, and a wave doesn't start until the previous wave finishes.

For testing, I ran this on the dev cluster using my test project. (I didn't run it against `google.com:rhel-infra`.)

![image](https://user-images.githubusercontent.com/575626/163258868-2e2a0f3a-5df3-480c-a427-3f067dc1a51c.png)



![image](https://user-images.githubusercontent.com/575626/163066663-eddb9114-5b80-44aa-9663-d1cabed89ab4.png)
