### PR TITLE
Fix directory for apt transport artifact registry package

### DIFF
--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -96,7 +96,7 @@ local upload_arle_autopush_staging = {
                 args: [
                   'storage',
                   'cp',
-		  '-n',
+                  '-n',
                   'gs://%s/%s/%s((.:package-version))%s' % [
                     common.prod_package_bucket,
                     tl.gcs_dir,
@@ -602,7 +602,6 @@ local pkggroup = {
           },
           upload_arle_autopush_staging {
             package: 'artifact-registry-apt-transport',
-            gcs_dir: 'apt-transport-artifact-registry',
             builds: apt_transport_builds,
             gcs_pkg_names: ['apt-transport-artifact-registry'],
             file_endings: apt_transport_file_endings,


### PR DESCRIPTION
At some point, it seems like the directory was changed from `artifact-registry-apt-transport` to `apt-transport-artifact-registry`.