### PR TITLE
Revert "Support multiple disks in a VM"

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -82,8 +82,7 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	}
 
 	// createDisksStep doesn't depend on any other steps.
-	createVMStep, i, err := t.appendCreateVMStep([]*compute.AttachedDiskInitializeParams{
-		{DiskName: vmname}}, name)
+	createVMStep, i, err := t.appendCreateVMStep(vmname, name)
 	if err != nil {
 		return nil, err
 	}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -57,13 +57,8 @@ type TestWorkflow struct {
 	lockProject bool
 }
 
-func (t *TestWorkflow) appendCreateVMStep(diskParams []*compute.AttachedDiskInitializeParams, hostname string) (*daisy.Step, *daisy.Instance, error) {
-	if len(diskParams) == 0 {
-		return nil, nil, fmt.Errorf("Create VM Step requires at least one boot disk")
-	}
-
-	// The name of the first boot disk determines the name of the VM
-	name := diskParams[0].DiskName
+func (t *TestWorkflow) appendCreateVMStep(name, hostname string) (*daisy.Step, *daisy.Instance, error) {
+	attachedDisk := &compute.AttachedDisk{Source: name}
 
 	var suffix string
 	if strings.Contains(t.Image, "windows") {
@@ -74,11 +69,7 @@ func (t *TestWorkflow) appendCreateVMStep(diskParams []*compute.AttachedDiskInit
 	instance.StartupScript = fmt.Sprintf("wrapper%s", suffix)
 	instance.Name = name
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
-
-	for _, diskParam := range diskParams {
-		instance.Disks = append(instance.Disks, &compute.AttachedDisk{InitializeParams: diskParam})
-	}
-
+	instance.Disks = append(instance.Disks, attachedDisk)
 	if hostname != "" && name != hostname {
 		instance.Hostname = hostname
 	}

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
-	"google.golang.org/api/compute/v1"
 )
 
 func TestAddStartStep(t *testing.T) {
@@ -195,8 +194,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.AttachedDiskInitializeParams{
-		{DiskName: "vmname"}}, "")
+	step, _, err := twf.appendCreateVMStep("vmname", "")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -214,8 +212,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if !ok || step != stepFromWF {
 		t.Error("step was not correctly added to workflow")
 	}
-	step2, _, err := twf.appendCreateVMStep([]*compute.AttachedDiskInitializeParams{
-		{DiskName: "vmname2"}}, "")
+	step2, _, err := twf.appendCreateVMStep("vmname2", "")
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -231,46 +228,6 @@ func TestAppendCreateVMStep(t *testing.T) {
 	}
 }
 
-func TestAppendCreateVMStepMultipleDisks(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
-	if err != nil {
-		t.Errorf("failed to create test workflow: %v", err)
-	}
-	if twf.wf == nil {
-		t.Fatal("test workflow is malformed")
-	}
-	if _, ok := twf.wf.Steps["create-disks"]; ok {
-		t.Fatal("create-disks step already exists")
-	}
-
-	mountedDiskType := "pd-extreme"
-	firstDiskParams := &compute.AttachedDiskInitializeParams{DiskName: "vmname"}
-	secondDiskParams := &compute.AttachedDiskInitializeParams{DiskName: "vmname", DiskType: mountedDiskType}
-	step, firstInstance, err := twf.appendCreateVMStep([]*compute.AttachedDiskInitializeParams{
-		firstDiskParams, secondDiskParams}, "")
-	if err != nil {
-		t.Errorf("failed to add wait step to test workflow: %v", err)
-	}
-	if step.CreateInstances == nil {
-		t.Fatal("CreateDisks step is missing")
-	}
-	if len(firstInstance.Disks) != 2 {
-		t.Fatal("Create VM step did not create two disks")
-	}
-	secondDiskType := firstInstance.Disks[1].InitializeParams.DiskType
-	if secondDiskType != mountedDiskType {
-		t.Fatal("DiskType for second disk not properly set")
-	}
-
-	instances := step.CreateInstances.Instances
-	if len(instances) != 1 {
-		t.Error("CreateInstances step is malformed")
-	}
-	if instances[0].Name != "vmname" {
-		t.Error("CreateInstances step is malformed")
-	}
-}
-
 func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	twf, err := NewTestWorkflow("name", "image", "30m")
 	if err != nil {
@@ -282,8 +239,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.AttachedDiskInitializeParams{
-		{DiskName: "vmname"}}, "vmname.example.com")
+	step, _, err := twf.appendCreateVMStep("vmname", "vmname.example.com")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/guest-test-infra#738

It appears that there are two potential issues which need to be resolved, and currently the image releases are blocked by failing tests. It is probably a good idea to revert this change until this is fixed.

1. there is likely a disk name conflict due to global unique disk names
2. The source image field of initparams likely needs to be set