### PR TITLE
Create separate publish task for artifact-releaser-test.

### DIFF
--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -20,6 +20,35 @@ else filename + '-';
 // Change '-' to '_', mainly used for images.
 local underscore(input) = std.strReplace(input, '-', '_');
 
+// Publish task results
+local publishresulttask = {
+  local tl = self,
+
+  result:: error 'must set result in publishresulttask',
+  package:: error 'must set package in publishresulttask',
+
+  task: tl.result,
+  config: {
+    platform: 'linux',
+    image_resource: {
+      type: 'registry-image',
+      source: { repository: 'gcr.io/gcp-guest/concourse-metrics' },
+    },
+    run: {
+      path: '/publish-job-result',
+      args: [
+        '--project-id=gcp-guest',
+        '--zone=us-west1-a',
+        '--pipeline=artifact-releaser-test',
+        '--job=build-' + tl.package,
+        '--task=publish-job-result',
+        '--result-state=' + tl.result,
+        '--start-timestamp=((.:start-timestamp-ms))',
+        '--metric-path=concourse/job/duration',
+      ],
+    },
+  },
+};
 
 local upload_arle_autopush_staging = {
   local tl = self,
@@ -68,23 +97,13 @@ local upload_arle_autopush_staging = {
       },
     },
   ],
-  on_success: {
-    task: 'publish-success-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'success',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_success: publishresulttask {
+    result: 'success',
+    job: tl.name,
   },
-  on_failure: {
-    task: 'publish-failure-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'failure',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_failure: publishresulttask {
+    result: 'failure',
+    job: tl.name,
   },
 };
 
@@ -135,23 +154,13 @@ local promote_arle_autopush_stable = {
           }
           for i in std.range(0, std.length(tl.repos) - 1)
         ],
-  on_success: {
-    task: 'publish-success-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'success',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_success: publishresulttask {
+    result: 'success',
+    job: tl.name,
   },
-  on_failure: {
-    task: 'publish-failure-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'failure',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_failure: publishresulttask {
+    result: 'failure',
+    job: tl.name,
   },
 };
 
@@ -199,23 +208,13 @@ local arle_publish_images_autopush = {
       },
     },
   ],
-  on_success: {
-    task: 'publish-success-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'success',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_success: publishresulttask {
+    result: 'success',
+    job: tl.name,
   },
-  on_failure: {
-    task: 'publish-failure-metric',
-    config: common.publishresulttask {
-      pipeline: 'artifact-releaser-test',
-      job: tl.name,
-      result_state: 'failure',
-      start_timestamp: '((.:start-timestamp-ms))',
-    },
+  on_failure: publishresulttask {
+    result: 'failure',
+    job: tl.name,
   },
 };
 
@@ -362,11 +361,6 @@ local pkggroup = {
       name: 'cron-resource',
       type: 'docker-image',
       source: { repository: 'cftoolsmiths/cron-resource' },
-    },
-    {
-      name: 'registry-image-forked',
-      type: 'registry-image',
-      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
     },
   ],
   resources: [

--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -25,7 +25,7 @@ local publishresulttask = {
   local tl = self,
 
   result:: error 'must set result in publishresulttask',
-  package:: error 'must set package in publishresulttask',
+  job:: error 'must set job in publishresulttask',
 
   task: tl.result,
   config: {
@@ -40,7 +40,7 @@ local publishresulttask = {
         '--project-id=gcp-guest',
         '--zone=us-west1-a',
         '--pipeline=artifact-releaser-test',
-        '--job=build-' + tl.package,
+        '--job=' + tl.job,
         '--task=publish-job-result',
         '--result-state=' + tl.result,
         '--start-timestamp=((.:start-timestamp-ms))',


### PR DESCRIPTION
The reason for this is because we keep getting an error in concourse saying that the `tag` field is an unknown field. Along with this change is cleaning up `resource_types` and removing the `registry-image-forked` resource type. 

One consideration was removing the `tag` from the `publishresulttask` implementation in `templates/common.libsonnet`. However, from looking through the documentation specific to `registry-image-forked`, it causes slightly different behavior (instead of focusing on the `latest` tag, it looks at semvers instead) which may not be desired, and thus we leave that task alone and create our own working implementation of it.