### PR TITLE
use guest attributes in packagebuild

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+guest_attr_url=http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/daisy/DaisyResult
+
+function put_guest_attr() {
+  curl -H "Metadata-Flavor: Google" -X PUT --data "$1" "$guest_attr_url"
+}
+
 function build_success() {
+  put_guest_attr "Success"
   echo "Build succeeded: $@"
   exit 0
 }
 
 function build_fail() {
+  put_guest_attr "Failure"
   echo "Build failed: $@"
   exit 1
 }

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -58,6 +58,9 @@
             "repo-name": "${repo_name}",
             "git-ref": "${git_ref}",
             "build-dir": "${build_dir}",
+            "enable-guest-attributes": "TRUE",
+            "block-project-ssh-keys": "TRUE",
+            "enable-oslogin": "FALSE",
             "version": "${version}"
           },
           "machineType": "${machine_type}",
@@ -73,11 +76,7 @@
       "WaitForInstancesSignal": [
         {
           "Name": "inst-build-pkg",
-          "SerialOutput": {
-            "Port": 1,
-            "SuccessMatch": "Build succeeded",
-            "FailureMatch": "Build failed"
-          }
+          "GuestAttribute": { }
         }
       ]
     },


### PR DESCRIPTION
Using serial console scraping is unreliable. Move package builds to use the new guest attributes feature in Daisy.

* Replace SerialOutput with GuestAttribute in common workflow, using default values
* Update common.sh to emit attributes in success and fail conditions
* Set sanity keys `enable-oslogin=FALSE` and `block-project-ssh-keys=TRUE`