### PR TITLE
Remove staging windows build from pipeline

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -40,8 +40,6 @@ jobs:
     file: guest-test-infra/concourse/pipelines/bare-metal-image-build.yaml
   - set_pipeline: windows-image-build
     file: rendered/windows-image-build.json
-  - set_pipeline: windows-image-staging-build
-    file: rendered/windows-image-build-staging.json
   - set_pipeline: container-build
     file: rendered/container-build.json
   - set_pipeline: rhui-release


### PR DESCRIPTION
Removing env was not as easy as I thought it would be; removing it from pipeline definition to unblock other updates