### PR TITLE
Add success/failure metrics to imgpublishjob

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -458,6 +458,24 @@ local imgpublishjob = {
 
   // Start of job.
   name: 'publish-to-%s-%s' % [job.env, job.image],
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
   plan: [
     { get: 'guest-test-infra' },
     { get: 'compute-image-tools' },


### PR DESCRIPTION
Allows us to track success/fail metrics for image publish jobs in Windows builds