### PR TITLE
Missing steps in release-testing-image

### DIFF
--- a/concourse/pipelines/artifact-releaser-test.yaml
+++ b/concourse/pipelines/artifact-releaser-test.yaml
@@ -159,6 +159,14 @@ jobs:
           release_notes: "Disregard this release. Alma Linux 8 test."
 - name: release-testing-image-to-artifact-releaser-prod
   plan:
+  - get: guest-test-infra
+  - get: compute-image-tools
+  - file: guest-test-infra/concourse/tasks/get-credential.yaml
+    task: get-credential
+  - task: generate-version
+    file: guest-test-infra/concourse/tasks/generate-version.yaml
+  - load_var: version
+    file: publish-version/version
   - task: publish-prod-test
     config:
       platform: linux

--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -46,7 +46,7 @@ jobs:
     file: rendered/container-build.json
   - set_pipeline: rhui-release
     file: rendered/rhui-release.json
-  - set_pipeline: artifact-releaser-autopush
-    file: guest-test-infra/concourse/pipelines/artifact-releaser-autopush.yaml
+  - set_pipeline: artifact-releaser-test
+    file: guest-test-infra/concourse/pipelines/artifact-releaser-test.yaml
   - set_pipeline: partner-image-validations
     file: rendered/partner-image-validations.json


### PR DESCRIPTION
Added missing steps for getting necessary repositories, generating credentials, and loading a version.