### PR TITLE
Update timeout for wait-for-build

### DIFF
--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -69,7 +69,7 @@
       ]
     },
     "wait-for-build": {
-      "Timeout": "20m",
+      "Timeout": "30m",
       "WaitForInstancesSignal": [
         {
           "Name": "inst-build-pkg",


### PR DESCRIPTION
Because 20m isn't enough for EL9. Setting to 30 to allow cleanup; plan to investigate why this is needed so suddenly later on, but this will hopefully unblock a release that needs to happen this week.