### PR TITLE
Update timeout thresholds for package builds

### DIFF
--- a/packagebuild/workflows/build_deb10.wf.json
+++ b/packagebuild/workflows/build_deb10.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_deb11.wf.json
+++ b/packagebuild/workflows/build_deb11.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_deb9.wf.json
+++ b/packagebuild/workflows/build_deb9.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el6.wf.json
+++ b/packagebuild/workflows/build_el6.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el7.wf.json
+++ b/packagebuild/workflows/build_el7.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el8.wf.json
+++ b/packagebuild/workflows/build_el8.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el8_arm64.wf.json
+++ b/packagebuild/workflows/build_el8_arm64.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el9.wf.json
+++ b/packagebuild/workflows/build_el9.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {

--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -22,6 +22,7 @@
   },
   "Steps": {
     "build-package": {
+      "Timeout": "20m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {


### PR DESCRIPTION
Default timeout of 10m has recently become too short for some builds of EL; increasing to 20m to allow proper cleanup.