### PR TITLE
quotation mistake

### DIFF
--- a/concourse/tasks/generate-id.yaml
+++ b/concourse/tasks/generate-id.yaml
@@ -13,4 +13,4 @@ run:
   path: /usr/local/bin/bash
   args:
   - -c
-  - "id=$(date '+%s'); echo $(id) | tee generate-id/id;
+  - "id=$(date '+%s'); echo $(id) | tee generate-id/id;"


### PR DESCRIPTION
Forgot to include a quotation in one of the generate-id tasks. 