### PR TITLE
[arm] use us-central1-a instead of us-west1-a for guest agent image test for spporting ARM

### DIFF
--- a/concourse/tasks/image-test-args.yaml
+++ b/concourse/tasks/image-test-args.yaml
@@ -12,7 +12,7 @@ run:
   path: /manager
   args:
   - -project=gcp-guest
-  - -zone=us-west1-a
+  - -zone=us-central1-a
   - -test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005
   - -images=((images))
   - -exclude=oslogin


### PR DESCRIPTION
use us-central1-a instead of us-west1-a for guest agent image test for spporting ARM

This suppose to be the last change for ARM packages build/publish