### PR TITLE
Use GCC 10 for EL7 rpm package builds

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -63,6 +63,12 @@ if [[ ${VERSION_ID} =~ 6|7 ]]; then
   GIT="git236"
 fi
 
+# Install DevToolSet with gcc 10 for EL7.
+# Centos 7 has only gcc 4.8.5 available.
+if (( ${VERSION_ID} == 7 )); then
+  try_command yum install -y centos-release-scl devtoolset-10-gcc-c++.x86_64
+fi
+
 # Enable CRB repo on EL9.
 if [[ ${VERSION_ID} = 9 ]]; then
   eval $(grep ID /etc/os-release)
@@ -116,6 +122,12 @@ done
 COMMITURL="https://github.com/$REPO_OWNER/$REPO_NAME/tree/$(git rev-parse HEAD)"
 
 echo "Building package(s)"
+
+# Enable gcc 10 for EL7 only and before rpmbuild
+if (( ${VERSION_ID} == 7 )); then
+  source /opt/rh/devtoolset-10/enable
+fi
+
 for spec in $TOBUILD; do
   PKGNAME="$(grep Name: "./packaging/${spec}"|cut -d' ' -f2-|tr -d ' ')"
   yum-builddep -y "./packaging/${spec}"

--- a/packagebuild/test_build.sh
+++ b/packagebuild/test_build.sh
@@ -20,7 +20,7 @@
 #        GCS_PATH=gs://vorakl-dev-builds/packages \
 #        VERSION=0.01 \
 #        BUILD_DIR=. \
-#    ./test_build_ver.sh 
+#    ./test_build.sh 
 
 DEFAULT_TYPE='deb11'
 DEFAULT_PROJECT='gcp-guest'


### PR DESCRIPTION
It turned out that Centos7 is the only platform among all we support on GCE at the moment that has a pretty ancient GCC available in the standard repos. It is gcc 4.8.5  when all others have minimum gcc 8 and higher (most of them has at least gcc 10). The problem I faced is that GCC (g++ specifically)  before ver 5 doesn't support one needed and  important feature.  To be certain, it doesn't have a copy constructor for fstream classes.

The official way to bring a newer version of GCC to Centos7 is installing Software Collections and then, Devtoolset with a needed version of GCC. That's what I integrated in the existing building script for RPMs and pinned installation of these extra packages for only EL7.

By the way, it doesn't correlate with the existing Build dependency `gcc-c++` (which is version 4.8.5) and is also installed (to keep compatibility with all other platforms e.g. EL8 and EL9, x86_64 as well as arm). That's because devtoolset enables a new gcc right before running `rpmbuild` so only g++ 10 is used for compiling code.