### PR TITLE
correct windows package paths

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -855,31 +855,31 @@ local buildpackageimagetask = {
       uploads: [
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/certgen.x86_64.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/certgen.x86_64.x86_64.((.:package-version)).0@1.goo"}',
           universe: 'cloud-yuck',
           repo: 'certgen',
         },
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-auto-updater.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-auto-updater.noarch.((.:package-version))@1.goo"}',
           universe: 'cloud-yuck',
           repo: 'google-compute-engine-auto-updater',
         },
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-powershell.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-powershell.noarch.((.:package-version))@1.goo"}',
           universe: 'cloud-yuck',
           repo: 'google-compute-engine-powershell',
         },
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-sysprep.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-sysprep.noarch.((.:package-version))@1.goo"}',
           universe: 'cloud-yuck',
           repo: 'google-compute-engine-sysprep',
         },
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-ssh.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/google-compute-engine-ssh.x86_64.((.:package-version)).0@1.goo"}',
           universe: 'cloud-yuck',
           repo: 'google-compute-engine-ssh',
         },


### PR DESCRIPTION
The paths for the windows packages in compute-image-windows are incorrect. Added arch and option `.0` suffix. Real files in bucket right now for comparison:

```
compute-image-windows/certgen.x86_64.20220603.00.0@1.goo
compute-image-windows/google-compute-engine-auto-updater.noarch.20220603.00@1.goo
compute-image-windows/google-compute-engine-powershell.noarch.20220603.00@1.goo
compute-image-windows/google-compute-engine-ssh.x86_64.20220603.00.0@1.goo
compute-image-windows/google-compute-engine-sysprep.noarch.20220603.00@1.goo
```