### PR TITLE
use direct ping library in multinic test

### DIFF
--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	cloud.google.com/go/storage v1.22.0
 	github.com/GoogleCloudPlatform/compute-image-tools/daisy v0.0.0-20220307223029-04ad9f09e70d
+	github.com/go-ping/ping v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/jstemmer/go-junit-report v1.0.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -99,6 +99,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -171,6 +173,7 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -3,10 +3,10 @@
 package network
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+	"github.com/go-ping/ping"
 )
 
 func TestPingVMToVM(t *testing.T) {
@@ -47,11 +47,14 @@ func pingTargetRetries(source, target string) error {
 // pingTarget sends ICMP ping to target from source once a second for 5
 // seconds, expecting 5 responses.
 func pingTarget(source, target string) error {
-	cmd := exec.Command("ping", "-q", "-c", "5", "-I", source, "-w", "5", target)
-	if err := cmd.Run(); err != nil {
+	pinger, err := ping.NewPinger(target)
+	if err != nil {
 		return err
 	}
-	return nil
+	pinger.SetPrivileged(true)
+	pinger.Source = source
+	pinger.Count = 5
+	return pinger.Run()
 }
 
 // dummy test for target VM.


### PR DESCRIPTION
The 'ping' binary is not available on ubuntu minimal images. Replace execution of ping binary with a go native ping implementation.

Tested on ubuntu minimal image:

```xml
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="6" time="0">
	<testsuite name="network-daily-ubuntu-minimal-2204-jammy-v20220603" tests="6" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestDHCP" time="0.01"></testcase>
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestDefaultMTU" time="0"></testcase>
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestPingVMToVM" time="8.11"></testcase>
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestAliases" time="30"></testcase>
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestAliasAfterReboot" time="30"></testcase>
		<testcase classname="network-daily-ubuntu-minimal-2204-jammy-v20220603" name="TestAliasAgentRestart" time="60.15"></testcase>
	</testsuite>
</testsuites>
```