### PR TITLE
add derivative image builds for oslogin

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -600,6 +600,144 @@ local buildpackageimagetask = {
       package: 'guest-oslogin',
       builds: ['deb10', 'deb11', 'deb11-arm64', 'el7', 'el8', 'el8-arm64', 'el9', 'el9-arm64'],
       gcs_dir: 'oslogin',
+      extra_tasks: [
+        {
+          task: 'generate-build-id',
+          config: {
+            platform: 'linux',
+            image_resource: {
+              type: 'registry-image',
+              source: { repository: 'busybox' },
+            },
+            outputs: [{ name: 'build-id-dir' }],
+            run: {
+              path: 'sh',
+              args: [
+                '-exc',
+                'buildid=$(date "+%s"); echo $buildid | tee build-id-dir/build-id',
+              ],
+            },
+          },
+        },
+        { load_var: 'build-id', file: 'build-id-dir/build-id' },
+        { get: 'compute-image-tools' },
+        {
+          in_parallel: {
+            fail_fast: true,
+            steps: [
+              buildpackageimagetask {
+                image_name: 'debian-10',
+                source_image: 'projects/debian-cloud/global/images/family/debian-10',
+                dest_image: 'debian-10-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1_amd64.deb',
+              },
+              buildpackageimagetask {
+                image_name: 'debian-11',
+                source_image: 'projects/debian-cloud/global/images/family/debian-11',
+                dest_image: 'debian-11-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1_amd64.deb',
+              },
+              buildpackageimagetask {
+                image_name: 'debian-11-arm64',
+                source_image: 'projects/debian-cloud/global/images/family/debian-11-arm64',
+                dest_image: 'debian-11-arm64-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1_arm64.deb',
+                machine_type: 't2a-standard-2',
+                worker_image: 'projects/compute-image-tools/global/images/family/debian-11-worker-arm64',
+              },
+              buildpackageimagetask {
+                image_name: 'centos-7',
+                source_image: 'projects/centos-cloud/global/images/family/centos-7',
+                dest_image: 'centos-7-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el7.x86_64.rpm',
+              },
+              buildpackageimagetask {
+                image_name: 'rhel-7',
+                source_image: 'projects/rhel-cloud/global/images/family/rhel-7',
+                dest_image: 'rhel-7-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el7.x86_64.rpm',
+              },
+              buildpackageimagetask {
+                image_name: 'rhel-8',
+                source_image: 'projects/rhel-cloud/global/images/family/rhel-8',
+                dest_image: 'rhel-8-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el8.x86_64.rpm',
+              },
+              buildpackageimagetask {
+                image_name: 'rocky-linux-8-optimized-gcp-arm64',
+                source_image: 'projects/bct-prod-images/global/images/family/rocky-linux-8-optimized-gcp-arm64',
+                dest_image: 'rocky-linux-8-optimized-gcp-arm64-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el8.aarch64.rpm',
+                machine_type: 't2a-standard-2',
+                worker_image: 'projects/compute-image-tools/global/images/family/debian-11-worker-arm64',
+              },
+              buildpackageimagetask {
+                image_name: 'rhel-9',
+                source_image: 'projects/rhel-cloud/global/images/family/rhel-9',
+                dest_image: 'rhel-9-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el9.x86_64.rpm',
+              },
+              buildpackageimagetask {
+                image_name: 'rhel-9-arm64',
+                source_image: 'projects/rhel-cloud/global/images/family/rhel-9-arm64',
+                dest_image: 'rhel-9-arm64-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el9.aarch64.rpm',
+                machine_type: 't2a-standard-2',
+                worker_image: 'projects/compute-image-tools/global/images/family/debian-11-worker-arm64',
+              },
+            ],
+          },
+        },
+        {
+          in_parallel: {
+            fail_fast: true,
+            steps: [
+              {
+                task: 'oslogin-image-tests-amd64',
+                config: {
+                  platform: 'linux',
+                  image_resource: {
+                    type: 'registry-image',
+                    source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
+                  },
+                  run: {
+                    path: '/manager',
+                    args: [
+                      '-project=gcp-guest',
+                      '-zone=us-central1-a',
+                      '-test_projects=oslogin-testing-project',
+                      '-images=projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id))',
+                      '-filter=oslogin',
+                    ],
+                  },
+                },
+              },
+              {
+                task: 'oslogin-image-tests-arm64',
+                config: {
+                  platform: 'linux',
+                  image_resource: {
+                    type: 'registry-image',
+                    source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
+                  },
+                  inputs: [{ name: 'guest-test-infra' }],
+                  run: {
+                    path: '/manager',
+                    args: [
+                      '-project=gcp-guest',
+                      '-zone=us-central1-a',
+                      '-test_projects=oslogin-testing-project',
+                      '-images=projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
+                      '-machine_type=t2a-standard-2',
+                      '-filter=oslogin',
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
       uploads: [
         uploadpackagetask {
           package_paths: '{"bucket":"gcp-guest-package-uploads","object":"oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb10_amd64.deb"}',


### PR DESCRIPTION
add the same kind of derivative image build and test steps as we have in guest agent build. 