### PR TITLE
support aussie licenses

### DIFF
--- a/imagetest/test_suites/image_validation/license_test.go
+++ b/imagetest/test_suites/image_validation/license_test.go
@@ -1,3 +1,4 @@
+//go:build cit
 // +build cit
 
 package imagevalidation
@@ -131,7 +132,7 @@ var licenses = []string{
 }
 
 const (
-	licenseNameRegex = `(?i)(((License|Copyright)\s*:\s*%[1]s)|((covered )?under (the )?%[1]s)|(under (the terms of )?the %[1]s))`
+	licenseNameRegex = `(?i)(((Licen[sc]e|Copyright)\s*:\s*%[1]s)|((covered )?under (the )?%[1]s)|(under (the terms of )?the %[1]s))`
 )
 
 var licenseGlobs = []string{


### PR DESCRIPTION
There's a package `libcanberra0` installed on ubuntu images by default that appears to fail the license test because it is spelled 'licence'. Amend the regex to support this spelling.

```xml
<testsuites name="" errors="0" failures="0" disabled="0" skipped="2" tests="9" time="0">
	<testsuite name="image_validation-daily-ubuntu-pro-2004-focal-v20220615" tests="9" failures="0" errors="0" disabled="0" skipped="2" time="0">
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestNTPService" time="0.01"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestHostname" time="0"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestFQDN" time="0.01"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestHostKeysGeneratedOnce" time="0.16"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestHostsFile" time="0">
			<skipped message="    image_validation_test.go:190: Not supported on Ubuntu"></skipped>
		</testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestArePackagesLegal" time="13.72"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestStandardPrograms" time="7.24"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestGuestPackages" time="0.04"></testcase>
		<testcase classname="image_validation-daily-ubuntu-pro-2004-focal-v20220615" name="TestCustomHostname" time="0">
			<skipped message="    image_validation_test.go:57: Custom hostnames not supported on Ubuntu"></skipped>
		</testcase>
	</testsuite>
</testsuites>
```