### PR TITLE
Add registry-image-forked resource type to artifact-releaser-test.

### DIFF
--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -216,7 +216,7 @@ local arle_publish_images_autopush = {
     result: 'success',
     job: tl.name,
   },
-  on_failure: {
+  on_failure: publishresulttask {
     result: 'failure',
     job: tl.name,
   },

--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -20,35 +20,6 @@ else filename + '-';
 // Change '-' to '_', mainly used for images.
 local underscore(input) = std.strReplace(input, '-', '_');
 
-// Publish results of tasks.
-local publishresulttask = {
-  local tl = self,
-
-  result:: error 'must set result in publishresulttask',
-  job:: error 'must set job in publishresulttask',
-
-  task: tl.result,
-  config: {
-    platform: 'linux',
-    image_resource: {
-      type: 'registry-image',
-      source: { repository: 'gcr.io/gcp-guest/concourse-metrics' },
-    },
-    run: {
-      path: '/publish-job-result',
-      args: [
-        '--project-id=gcp-guest',
-        '--zone=us-west1-a',
-        '--pipeline=artifact-releaser-test',
-        '--job=' + tl.job,
-        '--task=publish-job-result',
-        '--result-state=' + tl.result,
-        '--start-timestamp=((.:start-timestamp-ms))',
-        '--metric-path=concourse/job/duration',
-      ],
-    },
-  },
-};
 
 local upload_arle_autopush_staging = {
   local tl = self,
@@ -97,13 +68,23 @@ local upload_arle_autopush_staging = {
       },
     },
   ],
-  on_success: publishresulttask {
-    result: 'success',
-    job: tl.name,
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'artifact-releaser-test',
+      job: tl.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
-  on_failure: publishresulttask {
-    result: 'failure',
-    job: tl.name,
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build-staging',
+      job: tl.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
 };
 
@@ -154,13 +135,23 @@ local promote_arle_autopush_stable = {
           }
           for i in std.range(0, std.length(tl.repos) - 1)
         ],
-  on_success: publishresulttask {
-    result: 'success',
-    job: tl.name,
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'artifact-releaser-test',
+      job: tl.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
-  on_failure: publishresulttask {
-    result: 'failure',
-    job: tl.name,
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build-staging',
+      job: tl.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
 };
 
@@ -212,13 +203,23 @@ local arle_publish_images_autopush = {
       },
     },
   ],
-  on_success: publishresulttask {
-    result: 'success',
-    job: tl.name,
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'artifact-releaser-test',
+      job: tl.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
-  on_failure: publishresulttask {
-    result: 'failure',
-    job: tl.name,
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build-staging',
+      job: tl.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
   },
 };
 
@@ -365,6 +366,11 @@ local pkggroup = {
       name: 'cron-resource',
       type: 'docker-image',
       source: { repository: 'cftoolsmiths/cron-resource' },
+    },
+    {
+      name: 'registry-image-forked',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
     },
   ],
   resources: [

--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -80,7 +80,7 @@ local upload_arle_autopush_staging = {
   on_failure: {
     task: 'publish-failure-metric',
     config: common.publishresulttask {
-      pipeline: 'windows-image-build-staging',
+      pipeline: 'artifact-releaser-test',
       job: tl.name,
       result_state: 'failure',
       start_timestamp: '((.:start-timestamp-ms))',
@@ -147,7 +147,7 @@ local promote_arle_autopush_stable = {
   on_failure: {
     task: 'publish-failure-metric',
     config: common.publishresulttask {
-      pipeline: 'windows-image-build-staging',
+      pipeline: 'artifact-releaser-test',
       job: tl.name,
       result_state: 'failure',
       start_timestamp: '((.:start-timestamp-ms))',
@@ -215,7 +215,7 @@ local arle_publish_images_autopush = {
   on_failure: {
     task: 'publish-failure-metric',
     config: common.publishresulttask {
-      pipeline: 'windows-image-build-staging',
+      pipeline: 'artifact-releaser-test',
       job: tl.name,
       result_state: 'failure',
       start_timestamp: '((.:start-timestamp-ms))',

--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -20,7 +20,7 @@ else filename + '-';
 // Change '-' to '_', mainly used for images.
 local underscore(input) = std.strReplace(input, '-', '_');
 
-// Publish results of tasks. Used for jobs.
+// Publish results of tasks.
 local publishresulttask = {
   local tl = self,
 
@@ -212,23 +212,13 @@ local arle_publish_images_autopush = {
       },
     },
   ],
-  on_success: {
-    task: 'publish-success-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: 'arle-publish-image-autopush-%s' % tl.image,
-      result_state: 'success',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_success: publishresulttask {
+    result: 'success',
+    job: tl.name,
   },
   on_failure: {
-    task: 'publish-failure-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: 'arle-publish-image-autopush-%s' % tl.image,
-      result_state: 'failure',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+    result: 'failure',
+    job: tl.name,
   },
 };
 


### PR DESCRIPTION
Concourse is erroring across all groups, stating that it cannot find the appropriate resource type `registry-image-forked` for platform `linux`. This should fix that issue.