### PR TITLE
only build diagnostics when changed

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1070,7 +1070,7 @@ local buildpackageimagetask = {
           repo: 'google-compute-engine-diagnostics',
         },
       ],
-      build_dir: 'cli_tools/diagnostics'
+      build_dir: 'cli_tools/diagnostics',
     },
     promotepackagejob {
       package: 'compute-image-tools',
@@ -1226,6 +1226,7 @@ local buildpackageimagetask = {
         uri: 'https://github.com/GoogleCloudPlatform/compute-image-tools.git',
         branch: 'master',
         fetch_tags: true,
+        paths: ['cli_tools/diagnostics/**'],
       },
     },
     {


### PR DESCRIPTION
currently the diagnostics build is triggered by any new commits to compute-image-tools. this is a shared repo, resulting in many unnecessary builds. change the resource to only trigger to changes in the diagnostics dir.