### PR TITLE
Load linux date into var, use for tar gz and sbom json naming

### DIFF
--- a/concourse/pipelines/bare-metal-image-build.yaml
+++ b/concourse/pipelines/bare-metal-image-build.yaml
@@ -47,10 +47,15 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
       prefix: "rhel-7-metal"
+      id: ((.:id))
   - put: rhel-7-metal-gcs
     params:
       file: build-id-dir/rhel-7-metal*
@@ -93,10 +98,15 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
       prefix: "rhel-7-metal-dev"
+      id: ((.:id))
   - put: rhel-7-metal-dev-gcs
     params:
       file: build-id-dir/rhel-7-metal-dev*
@@ -139,10 +149,15 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
       prefix: "rhel-8-metal"
+      id: ((.:id))
   - put: rhel-8-metal-gcs
     params:
       file: build-id-dir/rhel-8-metal*
@@ -185,10 +200,15 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
       prefix: "rhel-8-metal-dev"
+      id: ((.:id))
   - put: rhel-8-metal-dev-gcs
     params:
       file: build-id-dir/rhel-8-metal-dev*

--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -42,6 +42,10 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -87,6 +91,10 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:
@@ -132,6 +140,10 @@ jobs:
     file: guest-test-infra/concourse/tasks/generate-timestamp.yaml
   - load_var: start-timestamp-ms
     file: timestamp/timestamp-ms
+  - task: generate-id
+    file: guest-test-infra/concourse/tasks/generate-id.yaml
+  - load_var: id
+    file: generate-id/id
   - task: generate-build-id
     file: guest-test-infra/concourse/tasks/generate-build-id.yaml
     vars:

--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -81,17 +81,17 @@ local imgbuildjob = {
       file: 'timestamp/timestamp-ms',
     },
     {
-      task: 'generate-linux-date',
-      file: 'guest-test-infra/concourse/tasks/generate-linux-date.yaml',
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
     },
     {
-      load_var: 'linux-date',
-      file: 'linux-date/linux-date-seconds',
+      load_var: 'id',
+      file: 'generate-id/id',
     },
     {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: tl.image_prefix, linux_date: '((.:linux-date))'},
+      vars: { prefix: tl.image_prefix, id: '((.:id))'},
     },
     // This is the 'put trick'. We don't have the real image tarball to write to GCS here, but we want
     // Concourse to treat this job as producing it. So we write an empty file now, and overwrite it later in

--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -81,9 +81,17 @@ local imgbuildjob = {
       file: 'timestamp/timestamp-ms',
     },
     {
+      task: 'generate-linux-date',
+      file: 'guest-test-infra/concourse/tasks/generate-linux-date.yaml',
+    },
+    {
+      load_var: 'linux-date',
+      file: 'linux-date/linux-date-seconds',
+    },
+    {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: tl.image_prefix },
+      vars: { prefix: tl.image_prefix, linux_date: '((.:linux-date))'},
     },
     // This is the 'put trick'. We don't have the real image tarball to write to GCS here, but we want
     // Concourse to treat this job as producing it. So we write an empty file now, and overwrite it later in

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -52,9 +52,17 @@ local imgbuildjob = {
       file: 'timestamp/timestamp-ms',
     },
     {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: job.image },
+      vars: { prefix: job.image, id: '((.:id))'},
     },
     {
       put: job.image + '-gcs',
@@ -179,9 +187,17 @@ local sqlimgbuildjob = {
       trigger: true,
     },
     {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: job.image },
+      vars: { prefix: job.image, id: '((.:id))' },
     },
     {
       put: job.image + '-gcs',
@@ -276,9 +292,17 @@ local containerimgbuildjob = {
       file: 'timestamp/timestamp-ms',
     },
     {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: job.image },
+      vars: { prefix: job.image, id: '((.:id))' },
     },
     {
       put: '%s-gcs' % job.image,
@@ -339,9 +363,17 @@ local windowsinstallmediaimgbuildjob = {
       file: 'timestamp/timestamp-ms',
     },
     {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: job.image },
+      vars: { prefix: job.image, id: '((.:id))' },
     },
     {
       put: '%s-gcs' % job.image,

--- a/concourse/tasks/generate-build-id-sbom.yaml
+++ b/concourse/tasks/generate-build-id-sbom.yaml
@@ -13,4 +13,4 @@ run:
   path: sh
   args:
   - -exc
-  - "buildid=((linux_date)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.sbom.json"
+  - "buildid=((id)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.sbom.json"

--- a/concourse/tasks/generate-build-id-sbom.yaml
+++ b/concourse/tasks/generate-build-id-sbom.yaml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: busybox
+
+outputs:
+- name: build-id-dir
+
+run:
+  path: sh
+  args:
+  - -exc
+  - "buildid=((linux_date)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.sbom.json"

--- a/concourse/tasks/generate-build-id.yaml
+++ b/concourse/tasks/generate-build-id.yaml
@@ -13,4 +13,4 @@ run:
   path: sh
   args:
   - -exc
-  - "buildid=((linux_date)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.tar.gz"
+  - "buildid=((id)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.tar.gz"

--- a/concourse/tasks/generate-build-id.yaml
+++ b/concourse/tasks/generate-build-id.yaml
@@ -13,4 +13,4 @@ run:
   path: sh
   args:
   - -exc
-  - "buildid=$(date '+%s'); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.tar.gz"
+  - "buildid=((linux_date)); echo $buildid | tee build-id-dir/build-id; touch build-id-dir/((prefix))-v${buildid}.tar.gz"

--- a/concourse/tasks/generate-id.yaml
+++ b/concourse/tasks/generate-id.yaml
@@ -7,10 +7,10 @@ image_resource:
     repository: bash
 
 outputs:
-- name: linux-date
+- name: id
 
 run:
   path: /usr/local/bin/bash
   args:
   - -c
-  - "linux-date=$(date '+%s'); echo $(linux-date) | tee linux-date/linux-date-seconds;
+  - "id=$(date '+%s'); echo $(id) | tee generate-id/id;

--- a/concourse/tasks/generate-linux-date.yaml
+++ b/concourse/tasks/generate-linux-date.yaml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: bash
+
+outputs:
+- name: linux-date
+
+run:
+  path: /usr/local/bin/bash
+  args:
+  - -c
+  - "linux-date=$(date '+%s'); echo $(linux-date) | tee linux-date/linux-date-seconds;

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -53,6 +53,31 @@
     gcs_dir: gcs_dir,
   },
 
+  gcssbomresource:: {
+    local resource = self,
+
+    regexp:: if self.sbom_destination != '' then
+      '%s/%s-v([0-9]+).sbom.json' % [self.sbom_destination, self.image]
+    else
+      error 'must set regexp or sbom_destination in gcssbomresource',
+
+    sbom_destination:: '',
+    image:: error 'must set image in gcssbomresource template',
+    bucket:: tl.prod_bucket,
+
+    name: self.image + '-sbom',
+    type: 'sbom',
+    source: {
+      bucket: resource.bucket,
+      regexp: resource.regexp,
+    },
+  },
+
+  GcsSbomResource(image, sbom_destination):: self.gcssbomresource {
+    image: image,
+    sbom_destination: sbom_destination,
+  },
+
   publishresulttask:: {
     local task = self,
 

--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -43,6 +43,7 @@
     // Add additional overrideable attrs.
     build_date:: '',
     gcs_url:: error 'must set gcs_url in daisy image task',
+    sbom_destination:: '',
 
     workflow_prefix+: 'build-publish/',
     vars+: [
@@ -54,7 +55,11 @@
     ] + if self.build_date == '' then
       []
     else
-      ['build_date=' + task.build_date],
+      ['build_date=' + task.build_date
+    ] + if self.sbom_destination == '' then
+      []
+    else
+      ['sbom_destination=' + task.sbom_destination],
   },
 
   daisywindowsinstallmediatask:: tl.daisytask {


### PR DESCRIPTION
With the current setup, concourse tasks can only create one file. However, we need a tar.gz and sbom.json file, and both need to have the same name so we can associate them.

To ensure they can have the same name, the linux date will be loaded into a local concourse variable. This can be reused in both generate-build-id and generate-build-id-sbom. 