### PR TITLE
Add SQL Server 2022 Preview to Windows pipeline

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -803,7 +803,7 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),
-    ImgGroup('sql-2022', sql_2022_images, prev_envs),
+    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', ['testing', 'staging']),
     ImgGroup('container-2019', container_images, server_envs),
     ImgGroup('windows-install-media', windows_install_media_images, windows_install_media_envs),
   ],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -208,11 +208,11 @@ local sqlimgbuildjob = {
       file: 'gcp-secret-manager/' + job.sql_version,
     },
     {
-      task: 'get-secret-windows-gcs-ssms-exe',
+      task: 'get-secret-ssms-version',
       config: gcp_secret_manager.getsecrettask { secret_name: job.ssms_version },
     },
     {
-      load_var: 'windows-gcs-ssms-exe',
+      load_var: 'ssms-version',
       file: 'gcp-secret-manager/windows_gcs_ssms_exe',
     },
     {
@@ -223,7 +223,7 @@ local sqlimgbuildjob = {
         vars+: [
           'source_image_project=bct-prod-images',
           'sql_server_media=((.:sql-server-media))',
-          'ssms_exe=((.:ssms_version))',
+          'ssms_exe=((.:ssms-version))',
           'timeout=4h',
         ],
       },

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -7,7 +7,6 @@ local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
 local client_envs = ['testing', 'staging', 'internal'];
 local server_envs = ['testing', 'staging', 'internal', 'prod'];
 local sql_envs = ['testing', 'staging', 'prod'];
-local prev_envs = ['testing', 'staging'];
 local windows_install_media_envs = ['testing', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');
 
@@ -777,8 +776,10 @@ local ImgGroup(name, images, environments) = {
         ] +
         //Publish job for SQL Preview build. Will be rolled into sql_images on formal release.
         [
-          ImgPublishJob('sql-2022-preview-windows-2022-dc', env, 'sqlserver', 'sqlserver-uefi')
-          for env in prev_envs
+          ImgPublishJob('sql-2022-preview-windows-2022-dc', 'testing', 'sqlserver', 'sqlserver-uefi')
+        ] +
+        [
+          ImgPublishJob('sql-2022-preview-windows-2022-dc', 'staging', 'sqlserver', 'sqlserver-uefi')
         ] +
         [
           ImgPublishJob(image, env, 'windows_container', 'windows-uefi')
@@ -804,7 +805,8 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),
-    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', prev_envs),
+    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', 'testing'),
+    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', 'staging'),
     ImgGroup('container-2019', container_images, server_envs),
     ImgGroup('windows-install-media', windows_install_media_images, windows_install_media_envs),
   ],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -213,7 +213,7 @@ local sqlimgbuildjob = {
     },
     {
       load_var: 'ssms-version',
-      file: 'gcp-secret-manager/windows_gcs_ssms_exe',
+      file: 'gcp-secret-manager/' + job.ssms_version,
     },
     {
       task: 'daisy-build',

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -7,6 +7,7 @@ local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
 local client_envs = ['testing', 'staging', 'internal'];
 local server_envs = ['testing', 'staging', 'internal', 'prod'];
 local sql_envs = ['testing', 'staging', 'prod'];
+local prev_envs = ['testing', 'staging'];
 local windows_install_media_envs = ['testing', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');
 
@@ -777,7 +778,7 @@ local ImgGroup(name, images, environments) = {
         //Publish job for SQL Preview build. Will be rolled into sql_images on formal release.
         [
           ImgPublishJob('sql-2022-preview-windows-2022-dc', env, 'sqlserver', 'sqlserver-uefi')
-          for env in ['testing', 'staging']
+          for env in prev_envs
         ] +
         [
           ImgPublishJob(image, env, 'windows_container', 'windows-uefi')
@@ -803,7 +804,7 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),
-    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', ['testing', 'staging']),
+    ImgGroup('sql-2022', 'sql-2022-preview-windows-2022-dc', prev_envs),
     ImgGroup('container-2019', container_images, server_envs),
     ImgGroup('windows-install-media', windows_install_media_images, windows_install_media_envs),
   ],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -509,7 +509,7 @@ local SQLImgBuildJob(image, base_image, sql_version, ssms_version) = sqlimgbuild
   image: image,
   base_image: base_image,
   sql_version: sql_version,
-  ssms_verion: ssms_version,
+  ssms_version: ssms_version,
 
   workflow: 'sqlserver/%s.wf.json' % image,
 };


### PR DESCRIPTION
Adds derivative build for SQL 2022 running on Windows Server 2022. Also had to add support for passing in SSMS version, as Microsoft moved away from a universal installer. We may need to pass different versions going forward.