### PR TITLE
SBOM bucket

### DIFF
--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -3,7 +3,7 @@
 
   prod_topic:: 'projects/artifact-releaser-prod/topics/gcp-guest-image-release-prod',
   prod_bucket:: 'artifact-releaser-prod-rtp',
-  sbom_bucket:: 'gce-image-sboms/sboms',
+  sbom_bucket:: 'gce-image-sboms',
   debian_image_prefixes:: {
     'debian-9': 'debian-9-stretch',
     'debian-10': 'debian-10-buster',
@@ -58,7 +58,7 @@
     local resource = self,
 
     regexp:: if self.sbom_destination != '' then
-      '%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image]
+      'sboms/%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image]
     else
       error 'must set regexp or sbom_destination in gcssbomresource',
 


### PR DESCRIPTION
sbom: remove root folder on bucket definition

This will break gcs calls for bucket validation.