### PR TITLE
Split off task template when generating SBOM, with sbom_destination var

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -9,7 +9,7 @@ local lego = import '../templates/lego.libsonnet';
 local envs = ['testing', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');
 
-local imgbuildtask = daisy.daisyimagetask {
+local imgbuildtask = daisy.daisyimagesbomtask {
   gcs_url: '((.:gcs-url))',
   sbom_destination: '((.:sbom-destination))',
 };

--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -37,7 +37,8 @@
     },
   },
 
-  daisyimagetask:: tl.daisytask {
+  // Template for images where the build results in a SBOM.
+  daisyimagesbomtask:: tl.daisytask {
     local task = self,
 
     // Add additional overrideable attrs.
@@ -53,6 +54,26 @@
       'workflow_root=../../',
       'gcs_url=' + task.gcs_url,
       'sbom_destination=' + task.sbom_destination
+    ] + if self.build_date == '' then
+      []
+    else
+      ['build_date=' + task.build_date],
+  },
+
+  daisyimagetask:: tl.daisytask {
+    local task = self,
+
+    // Add additional overrideable attrs.
+    build_date:: '',
+    gcs_url:: error 'must set gcs_url in daisy image task',
+
+    workflow_prefix+: 'build-publish/',
+    vars+: [
+      // Always reference workflow assets from Concourse input rather than container copy.
+      // This is interpreted by Daisy relative to the workflow location, so two directories up is e.g. out of
+      // enterprise_linux and then out of build-publish, ending in daisy_workflows
+      'workflow_root=../../',
+      'gcs_url=' + task.gcs_url,
     ] + if self.build_date == '' then
       []
     else


### PR DESCRIPTION
Allow some image builds to not generate a SBOM, while other image builds generate a SBOM.

Relevant, for example, when considering docker container images which do not generate an SBOM from sbom-util.