### PR TITLE
Fix sbom file pattern for all Debian images

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -539,7 +539,7 @@ local imggroup = {
              [
                common.gcssbomresource {
                  image: image,
-                 regexp: 'debian/%s-v([0-9]+).tar.gz' % common.debian_image_prefixes[self.image],
+                 regexp: 'debian/%s-v([0-9]+).sbom.json' % common.debian_image_prefixes[self.image],
                }
                for image in debian_images
              ] +


### PR DESCRIPTION
Right now, the sbom file pattern is the same as tarballs. For example:

```
{
         "name": "debian-11-sbom",
         "source": {
            "bucket": "artifact-releaser-prod-rtp",
            "regexp": "debian/debian-11-bullseye-v([0-9]+).tar.gz"
         },
         "type": "gcs"
      },
```
