### PR TITLE
Update EL9 timeout

### DIFF
--- a/packagebuild/workflows/build_el9.wf.json
+++ b/packagebuild/workflows/build_el9.wf.json
@@ -1,6 +1,6 @@
 {
   "Name": "el9",
-  "Timeout": "20m",
+  "Timeout": "40m",
   "Vars": {
     "gcs_path": {
       "Required": true
@@ -23,7 +23,7 @@
   },
   "Steps": {
     "build-package": {
-      "Timeout": "20m",
+      "Timeout": "40m",
       "SubWorkflow": {
         "Path": "./build_package.wf.json",
         "Vars": {


### PR DESCRIPTION
20m is still not enough; this needs deeper investigation but also need to unblock a different release in the short term.