### PR TITLE
Fix containers

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -145,13 +145,16 @@ local BuildContainerImage(image) = buildcontainerimgjob {
       dockerfile: 'guest-test-infra/container_images/gce-img-resource/Dockerfile',
     },
 
+    // TODO: this is built like daisy, with multi-platform binaries in GCS. Currently being built by CB in
+    // compute-image-tools.
+    //    buildcontainerimgjob {
+    //      destination: 'gcr.io/compute-image-tools/gce_image_publish',
+    //      dockerfile: 'gce_image_publish.Dockerfile',
+    //      image: 'gce_image_publish',
+    //      input: 'compute-image-tools',
+    //    },
+
     // Builds outside g-t-i repo.
-    buildcontainerimgjob {
-      destination: 'gcr.io/compute-image-tools/gce_image_publish',
-      dockerfile: 'gce_image_publish.Dockerfile',
-      image: 'gce_image_publish',
-      input: 'compute-image-tools',
-    },
     buildcontainerimgjob {
       context: 'compute-daisy',
       destination: 'gcr.io/compute-image-tools-test/test-runner',

--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -95,7 +95,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
   }],
   resources: [
     common.GitResource('guest-test-infra'),
-    common.GitResource('compute-image-tools'),
+    //common.GitResource('compute-image-tools'),
     {
       name: 'compute-image-tools-trigger',
       type: 'git',
@@ -146,7 +146,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
     },
 
     // TODO: this is built like daisy, with multi-platform binaries in GCS. Currently being built by CB in
-    // compute-image-tools.
+    // compute-image-tools project.
     //    buildcontainerimgjob {
     //      destination: 'gcr.io/compute-image-tools/gce_image_publish',
     //      dockerfile: 'gce_image_publish.Dockerfile',

--- a/container_images/concourse-metrics/Dockerfile
+++ b/container_images/concourse-metrics/Dockerfile
@@ -1,4 +1,17 @@
-FROM golang:1.13-alpine
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:alpine
 
 RUN apk add --no-cache git
 

--- a/container_images/jsonnet-go/Dockerfile
+++ b/container_images/jsonnet-go/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13
+FROM golang
 
 RUN go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 

--- a/container_images/validate-integtest/Dockerfile
+++ b/container_images/validate-integtest/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13
+FROM golang
+
 RUN go get -u github.com/jstemmer/go-junit-report
 
 FROM node


### PR DESCRIPTION
#424 was a bit overly broad, and should only have targeted package-building containers.

* restore golang version for other containers
* temporarily disable gce_image_publish until ready to migrate with other similar tools