### PR TITLE
Add linux_test build tags

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -29,10 +29,16 @@ RUN go build -o /out/manager ./cmd/manager/main.go
 RUN cd test_suites; for suite in *; do \
   [[ -d $suite ]] || continue; \
   cd $suite; \
-  go test -c -tags cit || exit 1; \
+  go test -c -tags cit,linux_test || exit 1; \
+  # Check if anything was actually built. If not just continue with the next suite.
+  # This will happen if there's a directory with test files without matching tags.
+  [[ -f "./${suite}.test" ]] || cd ..; \
+  [[ -f "./${suite}.test" ]] || continue; \
+  # Output the test names to a file. This will be used to identify which tests to run.
   ./"${suite}.test" -test.list '.*' > /out/"${suite}_tests.txt" || exit 1; \
   mv "${suite}.test" "/out/${suite}.amd64.test" || exit 1; \
-  GOARCH=arm64 go test -c -tags cit || exit 1; \
+  # Build for arm64
+  GOARCH=arm64 go test -c -tags cit,linux_test || exit 1; \
   mv "${suite}.test" "/out/${suite}.arm64.test" || exit 1; \
   cd ..; \
   done

--- a/imagetest/test_suites/disk/disk_resize_test.go
+++ b/imagetest/test_suites/disk/disk_resize_test.go
@@ -1,5 +1,5 @@
-// +build linux
 // +build cit
+// +build linux_test
 
 package disk
 

--- a/imagetest/test_suites/image_validation/clock_test.go
+++ b/imagetest/test_suites/image_validation/clock_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/license_test.go
+++ b/imagetest/test_suites/image_validation/license_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/linux_license_test.go
+++ b/imagetest/test_suites/image_validation/linux_license_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/package_test.go
+++ b/imagetest/test_suites/image_validation/package_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package imagevalidation
 

--- a/imagetest/test_suites/metadata/metadata_test.go
+++ b/imagetest/test_suites/metadata/metadata_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package metadata
 

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package metadata
 

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package metadata
 

--- a/imagetest/test_suites/network/alias_ip_test.go
+++ b/imagetest/test_suites/network/alias_ip_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package network
 

--- a/imagetest/test_suites/network/dhcp_test.go
+++ b/imagetest/test_suites/network/dhcp_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package network
 

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package network
 

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package network
 

--- a/imagetest/test_suites/oslogin/oslogin_test.go
+++ b/imagetest/test_suites/oslogin/oslogin_test.go
@@ -1,5 +1,5 @@
-//go:build cit
 // +build cit
+// +build linux_test
 
 package oslogin
 

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package security
 

--- a/imagetest/test_suites/ssh/host_key_test.go
+++ b/imagetest/test_suites/ssh/host_key_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package ssh
 

--- a/imagetest/test_suites/ssh/image_ssh_test.go
+++ b/imagetest/test_suites/ssh/image_ssh_test.go
@@ -1,4 +1,5 @@
 // +build cit
+// +build linux_test
 
 package ssh
 


### PR DESCRIPTION
This work is in effort to support Windows tests. In the future we will be able to add a `windows_test` build tag to separate tests that are windows specific from tests that are linux specific. This will also let us share tests that are os agnostic by adding both build tags.