### PR TITLE
add el9_arm64 packagebuild workflow

### DIFF
--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -1,0 +1,42 @@
+{
+  "Name": "el9",
+  "Vars": {
+    "gcs_path": {
+      "Required": true
+    },
+    "repo_owner": {
+      "Required": true
+    },
+    "repo_name": {
+      "Required": true
+    },
+    "git_ref": {
+      "Required": true
+    },
+    "version": {
+      "Required": true
+    },
+    "build_dir": {
+      "Required": true
+    }
+  },
+  "Steps": {
+    "build-package": {
+      "SubWorkflow": {
+        "Path": "./build_package.wf.json",
+        "Vars": {
+          "type": "rpm",
+          "sourceImage": "projects/bct-prod-images/global/images/family/rhel-9-arm64",
+          "gcs_path": "${gcs_path}",
+          "repo_owner": "${repo_owner}",
+          "repo_name": "${repo_name}",
+          "git_ref": "${git_ref}",
+          "build_dir": "${build_dir}",
+          "machine_type": "t2a-standard-2",
+          "zone": "us-central1-a",
+          "version": "${version}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The image doesn't exist yet, but this is a part of the bootstrapping process which enables package builds.