### PR TITLE
sbom: fix an inverted boolean check

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -127,7 +127,7 @@ function generate_and_push_sbom() {
   local VERSION=$4
 
   SBOM_FILE="${SBOM_DIR}/${PKGNAME}-${VERSION}.sbom.json"
-  if [ ! -e "${SBOM_FILE}" ]; then
+  if [ -e "${SBOM_FILE}" ]; then
     echo "SBOM was already generated for this package, skipping..."
     return
   fi


### PR DESCRIPTION
When checking if sbom was already previously generated we inverted the boolean condition check.