### PR TITLE
Added support for Alma Linux boot test

### DIFF
--- a/imagetest/test_suites/image_boot/image_boot_test.go
+++ b/imagetest/test_suites/image_boot/image_boot_test.go
@@ -19,6 +19,7 @@ import (
 
 // The values have been decided based on running spot tests for different images.
 var imageFamilyBootTimeThresholdMap = map[string]int{
+	"almalinux":   60,
 	"centos":      60,
 	"debian":      50,
 	"rhel":        60,
@@ -194,6 +195,8 @@ func TestBootTime(t *testing.T) {
 	var maxThreshold int
 
 	switch {
+	case strings.Contains(image, "almalinux"):
+		maxThreshold = imageFamilyBootTimeThresholdMap["almalinux"]
 	case strings.Contains(image, "centos"):
 		maxThreshold = imageFamilyBootTimeThresholdMap["centos"]
 	case strings.Contains(image, "debian"):

--- a/imagetest/test_suites/image_boot/setup.go
+++ b/imagetest/test_suites/image_boot/setup.go
@@ -33,11 +33,6 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return nil
 	}
 
-	if strings.Contains(t.Image, "rocky-linux-8") {
-		// secure boot is not supported on Rocky Linux
-		return nil
-	}
-
 	if strings.Contains(t.Image, "arm64") {
 		// secure boot is not supported on ARM images
 		return nil


### PR DESCRIPTION
Added support for Alma Linux boot test and removed rocky-linux-8 secure boot test skip condition as it is supported.