### PR TITLE
Fix a couple test cases for Debian 12.

### DIFF
--- a/imagetest/test_suites/image_validation/image_validation_test.go
+++ b/imagetest/test_suites/image_validation/image_validation_test.go
@@ -193,6 +193,10 @@ func TestHostsFile(t *testing.T) {
 		// Does not have dhclient or the dhclient exit hook.
 		t.Skip("Not supported on EL9")
 	}
+	if strings.Contains(image, "debian-12") {
+		// Does not have dhclient or the dhclient exit hook.
+		t.Skip("Not supported on Debian 12")
+	}
 
 	b, err := ioutil.ReadFile("/etc/hosts")
 	if err != nil {

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -76,7 +76,14 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err := vm2.Reboot(); err != nil {
 		return err
 	}
-	vm1.RunTests("TestPingVMToVM|TestDHCP|TestDefaultMTU")
+
+	if strings.Contains(t.Image, "debian-12") {
+		// Debian 12 doesn't have dhclient.
+		vm1.RunTests("TestDefaultMTU")
+	} else {
+		vm1.RunTests("TestPingVMToVM|TestDHCP|TestDefaultMTU")
+	}
+
 	if strings.Contains(t.Image, "debian-10") || strings.Contains(t.Image, "rhel-7-7-sap") || strings.Contains(t.Image, "rhel-8-1-sap") {
 		// GVNIC is not supported on some older distros.
 		vm2.RunTests("TestAlias")

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -361,12 +361,14 @@ func runCommand(name string, arg ...string) (string, string, error) {
 
 var (
 	allowedTCP = []string{
-		"22", // ssh
+		"22",   // ssh
+		"5355", // systemd-resolve
 	}
 	allowedUDP = []string{
-		"68",  // bootpc aka DHCP client port
-		"123", // ntp
-		"546", // dhcp v6 client port
+		"68",   // bootpc aka DHCP client port
+		"123",  // ntp
+		"546",  // dhcp v6 client port
+		"5355", // systemd-resolve
 	}
 )
 
@@ -417,13 +419,6 @@ func TestSockets(t *testing.T) {
 		// port 111
 		allowedTCP = append(allowedTCP, "111")
 		allowedUDP = append(allowedUDP, "111")
-	}
-
-	if strings.Contains(image, "rhel-8") && strings.Contains(image, "-sap") {
-		// RHEL 8 SAP Images are permitted to have 'systemd-resolve'
-		// listening on port 5355
-		allowedTCP = append(allowedTCP, "5355")
-		allowedUDP = append(allowedUDP, "5355")
 	}
 
 	if !(strings.Contains(image, "rhel-7") && strings.Contains(image, "-sap")) {


### PR DESCRIPTION
Most all modern distros now are going to have systemd-resovle and therefore that port is fairly normal.
There are still many failing test cases we're looking into.