### PR TITLE
windows: fix certgen upload resource name

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1081,7 +1081,7 @@ local buildpackageimagetask = {
       uploads: [
         uploadpackagetask {
           package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/certgen.x86_64.x86_64.((.:package-version)).0@1.goo"}',
+            '{"bucket":"gcp-guest-package-uploads","object":"compute-image-windows/certgen.x86_64.((.:package-version)).0@1.goo"}',
           sbom_file:
             '{"bucket":"gcp-guest-package-uploads","object":""}',
           universe: 'cloud-yuck',


### PR DESCRIPTION
The resource being generated is not consistent with name passed in to arle, the signing job will try to sign the wrong file (or a non existing package file).