### PR TITLE
rhui-release: wire manual-trigger

### DIFF
--- a/concourse/pipelines/rhui-release.yaml
+++ b/concourse/pipelines/rhui-release.yaml
@@ -8,10 +8,12 @@ jobs:
 - name: deploy-staging-us-west1
   plan:
   - get: cds-image
-    passed: [ ]
+    passed:
+    - manual-trigger
     trigger: true
   - get: rhua-image
-    passed: [ ]
+    passed:
+    - manual-trigger
     trigger: true
   - config:
       image_resource:


### PR DESCRIPTION
Updates the RHUI deployment pipeline to ensure that staging (and the rest of the deployment) doesn't start _unless_ the manual trigger button was clicked.