### PR TITLE
registry-image-forked: remove go download

### DIFF
--- a/container_images/registry-image-forked/dockerfiles/alpine/Dockerfile
+++ b/container_images/registry-image-forked/dockerfiles/alpine/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /src
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
 
 COPY . .
 ENV CGO_ENABLED 0

--- a/container_images/registry-image-forked/dockerfiles/ubuntu/Dockerfile
+++ b/container_images/registry-image-forked/dockerfiles/ubuntu/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /src
 
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
 
 COPY . .
 ENV CGO_ENABLED 0


### PR DESCRIPTION
With all the container inception go downloading is causing a pthread issue due security constraints imposed by the container environment - it's not a required operation so lets get rid of it.