### PR TITLE
skip secure boot test on arm

### DIFF
--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -38,6 +38,11 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return nil
 	}
 
+	if strings.Contains(t.Image, "arm64") {
+		// secure boot is not supported on ARM images
+		return nil
+	}
+
 	vm3, err := t.CreateTestVM("vm3")
 	if err != nil {
 		return err


### PR DESCRIPTION
Skip secure boot tests on ARM64

Test passes with change:

```xml
2022/06/06 21:44:49 Running in project gce-image-builder zone us-central1-a. Tests will run in projects: [gce-image-builder]
2022/06/06 21:44:49 using -filter image_boot
2022/06/06 21:44:49 Add test workflow for test image_boot on image projects/bct-prod-images/global/images/debian-11-bullseye-arm64-v20220606
2022/06/06 21:44:49 Done with setup
2022/06/06 21:44:50 Storing artifacts and logs in gs://gce-image-builder-cloud-test-outputs/2022-06-06T21:44:50Z
2022/06/06 21:44:50 running test image_boot/debian-11-bullseye-arm64-v20220606 (ID vz0qw) in project gce-image-builder
2022/06/06 21:48:22 finished test image_boot/debian-11-bullseye-arm64-v20220606 (ID vz0qw) in project gce-image-builder
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="3" time="0">
	<testsuite name="image_boot-debian-11-bullseye-arm64-v20220606" tests="3" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="image_boot-debian-11-bullseye-arm64-v20220606" name="TestGuestBoot" time="0"></testcase>
		<testcase classname="image_boot-debian-11-bullseye-arm64-v20220606" name="TestGuestReboot" time="0"></testcase>
		<testcase classname="image_boot-debian-11-bullseye-arm64-v20220606" name="TestGuestRebootOnHost" time="0"></testcase>
	</testsuite>
</testsuites>
```