### PR TITLE
Follow 8.3 windows file naming and support x86 images

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -25,8 +25,9 @@ ENV GO111MODULE on
 RUN go mod download
 RUN go build -o /out/wrapper.amd64 ./cmd/wrapper/main.go
 RUN GOARCH=arm64 go build -o /out/wrapper.arm64 ./cmd/wrapper/main.go
-RUN GOOS=windows GOARCH=amd64 go build -o /out/wrapper64.exe ./cmd/wrapper/main.go
-RUN GOOS=windows GOARCH=386 go build -o /out/wrapper32.exe ./cmd/wrapper/main.go
+# Setting the windows file names to respect 8.3 file naming.
+RUN GOOS=windows GOARCH=amd64 go build -o /out/wrapp64.exe ./cmd/wrapper/main.go
+RUN GOOS=windows GOARCH=386 go build -o /out/wrapp32.exe ./cmd/wrapper/main.go
 RUN go build -o /out/manager ./cmd/manager/main.go
 RUN cd test_suites; for suite in *; do \
   [[ -d $suite ]] || continue; \

--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -25,7 +25,8 @@ ENV GO111MODULE on
 RUN go mod download
 RUN go build -o /out/wrapper.amd64 ./cmd/wrapper/main.go
 RUN GOARCH=arm64 go build -o /out/wrapper.arm64 ./cmd/wrapper/main.go
-RUN GOOS=windows go build -o /out/wrapper.amd64.exe ./cmd/wrapper/main.go
+RUN GOOS=windows GOARCH=amd64 go build -o /out/wrapper64.exe ./cmd/wrapper/main.go
+RUN GOOS=windows GOARCH=386 go build -o /out/wrapper32.exe ./cmd/wrapper/main.go
 RUN go build -o /out/manager ./cmd/manager/main.go
 RUN cd test_suites; for suite in *; do \
   [[ -d $suite ]] || continue; \
@@ -35,9 +36,13 @@ RUN cd test_suites; for suite in *; do \
   mv "${suite}.test" "/out/${suite}.amd64.test" || exit 1; \
   GOARCH=arm64 go test -c -tags cit || exit 1; \
   mv "${suite}.test" "/out/${suite}.arm64.test" || exit 1; \
-  GOOS=windows go test -c -tags cit || exit 1; \
+  GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1; \
   if [ -f "${suite}.test.exe" ]; then \
-    mv "${suite}.test.exe" "/out/${suite}.amd64.test.exe" || exit 1; \
+    mv "${suite}.test.exe" "/out/${suite}64.exe" || exit 1; \
+  fi; \
+  GOOS=windows GOARCH=386 go test -c -tags cit || exit 1; \
+  if [ -f "${suite}.test.exe" ]; then \
+    mv "${suite}.test.exe" "/out/${suite}32.exe" || exit 1; \
   fi; \
   cd ..; \
   done

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -35,7 +35,7 @@ var (
 )
 
 const (
-	testWrapperPath = "/wrapper"
+	testWrapperPath        = "/wrapper"
 	testWrapperPathWindows = "/wrapp"
 )
 
@@ -285,9 +285,9 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 		}
 
 		if strings.Contains(twf.Image, "windows") {
-			arch_bits := "64"
+			archBits := "64"
 			if strings.Contains(twf.Image, "x86") {
-				arch_bits = "32"
+				archBits = "32"
 			}
 			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, arch_bits)
 			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPathWindows, arch_bits)

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -283,12 +283,17 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 			}
 		}
 
-		var suffix string
 		if strings.Contains(twf.Image, "windows") {
-			suffix = ".exe"
+			arch_bits := "64"
+			if strings.Contains(twf.Image, "x86") {
+				arch_bits = "32"
+			}
+			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, arch_bits)
+			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPath, arch_bits)
+		} else {
+			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s.%s.test", twf.Name, arch)
+			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s.%s", testWrapperPath, arch)
 		}
-		twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s.%s.test%s", twf.Name, arch, suffix)
-		twf.wf.Sources[fmt.Sprintf("wrapper%s", suffix)] = fmt.Sprintf("%s.%s%s", testWrapperPath, arch, suffix)
 
 		// add a final copy-objects step which copies the daisy-outs-path directory to twf.gcsPath + /outs
 		copyGCSObject := daisy.CopyGCSObject{}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -36,6 +36,7 @@ var (
 
 const (
 	testWrapperPath = "/wrapper"
+	testWrapperPathWindows = "/wrapp"
 )
 
 // TestWorkflow defines a test workflow which creates at least one test VM.
@@ -289,7 +290,7 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 				arch_bits = "32"
 			}
 			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, arch_bits)
-			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPath, arch_bits)
+			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPathWindows, arch_bits)
 		} else {
 			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s.%s.test", twf.Name, arch)
 			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s.%s", testWrapperPath, arch)

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -289,8 +289,8 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 			if strings.Contains(twf.Image, "x86") {
 				archBits = "32"
 			}
-			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, arch_bits)
-			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPathWindows, arch_bits)
+			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, archBits)
+			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPathWindows, archBits)
 		} else {
 			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s.%s.test", twf.Name, arch)
 			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s.%s", testWrapperPath, arch)


### PR DESCRIPTION
Follow 8.3 file naming for windows executables and also support x86 windows images.

Follow up to comments in previous PR https://github.com/GoogleCloudPlatform/guest-test-infra/pull/478#discussion_r892711947

```
2022/06/09 19:02:01 finished test image_boot/debian-10 (ID yplvh) in project pneil-sandbox
2022/06/09 19:04:50 finished test image_boot/windows-w-new-metadata-scripts (ID 4z26w) in project pneil-sandbox
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="10" time="0">
        <testsuite name="image_boot-debian-10" tests="5" failures="0" errors="0" disabled="0" skipped="0" time="0">
                <testcase classname="image_boot-debian-10" name="TestGuestBoot" time="0"></testcase>
                <testcase classname="image_boot-debian-10" name="TestGuestReboot" time="0"></testcase>
                <testcase classname="image_boot-debian-10" name="TestGuestRebootOnHost" time="0"></testcase>
                <testcase classname="image_boot-debian-10" name="TestGuestSecureBoot" time="0"></testcase>
                <testcase classname="image_boot-debian-10" name="TestBootTime" time="0"></testcase>
        </testsuite>
        <testsuite name="image_boot-windows-w-new-metadata-scripts" tests="5" failures="0" errors="0" disabled="0" skipped="0" time="0">
                <testcase classname="image_boot-windows-w-new-metadata-scripts" name="TestGuestBoot" time="0"></testcase>
                <testcase classname="image_boot-windows-w-new-metadata-scripts" name="TestGuestReboot" time="0"></testcase>
                <testcase classname="image_boot-windows-w-new-metadata-scripts" name="TestGuestRebootOnHost" time="0"></testcase>
                <testcase classname="image_boot-windows-w-new-metadata-scripts" name="TestGuestSecureBoot" time="19.67"></testcase>
                <testcase classname="image_boot-windows-w-new-metadata-scripts" name="TestBootTime" time="0.01"></testcase>
        </testsuite>
</testsuites>
```