### PR TITLE
Reworking publishing logic for Windows Client + Server

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -672,7 +672,7 @@ local ImgGroup(name, images, environments) = {
              ] +
              [
                common.GcsImgResource(image, 'windows-uefi')
-               for image in windows_images + windows_images + container_images
+               for image in windows_images + container_images
              ] +
              [
                common.GcsImgResource(image, 'sqlserver-uefi')


### PR DESCRIPTION
* Merge environments for client + server as these can now be shared due to the addition of "prod" to client builds
* Remove extraneous logic for client builds as the special logic is no longer required with the addition of "prod" environment
* Consolidate client_envs, server_envs, client_images, and server_images into windows_envs and windows_images since these are now identical
* Consolidate build and publish jobs to reflect the above changes


NOTE: This should not be merged until the respective publish files are updated. PR to follow shortly; opening this now for review purposes.