### PR TITLE
Update Golang version in `cloud-image-tests` for consistency

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-alpine as builder
+FROM golang:1.19-alpine as builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
Let's keep all Golang versions consistent.