### PR TITLE
packages: fix compute-image-tools git-resource definition

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1335,7 +1335,6 @@ local buildpackageimagetask = {
         uri: 'https://github.com/GoogleCloudPlatform/compute-image-tools.git',
         branch: 'master',
         fetch_tags: true,
-        paths: ['cli_tools/diagnostics/**'],
       },
     },
     {


### PR DESCRIPTION
Based on the documented behavior this resource will only yield new versions when cli_tools/diagnostics/** gets changed by a commit. This patch makes sure to remove it and allow us to get new versions for any new changes commited.