### PR TITLE
Update container build instructions 

### DIFF
--- a/imagetest/README.md
+++ b/imagetest/README.md
@@ -76,9 +76,9 @@ It is suggested to start by copying an existing test package.
 
 ## Building the container image ##
 
-From the root of this repository:
+From the `imagetest` directory of this repository:
 
-    $ docker build -t cloud-image-tests -f imagetest/Dockerfile .
+    $ docker build -t cloud-image-tests -f Dockerfile .
 
 ## What is being tested ##
 


### PR DESCRIPTION
The container build configurations were changed in https://github.com/GoogleCloudPlatform/guest-test-infra/pull/442. These instructions need to be updated to handle this.