### PR TITLE
changes to CIT for ubuntu images

### DIFF
--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -52,6 +52,10 @@ func TestCustomHostname(t *testing.T) {
 		// No dhclient and no dhclient exit hook.
 		t.Skip("Custom hostnames not supported on SLES")
 	}
+	if strings.Contains(image, "ubuntu") {
+		// No dhclient and no dhclient exit hook.
+		t.Skip("Custom hostnames not supported on Ubuntu")
+	}
 
 	TestFQDN(t)
 }
@@ -64,7 +68,7 @@ func TestFQDN(t *testing.T) {
 	}
 
 	if strings.Contains(image, "rhel-7-4-sap") {
-		t.Skip("hostname is not working well on RHEL 7-4-Sap")
+		t.Skip("hostname is not working well on RHEL 7.4 for SAP")
 	}
 
 	metadataHostname, err := utils.GetMetadata("hostname")
@@ -180,6 +184,10 @@ func TestHostsFile(t *testing.T) {
 	if strings.Contains(image, "sles") {
 		// SLES does not have dhclient or the dhclient exit hook.
 		t.Skip("Not supported on SLES")
+	}
+	if strings.Contains(image, "ubuntu") {
+		// Ubuntu does not have dhclient or the dhclient exit hook.
+		t.Skip("Not supported on Ubuntu")
 	}
 
 	b, err := ioutil.ReadFile("/etc/hosts")

--- a/imagetest/test_suites/image_validation/license_test.go
+++ b/imagetest/test_suites/image_validation/license_test.go
@@ -38,6 +38,7 @@ var licenseNames = []string{
 	"MIT",
 	"MIT license",
 	"MIT/X11 (BSD like)",
+	"MPL-2.0",
 	"no notice",
 	"noderivs",
 	"none",
@@ -126,6 +127,7 @@ var licenses = []string{
 	`DO WHAT THE HELL YOU WANT TO`, // Yes, this is a real license.
 	`arping: GPL v2 or later`,      // iputils has a license summary file
 	`PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2`,
+	`This is the Python license. In short, you can use this product in commercial and non-commercial applications`,
 }
 
 const (

--- a/imagetest/test_suites/image_validation/package_test.go
+++ b/imagetest/test_suites/image_validation/package_test.go
@@ -40,7 +40,7 @@ func TestGuestPackages(t *testing.T) {
 		t.Fatalf("couldn't determine image from metadata")
 	}
 	cmdPrefix := []string{"rpm", "-q", "--queryformat", "'%{NAME}\n'"}
-	if strings.Contains(image, "debian") {
+	if strings.Contains(image, "debian") || strings.Contains(image, "ubuntu") {
 		cmdPrefix = []string{"dpkg-query", "-W", "--showformat", "'${Package}\n'"}
 	}
 	packages := []string{"google-guest-agent", "google-osconfig-agent"}

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -128,6 +128,11 @@ func TestPasswordSecurity(t *testing.T) {
 		// SLES ships with "PermitRootLogin yes" in SSHD config.
 		t.Skip("Not supported on SLES")
 	}
+	if strings.Contains(image, "ubuntu") {
+		// Ubuntu doesn't set this option, but Ubuntu sshd defaults to prohibit-password
+		// TODO: find a way to determine the default so we can support 'not set' generally.
+		return
+	}
 
 	if err := verifySSHConfig(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
* skip custom hostname tests
* add 2 missing licenses
* add logic to use correct package manager

the shutdown script time test is still failing - this is more or less a genuine failure and i want to try to resolve it rather than adding a skip, at least right now

output:

```xml
<testsuites name="" errors="0" failures="1" disabled="0" skipped="2" tests="40" time="0">
	<testsuite name="security-ubuntu-2204-lts" tests="4" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="security-ubuntu-2204-lts" name="TestKernelSecuritySettings" time="0"></testcase>
		<testcase classname="security-ubuntu-2204-lts" name="TestAutomaticUpdates" time="0.01"></testcase>
		<testcase classname="security-ubuntu-2204-lts" name="TestPasswordSecurity" time="0"></testcase>
		<testcase classname="security-ubuntu-2204-lts" name="TestSockets" time="0.03"></testcase>
	</testsuite>
	<testsuite name="image_validation-ubuntu-2204-lts" tests="9" failures="0" errors="0" disabled="0" skipped="2" time="0">
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestNTPService" time="0.01"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestHostname" time="0"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestFQDN" time="0.01"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestHostKeysGeneratedOnce" time="0.12"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestHostsFile" time="0">
			<skipped message="    image_validation_test.go:190: Not supported on Ubuntu"></skipped>
		</testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestArePackagesLegal" time="12.28"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestStandardPrograms" time="5.5"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestGuestPackages" time="0.04"></testcase>
		<testcase classname="image_validation-ubuntu-2204-lts" name="TestCustomHostname" time="0">
			<skipped message="    image_validation_test.go:57: Custom hostnames not supported on Ubuntu"></skipped>
		</testcase>
	</testsuite>
	<testsuite name="image_boot-ubuntu-2204-lts" tests="5" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="image_boot-ubuntu-2204-lts" name="TestGuestBoot" time="0"></testcase>
		<testcase classname="image_boot-ubuntu-2204-lts" name="TestGuestReboot" time="0"></testcase>
		<testcase classname="image_boot-ubuntu-2204-lts" name="TestGuestRebootOnHost" time="0"></testcase>
		<testcase classname="image_boot-ubuntu-2204-lts" name="TestGuestSecureBoot" time="0"></testcase>
		<testcase classname="image_boot-ubuntu-2204-lts" name="TestBootTime" time="0"></testcase>
	</testsuite>
	<testsuite name="disk-ubuntu-2204-lts" tests="1" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="disk-ubuntu-2204-lts" name="TestDiskResize" time="0"></testcase>
	</testsuite>
	<testsuite name="ssh-ubuntu-2204-lts" tests="5" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="ssh-ubuntu-2204-lts" name="TestMatchingKeysInGuestAttributes" time="0.05"></testcase>
		<testcase classname="ssh-ubuntu-2204-lts" name="TestHostKeysAreUnique" time="61.04"></testcase>
		<testcase classname="ssh-ubuntu-2204-lts" name="TestSSHInstanceKey" time="60.61"></testcase>
		<testcase classname="ssh-ubuntu-2204-lts" name="TestEmptyTest" time="0"></testcase>
		<testcase classname="ssh-ubuntu-2204-lts" name="TestHostKeysNotOverrideAfterAgentRestart" time="0.12"></testcase>
	</testsuite>
	<testsuite name="network-ubuntu-2204-lts" tests="6" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="network-ubuntu-2204-lts" name="TestDHCP" time="0.01"></testcase>
		<testcase classname="network-ubuntu-2204-lts" name="TestDefaultMTU" time="0"></testcase>
		<testcase classname="network-ubuntu-2204-lts" name="TestPingVMToVM" time="8.14"></testcase>
		<testcase classname="network-ubuntu-2204-lts" name="TestAliases" time="30.01"></testcase>
		<testcase classname="network-ubuntu-2204-lts" name="TestAliasAfterReboot" time="30.01"></testcase>
		<testcase classname="network-ubuntu-2204-lts" name="TestAliasAgentRestart" time="60.16"></testcase>
	</testsuite>
	<testsuite name="metadata-ubuntu-2204-lts" tests="10" failures="1" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="metadata-ubuntu-2204-lts" name="TestTokenFetch" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestMetaDataResponseHeaders" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestGetMetaDataUsingIP" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestShutdownScript" time="0.01"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestShutdownScriptFailed" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestShutdownUrlScript" time="0.01"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestShutdownScriptTime" time="0.01">
			<failure type="">    shutdown_script_test.go:54: shut down time is 89 which is less than 110 seconds.</failure>
		</testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestStartupScript" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestStartupScriptFailed" time="0"></testcase>
		<testcase classname="metadata-ubuntu-2204-lts" name="TestDaemonScript" time="0.01"></testcase>
	</testsuite>
</testsuites>
```