### PR TITLE
remove imagetest-specific OWNERS file

### DIFF
--- a/imagetest/OWNERS
+++ b/imagetest/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - hopkiw
-reviewers:
-  - hopkiw
-  - ericdand
-  - zoran15
-  - ericedens
-  - bkatyl


### PR DESCRIPTION
no longer have a need for this split