### PR TITLE
Add bookworm to Concourse image build

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -483,7 +483,7 @@ local imggroup = {
 
 {
   local almalinux_images = ['almalinux-8', 'almalinux-9'],
-  local debian_images = ['debian-10', 'debian-11', 'debian-11-arm64'],
+  local debian_images = ['debian-10', 'debian-11', 'debian-11-arm64', 'debian-12', 'debian-12-arm64'],
   local centos_images = ['centos-7', 'centos-stream-8', 'centos-stream-9'],
   local rhel_sap_images = [
     'rhel-7-7-sap',

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -9,6 +9,8 @@
     'debian-10': 'debian-10-buster',
     'debian-11': 'debian-11-bullseye',
     'debian-11-arm64': 'debian-11-bullseye-arm64',
+    'debian-12': 'debian-12-bookworm',
+    'debian-12-arm64': 'debian-12-bookworm-arm64',
   },
 
   gitresource:: {


### PR DESCRIPTION
Adds debian-12 and debian-12-arm64 image build and test pipeline.