### PR TITLE
Release testing image to arle prod

### DIFF
--- a/concourse/pipelines/artifact-releaser-autopush.yaml
+++ b/concourse/pipelines/artifact-releaser-autopush.yaml
@@ -157,6 +157,21 @@ jobs:
           publish_version: ((.:version))
           source_version: "v20211027"
           release_notes: "Disregard this release. Alma Linux 8 test."
+      - task: publish-prod-debian-11
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: google/cloud-sdk
+              tag: alpine
+          run:
+            path: /bin/sh
+            args:
+            - -exc
+            - |
+              wf="{\"Name\": \"debian-prod-test\", {{$work_project := printf \"%q\" \"gce-image-builder\" -}} {{$endpoint := \`\"https://www.googleapis.com/compute/alpha/projects/\"\` -}} {{$delete_after := \`\"24h*30*6\"\` -}} {{if eq .environment \"prod\" -}} \"WorkProject\": {{$work_project}}, \"PublishProject\": \"bct-prod-images\", \"ComputeEndpoint\": {{$endpoint}}, \"DeleteAfter\": {{$delete_after}}, {{- else -}} \"WorkProject\": {{$work_project}}, \"PublishProject\": {{$work_project}}, \"ComputeEndpoint\": {{$endpoint}}, \"DeleteAfter\": {{$delete_after}}, {{- end}} {{$time := trimPrefix .publish_version \"v\"}} \"Images\": [{ \"Prefix\": \"debian-11-bullseye\", \"Family\": \"debian-11-prod-test\", \"Description\": \"Debian, Debian GNU/Linux, 11 (bullseye), amd64 built on {{$time}}, supports Shielded VM features\", \"Licenses\": [ {{if (or (eq .environment \"staging\") (eq .environment \"oslogin-staging\")) -}} \"projects/bct-staging-functional/global/licenses/debian-11-bullseye\" {{- else -}} \"projects/debian-cloud/global/licenses/debian-11-bullseye\" {{- end}} ], \"GuestOsFeatures\": [\"UEFI_COMPATIBLE\", \"VIRTIO_SCSI_MULTIQUEUE\"]}]}"
+              gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message "{\"type\": \"insertImage\", \"request\": {\"image_name\": \"debian-11-publish-prod-test\", \"gcs_image_path\": \"gs://artifact-releaser-autopush-rtp/debian\", \"image_publish_template\": \"${wf}\", \"source_version\": \"v20220511\", \"publish_version\": \"((.:version))\", \"release_notes\": \"Prod test.\"}}"
 - name: test-workload-identity
   plan:
   - task: show-workload-identity

--- a/concourse/pipelines/artifact-releaser-test.yaml
+++ b/concourse/pipelines/artifact-releaser-test.yaml
@@ -157,21 +157,23 @@ jobs:
           publish_version: ((.:version))
           source_version: "v20211027"
           release_notes: "Disregard this release. Alma Linux 8 test."
-      - task: publish-prod-test
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: google/cloud-sdk
-              tag: alpine
-          run:
-            path: /bin/sh
-            args:
-            - -exc
-            - |
-              wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/test-workflow.json | tr -d '\n')
-              gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message "{\"type\": \"insertImage\", \"request\": {\"image_name\": \"publish-prod-test\", \"gcs_image_path\": \"gs://artifact-releaser-autopush-rtp/publish-prod-test\", \"image_publish_template\": \"${wf}\", \"source_version\": \"v20220511\", \"publish_version\": \"((.:version))\", \"release_notes\": \"Prod test.\"}}"
+- name: release-testing-image-to-artifact-releaser-prod
+  plan:
+  - task: publish-prod-test
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: google/cloud-sdk
+          tag: alpine
+      run:
+        path: /bin/sh
+        args:
+        - -exc
+        - |
+          wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/test-workflow.json | tr -d '\n')
+          gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message "{\"type\": \"insertImage\", \"request\": {\"image_name\": \"publish-prod-test\", \"gcs_image_path\": \"gs://artifact-releaser-autopush-rtp/publish-prod-test\", \"image_publish_template\": \"${wf}\", \"source_version\": \"v20220511\", \"publish_version\": \"((.:version))\", \"release_notes\": \"Prod test.\"}}"
 - name: test-workload-identity
   plan:
   - task: show-workload-identity

--- a/concourse/pipelines/artifact-releaser-test.yaml
+++ b/concourse/pipelines/artifact-releaser-test.yaml
@@ -157,7 +157,7 @@ jobs:
           publish_version: ((.:version))
           source_version: "v20211027"
           release_notes: "Disregard this release. Alma Linux 8 test."
-      - task: publish-prod-debian-11
+      - task: publish-prod-test
         config:
           platform: linux
           image_resource:
@@ -170,8 +170,8 @@ jobs:
             args:
             - -exc
             - |
-              wf="{\"Name\": \"debian-prod-test\", {{$work_project := printf \"%q\" \"gce-image-builder\" -}} {{$endpoint := \`\"https://www.googleapis.com/compute/alpha/projects/\"\` -}} {{$delete_after := \`\"24h*30*6\"\` -}} {{if eq .environment \"prod\" -}} \"WorkProject\": {{$work_project}}, \"PublishProject\": \"bct-prod-images\", \"ComputeEndpoint\": {{$endpoint}}, \"DeleteAfter\": {{$delete_after}}, {{- else -}} \"WorkProject\": {{$work_project}}, \"PublishProject\": {{$work_project}}, \"ComputeEndpoint\": {{$endpoint}}, \"DeleteAfter\": {{$delete_after}}, {{- end}} {{$time := trimPrefix .publish_version \"v\"}} \"Images\": [{ \"Prefix\": \"debian-11-bullseye\", \"Family\": \"debian-11-prod-test\", \"Description\": \"Debian, Debian GNU/Linux, 11 (bullseye), amd64 built on {{$time}}, supports Shielded VM features\", \"Licenses\": [ {{if (or (eq .environment \"staging\") (eq .environment \"oslogin-staging\")) -}} \"projects/bct-staging-functional/global/licenses/debian-11-bullseye\" {{- else -}} \"projects/debian-cloud/global/licenses/debian-11-bullseye\" {{- end}} ], \"GuestOsFeatures\": [\"UEFI_COMPATIBLE\", \"VIRTIO_SCSI_MULTIQUEUE\"]}]}"
-              gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message "{\"type\": \"insertImage\", \"request\": {\"image_name\": \"debian-11-publish-prod-test\", \"gcs_image_path\": \"gs://artifact-releaser-autopush-rtp/debian\", \"image_publish_template\": \"${wf}\", \"source_version\": \"v20220511\", \"publish_version\": \"((.:version))\", \"release_notes\": \"Prod test.\"}}"
+              wf=$(sed 's/\"/\\"/g' ./compute-image-tools/daisy_workflows/build-publish/test-workflow.json | tr -d '\n')
+              gcloud pubsub topics publish "projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod" --message "{\"type\": \"insertImage\", \"request\": {\"image_name\": \"publish-prod-test\", \"gcs_image_path\": \"gs://artifact-releaser-autopush-rtp/publish-prod-test\", \"image_publish_template\": \"${wf}\", \"source_version\": \"v20220511\", \"publish_version\": \"((.:version))\", \"release_notes\": \"Prod test.\"}}"
 - name: test-workload-identity
   plan:
   - task: show-workload-identity


### PR DESCRIPTION
Previously there were no tasks in the ARLE testing pipeline to test an image publish without publishing to a public cloud project.

Now referencing a static debian-11 build we can use this entry to test in production.