### PR TITLE
arle: pass sbom_gcs_path to all jobs of interest

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -276,6 +276,7 @@ local imgpublishjob = {
                 'publish-%s-%s' % [tl.env, tl.image],
               config: arle.gcepublishtask {
                 source_gcs_path: tl.gcs,
+                sbom_gcs_path: '((.:sbom-destination))',
                 source_version: 'v((.:source-version))',
                 publish_version: '((.:publish-version))',
                 wf: tl.workflow,

--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -45,6 +45,7 @@ local common = import '../templates/common.libsonnet';
       wf:: error 'must set wf in arlepublishtask',
       source_version:: error 'must set source_version in arlepublishtask',
       publish_version:: error 'must set publish_version in arlepublishtask',
+      sbom_gcs_path:: '',
 
       platform: 'linux',
       image_resource: {


### PR DESCRIPTION
Make sure we are passing sbom_gcs_path both to arle and gce publish jobs.