### PR TITLE
[new golang build policy] upgrade presubmit golang version to 1.16

### DIFF
--- a/container_images/gobuild/Dockerfile
+++ b/container_images/gobuild/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13
+FROM golang:1.16
 
 RUN apt-get update && apt-get install -y git && \
     rm -rf /var/cache/apt/archives

--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -37,7 +37,7 @@ function install_go() {
     arch="arm64"
   fi
 
-  local GOLANG="go1.13.9.linux-${arch}.tar.gz"
+  local GOLANG="go1.16.15.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 

--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -37,7 +37,7 @@ function install_go() {
     arch="arm64"
   fi
 
-  local GOLANG="go1.16.15.linux-${arch}.tar.gz"
+  local GOLANG="go1.18.3.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
It's a part of the new packages policy. Upgrading the presubmit gobuild version to 1.16 to ensure the compatibility to 1.16 for partners.
Also upgrade version of built-by-google packages to 1.18.3 to ensure google use the latest compiler.