### PR TITLE
googet packages: fetch sbomutil from gcs

### DIFF
--- a/packagebuild/daisy_startupscript_goo.sh
+++ b/packagebuild/daisy_startupscript_goo.sh
@@ -21,11 +21,23 @@ REPO_NAME=$(curl -f -H Metadata-Flavor:Google ${URL}/repo-name)
 GIT_REF=$(curl -f -H Metadata-Flavor:Google ${URL}/git-ref)
 BUILD_DIR=$(curl -f -H Metadata-Flavor:Google ${URL}/build-dir)
 VERSION=$(curl -f -H Metadata-Flavor:Google ${URL}/version)
+SBOM_UTIL_GCS_ROOT=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-gcs-root)
 
 echo "Started build..."
 
 gsutil cp "${SRC_PATH}/common.sh" ./
 . common.sh
+
+# Determine the latest sbomutil gcs path if available
+if [ -n "${SBOM_UTIL_GCS_ROOT}" ]; then
+  SBOM_UTIL_GCS_PATH=$(gsutil ls $SBOM_UTIL_GCS_ROOT 2> /dev/null | tail -1)
+fi
+
+# Fetch sbomutil from gcs if available
+if [ -n "${SBOM_UTIL_GCS_PATH}" ]; then
+  echo "Fetching sbomutil: ${SBOM_UTIL_GCS_PATH}"
+  gsutil cp "${SBOM_UTIL_GCS_PATH}/sbomutil" ./
+fi
 
 try_command apt-get -y update
 try_command apt-get install -y --no-install-{suggests,recommends} git-core

--- a/packagebuild/workflows/build_goo.wf.json
+++ b/packagebuild/workflows/build_goo.wf.json
@@ -18,6 +18,9 @@
     },
     "build_dir": {
       "Required": true
+    },
+    "sbom_util_gcs_root": {
+      "Required": false
     }
   },
   "Steps": {
@@ -32,7 +35,8 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "build_dir": "${build_dir}",
-          "version": "${version}"
+          "version": "${version}",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }
     }


### PR DESCRIPTION
In preparation for generating SBOMs for guest environment first party packages this patch brings the required changes to fetching sbomutil from gcs for googet builds.