### PR TITLE
RHUI release: Prod is us-central1

### DIFF
--- a/concourse/pipelines/rhui-release.jsonnet
+++ b/concourse/pipelines/rhui-release.jsonnet
@@ -151,8 +151,8 @@ local deployjob = {
       passed: ['manual-trigger'],
     },
     deployjob {
-      name: 'deploy-prod-us-east1',
-      region: 'us-east1',
+      name: 'deploy-prod-us-central1',
+      region: 'us-central1',
       passed: ['deploy-staging-us-west1'],
     },
   ],


### PR DESCRIPTION
This fixes a mistake from https://github.com/GoogleCloudPlatform/guest-test-infra/pull/467 ; the prod region for RHUIv4 is us-central1, not us-east1.