### PR TITLE
Remove extra parenthesis in the echo statement

### DIFF
--- a/concourse/tasks/generate-id.yaml
+++ b/concourse/tasks/generate-id.yaml
@@ -13,4 +13,4 @@ run:
   path: /usr/local/bin/bash
   args:
   - -c
-  - "id=$(date '+%s'); echo $(id) | tee generate-id/id;"
+  - "id=$(date '+%s'); echo $id | tee generate-id/id;"


### PR DESCRIPTION
Echo statement with extra parenthesis caused syntax error.