### PR TITLE
Replace go get calls with go install

### DIFF
--- a/container_images/gocheck/Dockerfile
+++ b/container_images/gocheck/Dockerfile
@@ -15,7 +15,7 @@ FROM golang:1.19
 
 RUN apt-get update && apt-get install -y git && \
     rm -rf /var/cache/apt/archives
-RUN go get -u golang.org/x/lint/golint
+RUN go install golang.org/x/lint/golint@latest
 
 # Copy this Dockerfile for debugging.
 COPY Dockerfile Dockerfile

--- a/container_images/gointegtest/Dockerfile
+++ b/container_images/gointegtest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM golang:1.19
-RUN go get -u github.com/jstemmer/go-junit-report
+RUN go install github.com/jstemmer/go-junit-report@latest
 
 FROM gcr.io/compute-image-tools/daisy:latest
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:latest

--- a/container_images/gotest/Dockerfile
+++ b/container_images/gotest/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get -y install bash ca-certificates curl libssl-dev wg
     rm -rf /var/cache/apt/archives
 
 # Go test junit xml output
-RUN go get -u github.com/jstemmer/go-junit-report
-RUN go get -u golang.org/x/tools/cover
+RUN go install github.com/jstemmer/go-junit-report@latest
+RUN go install golang.org/x/tools/cover@latest
 
 # Copy this Dockerfile for debugging.
 COPY Dockerfile Dockerfile


### PR DESCRIPTION
From the build error:

'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation