### PR TITLE
Update go version in the go integration container

### DIFF
--- a/container_images/gointegtest/common.sh
+++ b/container_images/gointegtest/common.sh
@@ -33,7 +33,7 @@ function install_go() {
   # Installs a specific version of go for compilation, since availability varies
   # across linux distributions. Needs curl and tar to be installed.
 
-  local GOLANG="go1.13.9.linux-amd64.tar.gz"
+  local GOLANG="go1.19.6.linux-amd64.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
There is one more missing place where Go version wasn't updated.
Addition to changes in PR #620