### PR TITLE
Possible extra parenthesis caused by this variable

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -91,7 +91,7 @@ local imgbuildjob = {
     {
       task: 'generate-build-id',
       file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
-      vars: { prefix: tl.image_prefix, id: '((.:id))'},
+      vars: { prefix: tl.image_prefix, id: ((.:id))},
     },
     // This is the 'put trick'. We don't have the real image tarball to write to GCS here, but we want
     // Concourse to treat this job as producing it. So we write an empty file now, and overwrite it later in


### PR DESCRIPTION
The generate-build-id step is detecting an extra parenthesis set. 

It may be caused by the quotations when referencing the local variable.