### PR TITLE
Strip the word stable from date

### DIFF
--- a/concourse/tasks/get-last-stable-tag.yaml
+++ b/concourse/tasks/get-last-stable-tag.yaml
@@ -21,6 +21,6 @@ run:
     commit=$(cat repo/.git/refs/tags/stable)
     date=$(cd repo/.git/refs/tags; grep -l $commit stable-2*)
     [[ -z $date ]] && exit 1
-    echo $date | sed 's/\..*//' | tee last-stable-tag/date
+    echo $date | sed 's/\..*//' | sed 's/stable-//' | tee last-stable-tag/date
     echo stable-`date +%Y%m%d` | tee last-stable-tag/stable-today
     echo stable > last-stable-tag/stable


### PR DESCRIPTION
The tag names are of the form 20220110 or stable-20220110. This change makes it so the `stable-` string is stripped before writing to the file.