### PR TITLE
Fix OpenSSL version mismatch

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -48,7 +48,7 @@ RUN cd test_suites; for suite in *; do \
   cd ..; \
   done
 
-FROM alpine:edge
+FROM alpine:latest
 RUN apk add --no-cache openssh-keygen
 COPY --from=builder /out/* /
 


### PR DESCRIPTION
In the alpine docker image with `edge` tag is observed an issue with OpenSSL library version. This causes most CIT tests to fail. I nailed down the exact place where it happens in the code

https://github.com/GoogleCloudPlatform/guest-test-infra/blob/master/imagetest/fixtures.go#L415

and reproduced the issue in a separate environment:

```
$ docker run --rm -it alpine:edge sh

Unable to find image 'alpine:edge' locally
edge: Pulling from library/alpine
c0b0d1596f27: Already exists 
Digest: sha256:ff8db144214ae3fe9d1b29d3bc352e0e3d4e1dba36a39f65dce4c8b42c37ea77
Status: Downloaded newer image for alpine:edge

/ # apk add --no-cache openssh-keygen
fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
(1/1) Installing openssh-keygen (9.3_p1-r0)
Executing busybox-1.36.0-r3.trigger
OK: 8 MiB in 16 packages

/ # ssh-keygen 
OpenSSL version mismatch. Built against 30100000, you have 30000080
```

The fix sets a version of a base layer (Alpine Linux) in the target docker image to the same version as a build stage has (golang:1.19-alpine that has  alpine:3.17 as a base): https://github.com/GoogleCloudPlatform/guest-test-infra/blob/master/imagetest/Dockerfile#L15

In other words, it replaces `edge` with `3.17`  