### PR TITLE
sbom: fix the call to generate_and_push_sbom for rpm build

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -139,7 +139,7 @@ for spec in $TOBUILD; do
     -ba "${RPMDIR}/SPECS/${spec}"
 
   SRPM_FILE=$(find ${RPMDIR}/SRPMS -iname "${PKGNAME}*.src.rpm")
-  generate_and_push_sbom "${BUILD_DIR}" "${SRPM_FILE}" "${PKGNAME}" "${VERSION}"
+  generate_and_push_sbom ./ "${SRPM_FILE}" "${PKGNAME}" "${VERSION}"
 done
 
 rpms=$(find ${RPMDIR}/{S,}RPMS -iname "${PKGNAME}*.rpm")


### PR DESCRIPTION
In the rpm builds we don't have BUILD_DIR variable defined, this change assumes (as all the remaining of the build script does) that PWD is the build dir.