### PR TITLE
sbom: add support to arm64

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -140,7 +140,7 @@ local buildpackagejob = {
                   '-var:git_ref=((.:commit-sha))',
                   '-var:version=((.:package-version))',
                   '-var:gcs_path=gs://gcp-guest-package-uploads/' + tl.gcs_dir,
-                  '-var:sbom_util_gcs_root=gs://gce-image-sbom-util/linux',
+                  '-var:sbom_util_gcs_root=gs://gce-image-sbom-util',
                   '-var:build_dir=' + tl.build_dir,
                   'guest-test-infra/packagebuild/workflows/build_%s.wf.json' % underscore(build),
                 ],

--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -89,6 +89,13 @@ function deploy_sbomutil() {
     return
   fi
 
+  SBOM_UTIL_GCS_ROOT="${SBOM_UTIL_GCS_ROOT}/linux"
+
+  # suffix the gcs path with arm64 if that's the case
+  if [ "$(uname -m)" == "aarch64" ]; then
+    SBOM_UTIL_GCS_ROOT="${SBOM_UTIL_GCS_ROOT}_arm64"
+  fi
+
   export SBOM_UTIL=$(realpath "${PWD}/sbomutil")
   export SBOM_DIR="${PWD}"
 


### PR DESCRIPTION
Make sure to properly deploy sbomutil for the right architecture.