### PR TITLE
Transition ARLE publish tasks to spanner

### DIFF
--- a/concourse/tasks/gcloud-promote-package.yaml
+++ b/concourse/tasks/gcloud-promote-package.yaml
@@ -15,4 +15,4 @@ run:
   args:
   - -exc
   - |
-    gcloud pubsub topics publish $TOPIC --message '{"type": "promote", "request": {"universe": "((universe))", "repo": "((repo))", "environment": "((environment))"}}'
+    gcloud pubsub topics publish $TOPIC --message '{"type": "insertPackage", "request": {"universe": "((universe))", "repo": "((repo))", "environment": "((environment))"}}'

--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -56,7 +56,7 @@ local common = import '../templates/common.libsonnet';
         args: [
           '-exc',
           "wf=$(sed 's/\\\"/\\\\\"/g' ./compute-image-tools/daisy_workflows/build-publish/%s | tr -d '\\n')\n" % task.wf +
-          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"ImagePublish\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\"}}"\n' %
+          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"insertImage\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\"}}"\n' %
           [task.topic, task.image_name, task.gcs_image_path, task.source_version, task.publish_version],
         ],
       },


### PR DESCRIPTION
Changing the message type to reflect the transition to inserting images and packages to the Spanner DB when they are ready to be released.
- Previously for packages the promote message type indicated that the message should wait in the pub/sub queue to be read for release, switching to insertPackage to write package data to DB.
- For images the ImagePublish type also indicated the message should wait in the pub/sub queue. Now insertImage writes image data to DB.