### PR TITLE
Allow test vm to have multiple disks

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -76,13 +76,14 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	parts := strings.Split(name, ".")
 	vmname := strings.ReplaceAll(parts[0], "_", "-")
 
-	createDisksStep, err := t.appendCreateDisksStep(&compute.Disk{Name: vmname})
+	bootDisk := &compute.Disk{Name: vmname}
+	createDisksStep, err := t.appendCreateDisksStep(bootDisk)
 	if err != nil {
 		return nil, err
 	}
 
-	// createDisksStep doesn't depend on any other steps.
-	createVMStep, i, err := t.appendCreateVMStep(vmname, name)
+	// createDisksStep doesn't depend on any other steps
+	createVMStep, i, err := t.appendCreateVMStep([]*compute.Disk{bootDisk}, name)
 	if err != nil {
 		return nil, err
 	}

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -82,7 +82,7 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 		return nil, err
 	}
 
-	// createDisksStep doesn't depend on any other steps
+	// createDisksStep doesn't depend on any other steps.
 	createVMStep, i, err := t.appendCreateVMStep([]*compute.Disk{bootDisk}, name)
 	if err != nil {
 		return nil, err

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -67,11 +67,11 @@ type TestWorkflow struct {
 }
 
 func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, hostname string) (*daisy.Step, *daisy.Instance, error) {
-  if len(disks) == 0 || disks[0].Name == "" {
-    return nil, nil, fmt.Errorf("failed to create VM from empty boot disk")
-  }
-  // The boot disk is the first disk, and the VM name comes from that
-  name := disks[0].Name
+	if len(disks) == 0 || disks[0].Name == "" {
+		return nil, nil, fmt.Errorf("failed to create VM from empty boot disk")
+	}
+	// The boot disk is the first disk, and the VM name comes from that
+	name := disks[0].Name
 
 	var suffix string
 	if strings.Contains(t.Image, "windows") {
@@ -87,11 +87,10 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, hostname string
 	}
 
 	for _, disk := range disks {
-	  currentDiskName := disk.Name
-	currentAttachedDisk := &compute.AttachedDisk{Source: currentDiskName}
-	instance.Disks = append(instance.Disks, currentAttachedDisk)
+		currentDiskName := disk.Name
+		currentAttachedDisk := &compute.AttachedDisk{Source: currentDiskName}
+		instance.Disks = append(instance.Disks, currentAttachedDisk)
 	}
-
 
 	instance.Metadata = make(map[string]string)
 	instance.Metadata["_test_vmname"] = name

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -87,9 +87,7 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, hostname string
 	}
 
 	for _, disk := range disks {
-		currentDiskName := disk.Name
-		currentAttachedDisk := &compute.AttachedDisk{Source: currentDiskName}
-		instance.Disks = append(instance.Disks, currentAttachedDisk)
+		instance.Disks = append(instance.Disks, &compute.AttachedDisk{Source: disk.Name})
 	}
 
 	instance.Metadata = make(map[string]string)

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -195,7 +195,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname"}}, "")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}}, "")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if !ok || step != stepFromWF {
 		t.Error("step was not correctly added to workflow")
 	}
-	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname2"}}, "")
+	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname2"}}, "")
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname"}}, "vmname.example.com")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}}, "vmname.example.com")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -195,7 +195,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep("vmname", "")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname"}}, "")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if !ok || step != stepFromWF {
 		t.Error("step was not correctly added to workflow")
 	}
-	step2, _, err := twf.appendCreateVMStep("vmname2", "")
+	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname2"}}, "")
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep("vmname", "vmname.example.com")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{&compute.Disk{Name: "vmname"}}, "vmname.example.com")
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}


### PR DESCRIPTION
Functionality of the current tests should not change. This should allow a future change to create a test vm with 2 or more disks.