### PR TITLE
package build: pass down sbom_util_gcs_root

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -140,6 +140,7 @@ local buildpackagejob = {
                   '-var:git_ref=((.:commit-sha))',
                   '-var:version=((.:package-version))',
                   '-var:gcs_path=gs://gcp-guest-package-uploads/' + tl.gcs_dir,
+                  '-var:sbom_util_gcs_root=gs://gce-image-sbom-util/linux',
                   '-var:build_dir=' + tl.build_dir,
                   'guest-test-infra/packagebuild/workflows/build_%s.wf.json' % underscore(build),
                 ],

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -32,6 +32,9 @@
     "build_dir": {
       "Required": true
     },
+    "sbom_util_gcs_root": {
+      "Required": false
+    },
     "machine_type": {
       "Value": "e2-standard-2",
       "Description": "machine type"
@@ -58,7 +61,8 @@
             "repo-name": "${repo_name}",
             "git-ref": "${git_ref}",
             "build-dir": "${build_dir}",
-            "version": "${version}"
+            "version": "${version}",
+            "sbom-util-gcs-root": "${sbom_util_gcs_root}"
           },
           "machineType": "${machine_type}",
           "zone": "${zone}",


### PR DESCRIPTION
By passing down sbom_util_gcs_root the package build workflow will start fetching the sbomutil binary.