### PR TITLE
[guest-agent image test] fix: verify that shut down script executed no less than 80s

### DIFF
--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -46,7 +46,7 @@ func TestShutdownUrlScript(t *testing.T) {
 
 // TestShutdownScriptTime test that shutdown scripts can run for around two minutes
 func TestShutdownScriptTime(t *testing.T) {
-	bytes, err := ioutil.ReadFile(shutdownOutputPath)
+	bytes, err := ioutil.ReadFile("/shutdown.txt")
 	if err != nil {
 		t.Fatalf("error reading file: %v", err)
 	}

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -10,7 +10,8 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
-const shutdownTime = 110 // about 2 minutes
+// The designed shutdown limit is 90s. Let's verify it's executed no less than 80s.
+const shutdownTime = 80
 
 // TestShutdownScript test the standard metadata script.
 func TestShutdownScript(t *testing.T) {
@@ -45,7 +46,7 @@ func TestShutdownUrlScript(t *testing.T) {
 
 // TestShutdownScriptTime test that shutdown scripts can run for around two minutes
 func TestShutdownScriptTime(t *testing.T) {
-	bytes, err := ioutil.ReadFile("/shutdown.txt")
+	bytes, err := ioutil.ReadFile(shutdownOutputPath)
 	if err != nil {
 		t.Fatalf("error reading file: %v", err)
 	}


### PR DESCRIPTION
The actual allowed running time period is 90s, not 120s. So let's set the threshold to 80s other than 110s.