### PR TITLE
daisy: properly set the container tag

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -208,7 +208,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
               platform: 'linux',
               image_resource: {
                 type: 'registry-image',
-                source: { repository: 'golang:bullseye' },
+                source: { repository: 'golang', tag: 'bullseye' },
               },
               inputs: [{ name: 'compute-daisy', path: '.' }],
               outputs: [{ name: arch }],


### PR DESCRIPTION
We assumed that the format <repository>:<tag> was valid for concourses registry-image-resource, however tag needs to be specified with the tag field in the resources configuration.