### PR TITLE
Fix 'registry-image-forked' build

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -40,6 +40,7 @@ local buildcontainerimgjob = {
   dockerfile:: 'Dockerfile',
   input:: 'guest-test-infra',
   passed:: '',
+  privileged:: false,
   extra_steps:: [],
   extra_resources:: [],
 
@@ -65,6 +66,7 @@ local buildcontainerimgjob = {
           },
           {
             task: 'build-image',
+	    privileged: job.privileged,
             config: buildcontainerimgtask {
               commit_sha: '((.:%s-commit-sha))' % job.image,
               destination: job.destination,
@@ -124,6 +126,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
     BuildContainerImage('registry-image-forked') {
       dockerfile: 'dockerfiles/alpine/Dockerfile',
       repo: 'gcr.io/compute-image-tools',
+      privileged: true,
     },
 
     // These build from the root of the repo.

--- a/container_images/registry-image-forked/dockerfiles/alpine/Dockerfile
+++ b/container_images/registry-image-forked/dockerfiles/alpine/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 
 COPY go.mod .
 COPY go.sum .
+RUN go mod download
 
 COPY . .
 ENV CGO_ENABLED 0

--- a/container_images/registry-image-forked/dockerfiles/ubuntu/Dockerfile
+++ b/container_images/registry-image-forked/dockerfiles/ubuntu/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 
 COPY go.mod .
 COPY go.sum .
+RUN go mod download
 
 COPY . .
 ENV CGO_ENABLED 0


### PR DESCRIPTION
Multiple nested layers of containers (two, to be precise) in Concourse build system causes issues with pthreads in CGO runtime. It turned out to be a general issue and not related to one particular sub-command. This happens during container images builds. 

```
INFO[0030] Args: [-c go build -o /assets/in ./cmd/in]   
INFO[0030] Running: [/bin/sh -c go build -o /assets/in ./cmd/in] 
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7f2dfae01a7c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: g 0: unknown pc 0x7f2dfae01a7c
stack: frame={sp:0x7ffdfa9f9e60, fp:0x0} stack=[0x7ffdfa1fb3e0,0x7ffdfa9fa3f0)
0x00007ffdfa9f9d60:  0x0000000000000000  0x0000000000000000 
0x00007ffdfa9f9d70:  0x0000000000000000  0x0000000000000000 
0x00007ffdfa9f9d80:  0x0000000000000000  0x0000000000000000 
```

A certain nested container requires a privileged mode:

```
...
INFO[0035] Taking snapshot of full filesystem...        
INFO[0036] Cmd: /bin/sh                                 
INFO[0036] Args: [-c go mod download]                   
INFO[0036] Running: [/bin/sh -c go mod download]        
INFO[0072] Taking snapshot of full filesystem...        
INFO[0089] COPY . .                                     
INFO[0089] Taking snapshot of files...                  
INFO[0089] ENV CGO_ENABLED 0                            
INFO[0089] RUN go build -o /assets/in ./cmd/in          
INFO[0089] Cmd: /bin/sh                                 
INFO[0089] Args: [-c go build -o /assets/in ./cmd/in]   
INFO[0089] Running: [/bin/sh -c go build -o /assets/in ./cmd/in] 
INFO[0094] Taking snapshot of full filesystem...        
INFO[0097] RUN go build -o /assets/out ./cmd/out        
INFO[0097] Cmd: /bin/sh                                 
...
```

 I also reverted the previous commit as it didn't solve the build issue.