### PR TITLE
Enable testing of Ubuntu 22.10 (Kinetic Kudu) images

### DIFF
--- a/concourse/pipelines/partner-image-validations.jsonnet
+++ b/concourse/pipelines/partner-image-validations.jsonnet
@@ -266,17 +266,15 @@ local imagevalidationjob = {
 };
 
 local ubuntudevelimages = [
-  'ubuntu-minimal-2204-lts',
   'ubuntu-1604-lts',
   'ubuntu-1804-lts',
   'ubuntu-2004-lts',
-  'ubuntu-2110',
   'ubuntu-2204-lts',
   'ubuntu-2210-amd64',
   'ubuntu-minimal-1604-lts',
   'ubuntu-minimal-1804-lts',
   'ubuntu-minimal-2004-lts',
-  'ubuntu-minimal-2110',
+  'ubuntu-minimal-2204-lts',
   'ubuntu-minimal-2210-amd64',
 ];
 

--- a/concourse/pipelines/partner-image-validations.jsonnet
+++ b/concourse/pipelines/partner-image-validations.jsonnet
@@ -272,10 +272,12 @@ local ubuntudevelimages = [
   'ubuntu-2004-lts',
   'ubuntu-2110',
   'ubuntu-2204-lts',
+  'ubuntu-2210-amd64',
   'ubuntu-minimal-1604-lts',
   'ubuntu-minimal-1804-lts',
   'ubuntu-minimal-2004-lts',
   'ubuntu-minimal-2110',
+  'ubuntu-minimal-2210-amd64',
 ];
 
 local ubuntuproposedimages = [


### PR DESCRIPTION
Currently 22.10 images aren't being tested.

```
$ gcloud compute images list --no-standard-images --project ubuntu-os-cloud-devel --filter 'family~2210-amd64'
NAME                                               PROJECT                FAMILY                     DEPRECATED  STATUS
daily-ubuntu-2210-kinetic-amd64-v20220828          ubuntu-os-cloud-devel  ubuntu-2210-amd64                      READY
daily-ubuntu-minimal-2210-kinetic-amd64-v20220909  ubuntu-os-cloud-devel  ubuntu-minimal-2210-amd64              READY
```