### PR TITLE
Pass in machine type to fixtures

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -144,7 +144,7 @@ func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instance
 		createDisksSteps[i] = createDisksStep
 	}
 
-  instanceParams["hostname"] = name
+	instanceParams["hostname"] = name
 	// createDisksStep doesn't depend on any other steps.
 	createVMStep, i, err := t.appendCreateVMStep(disks, instanceParams)
 	if err != nil {

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -83,7 +83,7 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	}
 
 	// createDisksStep doesn't depend on any other steps.
-	createVMStep, i, err := t.appendCreateVMStep([]*compute.Disk{bootDisk}, name)
+	createVMStep, i, err := t.appendCreateVMStep([]*compute.Disk{bootDisk}, map[string]string{"hostname": name})
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 
 // CreateTestVMMultipleDisks adds the necessary steps to create a VM with the specified
 // name to the workflow.
-func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk) (*TestVM, error) {
+func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instanceParams map[string]string) (*TestVM, error) {
 	if len(disks) == 0 || disks[0].Name == "" {
 		return nil, fmt.Errorf("failed to create multiple disk VM with empty boot disk")
 	}
@@ -144,12 +144,12 @@ func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk) (*TestVM
 		createDisksSteps[i] = createDisksStep
 	}
 
+  instanceParams["hostname"] = name
 	// createDisksStep doesn't depend on any other steps.
-	createVMStep, i, err := t.appendCreateVMStep(disks, name)
+	createVMStep, i, err := t.appendCreateVMStep(disks, instanceParams)
 	if err != nil {
 		return nil, err
 	}
-	// can modify the daisy instance here to set the machinetype
 	for _, createDisksStep := range createDisksSteps {
 		if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
 			return nil, err

--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -74,7 +74,7 @@ func TestCreateVMMultipleDisks(t *testing.T) {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
 	disks := []*compute.Disk{{Name: "vm"}, {Name: "mountdisk", Type: PdSsd, SizeGb: 100}}
-	tvm, err := twf.CreateTestVMMultipleDisks(disks)
+	tvm, err := twf.CreateTestVMMultipleDisks(disks, map[string]string{})
 	if err != nil {
 		t.Errorf("failed to create test vm: %v", err)
 	}
@@ -146,9 +146,14 @@ func TestRebootMultipleDisks(t *testing.T) {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
 	disks := []*compute.Disk{{Name: "vm"}, {Name: "mountdisk", Type: PdBalanced, SizeGb: 100}}
-	tvm, err := twf.CreateTestVMMultipleDisks(disks)
+	testMachineType := "c3-standard-4"
+	pdBalancedParams := map[string]string{"machineType": testMachineType}
+	tvm, err := twf.CreateTestVMMultipleDisks(disks, pdBalancedParams)
 	if err != nil {
 		t.Errorf("failed to create test vm: %v", err)
+	}
+	if tvm.instance.MachineType != testMachineType {
+		t.Errorf("failed to set test machine type, expected %s but got %s", testMachineType, tvm.instance.MachineType)
 	}
 	if twf.counter != 0 {
 		t.Errorf("step counter not starting at 0")

--- a/imagetest/test_suites/storage_perf/setup.go
+++ b/imagetest/test_suites/storage_perf/setup.go
@@ -17,7 +17,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	hyperdiskParams := map[string]string{"machineType": "c3-standard-88"}
 	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName, Type: imagetest.PdBalanced, SizeGb: bootdiskSize},
-		{Name: mountDiskName, Type: imagetest.HyperdiskExtreme, SizeGb: hyperdiskSize}}, hyperdiskParams )
+		{Name: mountDiskName, Type: imagetest.HyperdiskExtreme, SizeGb: hyperdiskSize}}, hyperdiskParams)
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/storage_perf/setup.go
+++ b/imagetest/test_suites/storage_perf/setup.go
@@ -15,8 +15,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if bootdiskSize == hyperdiskSize {
 		return fmt.Errorf("boot disk and mount disk must be different sizes for disk identification")
 	}
+	hyperdiskParams := map[string]string{"machineType": "c3-standard-88"}
 	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName, Type: imagetest.PdBalanced, SizeGb: bootdiskSize},
-		{Name: mountDiskName, Type: imagetest.HyperdiskExtreme, SizeGb: hyperdiskSize}})
+		{Name: mountDiskName, Type: imagetest.HyperdiskExtreme, SizeGb: hyperdiskSize}}, hyperdiskParams )
 	if err != nil {
 		return err
 	}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -73,7 +73,7 @@ type TestWorkflow struct {
 	lockProject bool
 }
 
-func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, hostname string) (*daisy.Step, *daisy.Instance, error) {
+func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams map[string]string) (*daisy.Step, *daisy.Instance, error) {
 	if len(disks) == 0 || disks[0].Name == "" {
 		return nil, nil, fmt.Errorf("failed to create VM from empty boot disk")
 	}
@@ -89,9 +89,18 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, hostname string
 	instance.StartupScript = fmt.Sprintf("wrapper%s", suffix)
 	instance.Name = name
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
+	hostname, foundKey := instanceParams["hostname"]
+	if !foundKey {
+	  hostname = ""
+	}
 	if hostname != "" && name != hostname {
 		instance.Hostname = hostname
 	}
+
+  if machineType, foundKey := instanceParams["machineType"]; foundKey {
+    instance.MachineType = machineType
+  }
+
 
 	for _, disk := range disks {
 		instance.Disks = append(instance.Disks, &compute.AttachedDisk{Source: disk.Name})

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -91,16 +91,15 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
 	hostname, foundKey := instanceParams["hostname"]
 	if !foundKey {
-	  hostname = ""
+		hostname = ""
 	}
 	if hostname != "" && name != hostname {
 		instance.Hostname = hostname
 	}
 
-  if machineType, foundKey := instanceParams["machineType"]; foundKey {
-    instance.MachineType = machineType
-  }
-
+	if machineType, foundKey := instanceParams["machineType"]; foundKey {
+		instance.MachineType = machineType
+	}
 
 	for _, disk := range disks {
 		instance.Disks = append(instance.Disks, &compute.AttachedDisk{Source: disk.Name})

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -195,7 +195,8 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}}, "")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}},
+	  map[string]string{"hostname": ""})
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -213,7 +214,8 @@ func TestAppendCreateVMStep(t *testing.T) {
 	if !ok || step != stepFromWF {
 		t.Error("step was not correctly added to workflow")
 	}
-	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname2"}}, "")
+	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname2"}},
+	  map[string]string{"hostname": ""})
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -241,7 +243,8 @@ func TestAppendCreateVMStepMultipleDisks(t *testing.T) {
 		t.Fatal("create-disks step already exists")
 	}
 	step, instanceFromStep, err := twf.appendCreateVMStep([]*compute.Disk{
-		{Name: "vmname"}, {Name: "mountdiskname", Type: PdBalanced}}, "")
+		{Name: "vmname"}, {Name: "mountdiskname", Type: PdBalanced}},
+		map[string]string{"hostname": "", "machineType": "n1-standard-1"})
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -275,7 +278,8 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 	if _, ok := twf.wf.Steps["create-disks"]; ok {
 		t.Fatal("create-disks step already exists")
 	}
-	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}}, "vmname.example.com")
+	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}},
+	  map[string]string{"hostname": "vmname.example.com"})
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -196,7 +196,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 		t.Fatal("create-disks step already exists")
 	}
 	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}},
-	  map[string]string{"hostname": ""})
+		map[string]string{"hostname": ""})
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 		t.Error("step was not correctly added to workflow")
 	}
 	step2, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname2"}},
-	  map[string]string{"hostname": ""})
+		map[string]string{"hostname": ""})
 	if err != nil {
 		t.Fatalf("failed to add wait step to test workflow: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 		t.Fatal("create-disks step already exists")
 	}
 	step, _, err := twf.appendCreateVMStep([]*compute.Disk{{Name: "vmname"}},
-	  map[string]string{"hostname": "vmname.example.com"})
+		map[string]string{"hostname": "vmname.example.com"})
 	if err != nil {
 		t.Errorf("failed to add wait step to test workflow: %v", err)
 	}


### PR DESCRIPTION
Instead of passing the c3 machine type in the command line, make the tests able to pass in the machine type, such as for the hyperdisk test.