### PR TITLE
Use jsonnet for RHUI pipeline

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -38,7 +38,7 @@ jobs:
   - set_pipeline: container-build
     file: rendered/container-build.json
   - set_pipeline: rhui-release
-    file: rendered/rhui-release.yaml
+    file: rendered/rhui-release.json
   - set_pipeline: artifact-releaser-autopush
     file: guest-test-infra/concourse/pipelines/artifact-releaser-autopush.yaml
   - set_pipeline: partner-image-validations

--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -38,7 +38,7 @@ jobs:
   - set_pipeline: container-build
     file: rendered/container-build.json
   - set_pipeline: rhui-release
-    file: guest-test-infra/concourse/pipelines/rhui-release.yaml
+    file: rendered/rhui-release.yaml
   - set_pipeline: artifact-releaser-autopush
     file: guest-test-infra/concourse/pipelines/artifact-releaser-autopush.yaml
   - set_pipeline: partner-image-validations

--- a/concourse/pipelines/rhui-release.jsonnet
+++ b/concourse/pipelines/rhui-release.jsonnet
@@ -1,0 +1,142 @@
+local project = 'google.com:rhel-infra';
+
+local gatejob = {
+  local job = self,
+
+  name: error 'must set name on gatejob',
+  trigger:: true,
+  passed:: [],
+  plan: [
+    {
+      get: imageResource,
+      trigger: job.trigger,
+      passed: job.passed,
+    }
+    for imageResource in ['cds-image', 'rhua-image']
+  ],
+};
+
+local gcloudmigtask = {
+  local task = self,
+
+  node:: error 'must set node on gcloudmigtask',
+  stage:: 'prod',
+  region:: error 'must set region on gcloudmigtask',
+  action:: error 'must set action on gcloudmigtask',
+
+  task: error 'must set task',
+  config: {
+    image_resource: {
+      source: {
+        repository: 'google/cloud-sdk',
+        tag: 'alpine',
+      },
+      type: 'registry-image',
+    },
+    platform: 'linux',
+    run: {
+      args: [
+        'compute',
+        'instance-groups',
+        'managed',
+      ] + task.action + [
+        '--quiet',
+        '%s-mig-%s-%s' % [task.node, task.stage, task.region],
+        '--region=' + task.region,
+        '--project=' + project,
+      ],
+      path: 'gcloud',
+    },
+  },
+};
+
+local deployjob = gatejob {
+  local job = self,
+
+  stage:: 'prod',
+  region:: error 'must set region on deployjob',
+  plan: super.plan + std.flattenArrays([
+    [
+      gcloudmigtask {
+        task: nodeType + '-start-rolling-update',
+        node: nodeType,
+        stage: job.stage,
+        region: job.region,
+        action: ['rolling-action', 'replace'],
+      },
+      gcloudmigtask {
+        task: nodeType + '-wait-for-version-target',
+        node: nodeType,
+        stage: job.stage,
+        region: job.region,
+        action: ['wait-until', '--version-target-reached'],
+      },
+      gcloudmigtask {
+        task: nodeType + '-wait-for-stable',
+        node: nodeType,
+        stage: job.stage,
+        region: job.region,
+        action: ['wait-until', '--stable'],
+      },
+    ]
+    for nodeType in ['rhua', 'cds']
+  ]),
+};
+
+{
+  resource_types: [
+    {
+      name: 'registry-image-private',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
+    },
+    {
+      name: 'gce-img',
+      type: 'registry-image-private',
+      source: {
+        google_auth: true,
+        repository: 'gcr.io/gcp-guest/gce-img-resource',
+      },
+    },
+  ],
+  resources: [
+    {
+      name: nodeType + '-image',
+      type: 'gce-img',
+      source: {
+        project: project,
+        family: nodeType,
+      },
+    }
+    for nodeType in ['cds', 'rhua']
+  ],
+  jobs: [
+    gatejob {
+      name: 'manual-trigger',
+      trigger: false,
+    },
+    deployjob {
+      name: 'deploy-staging-us-west1',
+      stage: 'staging',
+      region: 'us-west1',
+      passed: ['manual-trigger'],
+    },
+  ] + [
+    deployjob {
+      name: 'deploy-prod-' + region,
+      region: region,
+      passed: ['deploy-staging-us-west1'],
+    }
+    for region in ['europe-west1', 'us-central1']
+  ] + [
+    gatejob {
+      name: 'gate-1',
+      passed: ['deploy-prod-' + region for region in ['europe-west1', 'us-central1']],
+    },
+    deployjob {
+      name: 'deploy-prod-asia-southeast1',
+      region: 'asia-southeast1',
+      passed: ['gate-1'],
+    },
+  ],
+}


### PR DESCRIPTION
This migrates the `rhui-release` pipeline from raw yaml to jsonnet, including the wait-for-stable feature from https://github.com/GoogleCloudPlatform/guest-test-infra/pull/451 .