### PR TITLE
RHUI: Prod currently uses us-east1 only

### DIFF
--- a/concourse/pipelines/rhui-release.jsonnet
+++ b/concourse/pipelines/rhui-release.jsonnet
@@ -151,23 +151,9 @@ local deployjob = {
       passed: ['manual-trigger'],
     },
     deployjob {
-      name: 'deploy-prod-europe-west1',
-      region: 'europe-west1',
+      name: 'deploy-prod-us-east1',
+      region: 'us-east1',
       passed: ['deploy-staging-us-west1'],
-    },
-    deployjob {
-      name: 'deploy-prod-us-central1',
-      region: 'us-central1',
-      passed: ['deploy-staging-us-west1'],
-    },
-    gatejob {
-      name: 'gate-1',
-      passed: ['deploy-prod-europe-west1', 'deploy-prod-us-central1'],
-    },
-    deployjob {
-      name: 'deploy-prod-asia-southeast1',
-      region: 'asia-southeast1',
-      passed: ['gate-1'],
     },
   ],
 }


### PR DESCRIPTION
The TCP proxy is currently randomizing traffic to backends when traffic uses a specific route. While we're working on that issue, we've reduced prod to a single region to avoid clients from seeing inconsistent regional backends.

Here's the pipeline's view in the dev cluster:

![image](https://user-images.githubusercontent.com/575626/169096802-76786939-d596-4e19-8464-8f62edd8ca4e.png)
