### PR TITLE
debian packages: fetch sbomutil from gcs

### DIFF
--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -22,15 +22,25 @@ GIT_REF=$(curl -f -H Metadata-Flavor:Google ${URL}/git-ref)
 BUILD_DIR=$(curl -f -H Metadata-Flavor:Google ${URL}/build-dir)
 VERSION=$(curl -f -H Metadata-Flavor:Google ${URL}/version)
 VERSION=${VERSION:="1dummy"}
+SBOM_UTIL_GCS_ROOT=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-gcs-root)
 
 DEBIAN_FRONTEND=noninteractive
 
 echo "Started build..."
 
-
 gsutil cp "${SRC_PATH}/common.sh" ./
 . common.sh
 
+# Determine the latest sbomutil gcs path if available
+if [ -n "${SBOM_UTIL_GCS_ROOT}" ]; then
+  SBOM_UTIL_GCS_PATH=$(gsutil ls $SBOM_UTIL_GCS_ROOT 2> /dev/null | tail -1)
+fi
+
+# Fetch sbomutil from gcs if available
+if [ -n "${SBOM_UTIL_GCS_PATH}" ]; then
+  echo "Fetching sbomutil: ${SBOM_UTIL_GCS_PATH}"
+  gsutil cp "${SBOM_UTIL_GCS_PATH}/sbomutil" ./
+fi
 
 try_command apt-get -y update
 try_command apt-get install -y --no-install-{suggests,recommends} git-core \

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -30,12 +30,24 @@ GIT_REF=$(get_md git-ref)
 BUILD_DIR=$(get_md build-dir)
 VERSION=$(get_md version)
 VERSION=${VERSION:-"dummy"}
+SBOM_UTIL_GCS_ROOT=$(get_md sbom-util-gcs-root)
 
 echo "Started build..."
 
 # common.sh contains functions common to all builds.
 gsutil cp "${SRC_PATH}/common.sh" ./
 . common.sh
+
+# Determine the latest sbomutil gcs path if available
+if [ -n "${SBOM_UTIL_GCS_ROOT}" ]; then
+  SBOM_UTIL_GCS_PATH=$(gsutil ls $SBOM_UTIL_GCS_ROOT 2> /dev/null | tail -1)
+fi
+
+# Fetch sbomutil from gcs if available
+if [ -n "${SBOM_UTIL_GCS_PATH}" ]; then
+  echo "Fetching sbomutil: ${SBOM_UTIL_GCS_PATH}"
+  gsutil cp "${SBOM_UTIL_GCS_PATH}/sbomutil" ./
+fi
 
 # Install git2 as this is not available in centos 6/7
 VERSION_ID=6

--- a/packagebuild/workflows/build_deb10.wf.json
+++ b/packagebuild/workflows/build_deb10.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_deb11.wf.json
+++ b/packagebuild/workflows/build_deb11.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -36,7 +39,8 @@
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
           "zone": "us-central1-a",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_deb9.wf.json
+++ b/packagebuild/workflows/build_deb9.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el6.wf.json
+++ b/packagebuild/workflows/build_el6.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el7.wf.json
+++ b/packagebuild/workflows/build_el7.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el8.wf.json
+++ b/packagebuild/workflows/build_el8.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el8_arm64.wf.json
+++ b/packagebuild/workflows/build_el8_arm64.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -36,7 +39,8 @@
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
           "zone": "us-central1-a",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el9.wf.json
+++ b/packagebuild/workflows/build_el9.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -34,7 +37,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }

--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -19,6 +19,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -36,7 +39,8 @@
           "build_dir": "${build_dir}",
           "machine_type": "t2a-standard-2",
           "zone": "us-central1-a",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }


### PR DESCRIPTION
In preparation for generating SBOMs for guest environment first party packages this patch brings the required changes to fetching sbomutil from gcs for debian builds.