### PR TITLE
arlepublishtask: make sure to pass the sbom's path

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -234,6 +234,15 @@ local imgpublishjob = {
             params: { skip_download: 'true' },
           },
           {
+            get: tl.image + '-sbom',
+            passed: [tl.passed],
+            params: { skip_download: 'true' },
+          },
+          {
+            load_var: 'sbom-destination',
+            file: '%s-sbom/url' % tl.image,
+          },
+          {
             load_var: 'source-version',
             file: tl.image + '-gcs/version',
           },
@@ -251,6 +260,7 @@ local imgpublishjob = {
               task: 'publish-' + tl.image,
               config: arle.arlepublishtask {
                 gcs_image_path: tl.gcs,
+                sbom_gcs_path: '((.:sbom-destination))',
                 source_version: 'v((.:source-version))',
                 publish_version: '((.:publish-version))',
                 wf: tl.workflow,

--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -9,6 +9,7 @@ local common = import '../templates/common.libsonnet';
     source_gcs_path:: error 'must set source_gcs_path in gcepublishtask',
     source_version:: error 'must set source_version in gcepublishtask',
     wf:: error 'must set wf in gcepublishtask',
+    sbom_gcs_path:: '',
 
     platform: 'linux',
     image_resource: {


### PR DESCRIPTION
We are not using it yet but making sure the sbom path is getting set to arlepublishtask object.