### PR TITLE
daisy: build daisy statically & update container image

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -208,11 +208,11 @@ local BuildContainerImage(image) = buildcontainerimgjob {
               platform: 'linux',
               image_resource: {
                 type: 'registry-image',
-                source: { repository: 'golang' },
+                source: { repository: 'golang:bullseye' },
               },
               inputs: [{ name: 'compute-daisy', path: '.' }],
               outputs: [{ name: arch }],
-              params: { GOOS: arch },
+              params: { GOOS: arch, CGO_ENABLED: 0 },
               run: {
                 path: 'go',
                 dir: 'cli',


### PR DESCRIPTION
Make sure we are building daisy statically; additionally we are
updating the container image to be consistent across the other
build environments.