### PR TITLE
rpm build: make sure we have python3-devel available

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -62,7 +62,7 @@ if [[ ${VERSION_ID} = 9 ]]; then
   fi
 fi
 
-try_command yum install -y $GIT rpmdevtools yum-utils
+try_command yum install -y $GIT rpmdevtools yum-utils python3-devel
 
 git_checkout "$REPO_OWNER" "$REPO_NAME" "$GIT_REF"
 


### PR DESCRIPTION
Without the python3-devel we'll not have the python3 rpm macros available breaking packages requiring them.