### PR TITLE
Generate timestamp and load into var for image publish.

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -480,6 +480,14 @@ local imgpublishjob = {
     { get: 'guest-test-infra' },
     { get: 'compute-image-tools' },
     {
+      task: 'generate-timestamp',
+      file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+    },
+    {
+      load_var: 'start-timestamp-ms',
+      file: 'timestamp/timestamp-ms',
+    },
+    {
       get: '%s-gcs' % job.image,
       params: { skip_download: 'true' },
       passed: [job.passed],


### PR DESCRIPTION
This is a follow-up to pull #573 