### PR TITLE
fix go build directives all across the repo.

### DIFF
--- a/imagetest/test_suites/disk/disk_resize_test.go
+++ b/imagetest/test_suites/disk/disk_resize_test.go
@@ -1,5 +1,5 @@
-//go:build linux || ignore || cit
-// +build linux ignore cit
+//go:build linux && cit
+// +build linux,cit
 
 package disk
 

--- a/imagetest/test_suites/image_boot/image_boot_test.go
+++ b/imagetest/test_suites/image_boot/image_boot_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package imageboot
 

--- a/imagetest/test_suites/image_validation/clock_test.go
+++ b/imagetest/test_suites/image_validation/clock_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/license_test.go
+++ b/imagetest/test_suites/image_validation/license_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/linux_license_test.go
+++ b/imagetest/test_suites/image_validation/linux_license_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package imagevalidation
 

--- a/imagetest/test_suites/image_validation/package_test.go
+++ b/imagetest/test_suites/image_validation/package_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package imagevalidation
 

--- a/imagetest/test_suites/metadata/metadata_test.go
+++ b/imagetest/test_suites/metadata/metadata_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package metadata
 

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package metadata
 

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package metadata
 

--- a/imagetest/test_suites/network/alias_ip_test.go
+++ b/imagetest/test_suites/network/alias_ip_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package network
 

--- a/imagetest/test_suites/network/dhcp_test.go
+++ b/imagetest/test_suites/network/dhcp_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package network
 

--- a/imagetest/test_suites/network/gvnic_test.go
+++ b/imagetest/test_suites/network/gvnic_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package network
 

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package network
 

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package network
 

--- a/imagetest/test_suites/oslogin/oslogin_test.go
+++ b/imagetest/test_suites/oslogin/oslogin_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package oslogin
 

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package security
 

--- a/imagetest/test_suites/ssh/host_key_test.go
+++ b/imagetest/test_suites/ssh/host_key_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package ssh
 

--- a/imagetest/test_suites/ssh/image_ssh_test.go
+++ b/imagetest/test_suites/ssh/image_ssh_test.go
@@ -1,4 +1,5 @@
-// go:build cit
+//go:build cit
+// +build cit
 
 package ssh
 

--- a/imagetest/test_suites/windows/driver_package_test.go
+++ b/imagetest/test_suites/windows/driver_package_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package windows
 

--- a/imagetest/test_suites/windows/googet_test.go
+++ b/imagetest/test_suites/windows/googet_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package windows
 

--- a/imagetest/test_suites/windows_containers/docker_container_test.go
+++ b/imagetest/test_suites/windows_containers/docker_container_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package windowscontainers
 

--- a/imagetest/test_suites/windows_image_validation/image_validation_test.go
+++ b/imagetest/test_suites/windows_image_validation/image_validation_test.go
@@ -1,5 +1,5 @@
-// go:build cit
-// go:build cit
+//go:build cit
+// +build cit
 
 package windowsimagevalidation
 


### PR DESCRIPTION
With commit 89ce9742feda23ba1e12b99e758d6d268d5e7c87 we duplicated some of the directives and got it wrong for some, this patch reviews it fix all the mess.