### PR TITLE
Allow hyperdisk testing by changing boot disk

### DIFF
--- a/imagetest/test_suites/storage_perf/setup.go
+++ b/imagetest/test_suites/storage_perf/setup.go
@@ -14,7 +14,7 @@ const (
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName, Type: imagetest.PdBalanced, SizeGb: 100},
+	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName, Type: imagetest.PdBalanced, SizeGb: 10},
 		{Name: "pdextreme", Type: imagetest.HyperdiskExtreme, SizeGb: 100}})
 	if err != nil {
 		return err

--- a/imagetest/test_suites/storage_perf/setup.go
+++ b/imagetest/test_suites/storage_perf/setup.go
@@ -14,8 +14,8 @@ const (
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName},
-		{Name: "pdextreme", Type: imagetest.PdExtreme, SizeGb: 100}})
+	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName, Type: imagetest.PdBalanced, SizeGb: 100},
+		{Name: "pdextreme", Type: imagetest.HyperdiskExtreme, SizeGb: 100}})
 	if err != nil {
 		return err
 	}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -62,8 +62,6 @@ type TestWorkflow struct {
 	Image string
 	// ShortImage will be only the final component of Image, used for naming.
 	ShortImage string
-	// MachineType can be used to set the machine shape, currently unused.
-	MachineType string
 	// destination for workflow outputs in GCS.
 	gcsPath        string
 	skipped        bool


### PR DESCRIPTION
c3 boot disk must be pd balanced, not pd standard.