### PR TITLE
Change resource type for worker

### DIFF
--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -66,7 +66,7 @@
     bucket:: tl.prod_bucket,
 
     name: self.image + '-sbom',
-    type: 'sbom',
+    type: 'gcs',
     source: {
       bucket: resource.bucket,
       regexp: resource.regexp,


### PR DESCRIPTION
The resource type for gcssbomresource needs to equal 'gcs' so that a worker can be found. 