### PR TITLE
RHUI release: Require manual trigger

### DIFF
--- a/concourse/pipelines/rhui-release.jsonnet
+++ b/concourse/pipelines/rhui-release.jsonnet
@@ -143,6 +143,7 @@ local deployjob = {
   jobs: [
     gatejob {
       name: 'manual-trigger',
+      trigger: false,
     },
     deployjob {
       name: 'deploy-staging-us-west1',


### PR DESCRIPTION
This updates the `manual-trigger` step to require a manual click for releasing the image.