### PR TITLE
test: don't fail if we succeed to create marker file

### DIFF
--- a/imagetest/test_suites/disk/disk_resize_test.go
+++ b/imagetest/test_suites/disk/disk_resize_test.go
@@ -39,7 +39,8 @@ func TestDiskResize(t *testing.T) {
 		if _, err := os.Create(markerFile); err != nil {
 			t.Fatalf("failed creating marker file: %v", err)
 		}
-		t.Fatalf("First boot")
+	} else if err != nil {
+		t.Fatal("failed to stat marker file: %+v", err)
 	}
 
 	// Total blocks * size per block = total space in bytes

--- a/imagetest/test_suites/image_boot/image_boot_test.go
+++ b/imagetest/test_suites/image_boot/image_boot_test.go
@@ -94,7 +94,8 @@ func TestGuestReboot(t *testing.T) {
 		if _, err := os.Create(markerFile); err != nil {
 			t.Fatalf("failed creating marker file: %v", err)
 		}
-		t.Fatal("marker file does not exist")
+	} else if err != nil {
+		t.Fatal("failed to stat marker file: %+v", err)
 	}
 	// second boot
 	t.Log("marker file exist signal the guest reboot successful")

--- a/imagetest/test_suites/network/alias_ip_test.go
+++ b/imagetest/test_suites/network/alias_ip_test.go
@@ -31,8 +31,10 @@ func TestAliasAfterReboot(t *testing.T) {
 		if _, err := os.Create(markerFile); err != nil {
 			t.Fatalf("failed creating marker file: %v", err)
 		}
-		t.Fatal("missing marker file, maybe first boot")
+	} else if err != nil {
+		t.Fatal("failed to stat marker file: %+v", err)
 	}
+
 	// second boot
 	if err := verifyIPAliases(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
In the network/disk/boot tests we try to assess if the boot marker
file exists and if it doesn't exist we try to create it, but always
run into t.Fatal() even if we succeeded.