### PR TITLE
Change name of outputs directory to conform with tee command

### DIFF
--- a/concourse/tasks/generate-id.yaml
+++ b/concourse/tasks/generate-id.yaml
@@ -7,7 +7,7 @@ image_resource:
     repository: bash
 
 outputs:
-- name: id
+- name: generate-id
 
 run:
   path: /usr/local/bin/bash


### PR DESCRIPTION
Looking at the format of the yaml tasks, the value of "outputs" in the task must be the name of the directory, not the name of the final variable.

If the output file is generate-id/id, "outputs" must equal generate-id, not id. 