### PR TITLE
sbom: fix the path we are looking up source rpms

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -150,7 +150,7 @@ for spec in $TOBUILD; do
     --define "_go ${GO:-"UNSET"}" --define "_gopath ${GOPATH:-"UNSET"}" \
     -ba "${RPMDIR}/SPECS/${spec}"
 
-  SRPM_FILE=$(find ${RPMDIR}/{S,}RPM -iname "${PKGNAME}*.src.rpm")
+  SRPM_FILE=$(find ${RPMDIR}/SRPMS -iname "${PKGNAME}*.src.rpm")
   SBOM_FILE="${SBOM_DIR}/${PKGNAME}-${VERSION}.sbom.json"
 
   # We need only a single sbom, if we have multiple specs for the same package


### PR DESCRIPTION
The binary packages are being written to /usr/src/redhat/SRPMS/ and /usr/src/redhat/RPMS/ respectively, the command to find it was missing plural suffix in the directory name i.e SRPM instead of SRPMS and RPM instead of RPMS.

This change also make sure to lookup only within SRPMS directory since we are interested on the source rpm.