### PR TITLE
Add windows Client 8 and 10 to Concourse Windows pipeline

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -590,7 +590,11 @@ local ImgGroup(name, images, environments) = {
         [
           ImgPublishJob(image, env, 'windows', 'windows-uefi') {passed:'publish-to-staging-' + image}
           for image in windows_client_images
-          for env in client_envs
+          for env in ['testing', 'staging']
+        ] +
+        [
+          ImgPublishJob(image, 'internal'', 'windows', 'windows-uefi') {passed:'publish-to-staging-' + image}
+          for image in windows_client_images
         ] +
         [
           ImgPublishJob(image, env, 'windows', 'windows-uefi')

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -328,14 +328,8 @@ local imgpublishjob = {
         else if job.env == 'internal' then
           'publish-to-prod-' + job.image,
       ],
-      // Auto-publish to testing after build. Auto-publish to prod (still gated by ARLE) and internal after staging publish.
-      trigger: if job.env == 'testing' then
-        true
-      else if job.env == 'prod' then
-        true
-      else if job.env == 'internal' then
-        true
-      else false,
+      // Builds are automatically pushed to testing. Triggering staging will automatically progress to prod and internal.
+      trigger: if job.env == 'staging' then false else true,
     },
     {
       load_var: 'source-version',
@@ -524,8 +518,8 @@ local ImgGroup(name, images, environments) = {
   jobs: [
           // Windows builds
 
-          ImgBuildJob('windows-client-81, 'win-81-64', 'windows_gcs_updates_client81-64'),
-          ImgBuildJob('windows-client-10-21h2, 'win10-21h2-64', 'windows_gcs_updates_client10-21h2-64'),
+          ImgBuildJob('windows-client-81', 'win-81-64', 'windows_gcs_updates_client81-64'),
+          ImgBuildJob('windows-client-10-21h2', 'win10-21h2-64', 'windows_gcs_updates_client10-21h2-64'),
           ImgBuildJob('windows-server-2022-dc', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-2022-dc-core', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-20h2-dc-core', 'winserver-20h2-64', 'windows_gcs_updates_sac20h2'),

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -510,7 +510,7 @@ local ImgGroup(name, images, environments) = {
              ] +
              [
                common.GcsImgResource(image, 'windows-uefi')
-               for image in windows_images + container_images
+               for image in windows_client_images + windows_server_images + container_images
              ] +
              [
                common.GcsImgResource(image, 'sqlserver-uefi')

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -322,13 +322,19 @@ local imgpublishjob = {
           'build-' + job.image
         else if job.env == 'staging' then
           'publish-to-testing-' + job.image
-        else if job.env == 'internal' then
-          'publish-to-prod-' + job.image
         else if job.env == 'prod' then
-          'publish-to-staging-' + job.image,
+          'publish-to-staging-' + job.image
+        else if job.env == 'internal' then
+          'publish-to-prod-' + job.image,
       ],
-      // Auto-publish to testing after build. Auto-publish to internal after staging publish
-      trigger: if job.env == 'testing' || job.env == 'internal' then true else false,
+      // Auto-publish to testing after build. Auto-publish to prod (still gated by ARLE) and internal after staging publish.
+      trigger: if job.env == 'testing' then
+        true
+      else if job.env == 'prod' then
+        true
+      else if job.env == 'internal' then
+        true
+      else false,
     },
     {
       load_var: 'source-version',

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -487,8 +487,8 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2019-dc-core-for-containers',
   ],
 
-  local windows_images = windows_2012_images + windows_2016_images + windows_2019_images
-                         + windows_20h2_images + windows_2022_images,
+  local windows_images = windows_81_images + windows_10_images + windows_2012_images + windows_2016_images
+                         + windows_2019_images + windows_20h2_images + windows_2022_images,
   local sql_images = sql_2012_images + sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images,
 
   resource_types: [

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -4,6 +4,7 @@ local common = import '../templates/common.libsonnet';
 local daisy = import '../templates/daisy.libsonnet';
 local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
 
+local client_envs = ['testing', 'staging', 'internal']
 local server_envs = ['testing', 'staging', 'internal', 'prod'];
 local sql_envs = ['testing', 'staging', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');
@@ -418,6 +419,12 @@ local ImgGroup(name, images, environments) = {
 
 // Start of output.
 {
+  local windows_81_images = [
+    'windows-client-81',
+  ]
+  local windows_10_images = [
+    'windows-client-10-21h2',
+  ]
   local windows_2012_images = [
     'windows-server-2012-r2-dc',
     'windows-server-2012-r2-dc-core',
@@ -517,6 +524,8 @@ local ImgGroup(name, images, environments) = {
   jobs: [
           // Windows builds
 
+          ImgBuildJob('windows-client-81, 'win-81-64', 'windows_gcs_updates_client81-64'),
+          ImgBuildJob('windows-client-10-21h2, 'win10-21h2-64', 'windows_gcs_updates_client10-21h2-64'),
           ImgBuildJob('windows-server-2022-dc', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-2022-dc-core', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-20h2-dc-core', 'winserver-20h2-64', 'windows_gcs_updates_sac20h2'),
@@ -599,6 +608,8 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
+    ImgGroup('windows-81', windows_81_images, client_envs),
+    ImgGroup('windows-10', windows_10_images, client_envs),
     ImgGroup('windows-2012', windows_2012_images, server_envs),
     ImgGroup('windows-2016', windows_2016_images, server_envs),
     ImgGroup('windows-2019', windows_2019_images, server_envs),

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -4,7 +4,7 @@ local common = import '../templates/common.libsonnet';
 local daisy = import '../templates/daisy.libsonnet';
 local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
 
-local client_envs = ['testing', 'staging', 'internal']
+local client_envs = ['testing', 'staging', 'internal'];
 local server_envs = ['testing', 'staging', 'internal', 'prod'];
 local sql_envs = ['testing', 'staging', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -415,10 +415,10 @@ local ImgGroup(name, images, environments) = {
 {
   local windows_81_images = [
     'windows-client-81',
-  ]
+  ],
   local windows_10_images = [
     'windows-client-10-21h2',
-  ]
+  ],
   local windows_2012_images = [
     'windows-server-2012-r2-dc',
     'windows-server-2012-r2-dc-core',

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -593,7 +593,7 @@ local ImgGroup(name, images, environments) = {
           for env in ['testing', 'staging']
         ] +
         [
-          ImgPublishJob(image, 'internal'', 'windows', 'windows-uefi') {passed:'publish-to-staging-' + image}
+          ImgPublishJob(image, 'internal', 'windows', 'windows-uefi') {passed:'publish-to-staging-' + image}
           for image in windows_client_images
         ] +
         [

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -487,8 +487,9 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2019-dc-core-for-containers',
   ],
 
-  local windows_images = windows_81_images + windows_10_images + windows_2012_images + windows_2016_images
-                         + windows_2019_images + windows_20h2_images + windows_2022_images,
+  local windows_client_images = windows_81_images + windows_10_images,
+  local windows_server_images = windows_2012_images + windows_2016_images + windows_2019_images
+                         + windows_20h2_images + windows_2022_images,
   local sql_images = sql_2012_images + sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images,
 
   resource_types: [
@@ -587,7 +588,12 @@ local ImgGroup(name, images, environments) = {
 
         [
           ImgPublishJob(image, env, 'windows', 'windows-uefi')
-          for image in windows_images
+          for image in windows_client_images
+          for env in client_envs
+        ] +
+        [
+          ImgPublishJob(image, env, 'windows', 'windows-uefi')
+          for image in windows_server_images
           for env in server_envs
         ] +
         [

--- a/container_images/daisy-builder/main.sh
+++ b/container_images/daisy-builder/main.sh
@@ -55,10 +55,12 @@ function generate_build_workflow() {
   "Steps": {'
 
   for distro in ${DISTROS//,/ }; do
+    distrodash=$(echo "$distro" | tr '_' '-')
     if [[ "$config" =~ IncludeWorkflow ]]; then
+      # Append additional steps
       config="${config},"
     fi
-    config="${config}\n"'    "'"$distro"'": {
+    config="${config}\n"'    "'"$distrodash"'": {
       "IncludeWorkflow": {
         "Path": "./workflows/build_'"$distro"'.wf.json",
         "Vars": {


### PR DESCRIPTION
This enables Concourse to build Windows 8.1 and 10 Version 21h2 for internal testing only.