### PR TITLE
gcssbom resource: use the resource's "constructor"

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -536,13 +536,8 @@ local imggroup = {
                }
                for image in debian_images
              ] +
-             [
-               common.gcssbomresource {
-                 image: image,
-                 regexp: 'debian/%s-v([0-9]+).sbom.json' % common.debian_image_prefixes[self.image],
-               }
-               for image in debian_images
-             ] +
+             [common.gcssbomresource { image: image, image_prefix: common.debian_image_prefixes[image],
+                                       sbom_destination: 'debian' } for image in debian_images] +
              [common.gcsimgresource { image: image, gcs_dir: 'centos' } for image in centos_images] +
              [common.gcssbomresource { image: image, sbom_destination: 'centos' } for image in centos_images] +
              [common.gcsimgresource { image: image, gcs_dir: 'rhel' } for image in rhel_images] +

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -58,7 +58,7 @@
     local resource = self,
 
     regexp:: if self.sbom_destination != '' then
-      'sboms/%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image_prefix]
+      'sboms/%s/%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image_prefix, self.image_prefix]
     else
       error 'must set regexp or sbom_destination in gcssbomresource',
 

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -58,11 +58,12 @@
     local resource = self,
 
     regexp:: if self.sbom_destination != '' then
-      'sboms/%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image]
+      'sboms/%s/%s-v([0-9]+)-([0-9]+).sbom.json' % [self.sbom_destination, self.image_prefix]
     else
       error 'must set regexp or sbom_destination in gcssbomresource',
 
     sbom_destination:: '',
+    image_prefix:: self.image,
     image:: error 'must set image in gcssbomresource template',
     bucket:: tl.sbom_bucket,
 


### PR DESCRIPTION
Avoid having custom regexp spread across but reuse the "constructor" instead.