### PR TITLE
Fix sbom util path name error

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -185,7 +185,7 @@ local elimgbuildjob = imgbuildjob {
   ],
 
   // Add EL and sbom util args to build task.
-  build_task+: { vars+: ['installer_iso=((.:iso-secret))', 'sbom_util_gcs_path=((.:sbom-util-secret))'] },
+  build_task+: { vars+: ['installer_iso=((.:iso-secret))', 'sbom_util_gcs_root=((.:sbom-util-secret))'] },
 };
 
 local imgpublishjob = {


### PR DESCRIPTION
The variable sbom_util_gcs_path should be renamed sbom_util_gcs_root