### PR TITLE
Add IsWindows to test utils

### DIFF
--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -291,10 +291,7 @@ func Skip32BitWindows(t *testing.T, skipMsg string) {
 
 // IsWindows returns true if the detected runtime environment is Windows.
 func IsWindows() bool {
-	if runtime.GOOS == "windows" {
-		return true
-	}
-	return false
+	return runtime.GOOS == "windows"
 }
 
 // IsWindowsClient returns true if the image is a client (non-server) Windows image.

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -289,6 +289,14 @@ func Skip32BitWindows(t *testing.T, skipMsg string) {
 	}
 }
 
+// IsWindows returns true if the detected runtime environment is Windows.
+func IsWindows() bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return false
+}
+
 // IsWindowsClient returns true if the image is a client (non-server) Windows image.
 func IsWindowsClient(image string) bool {
 	for _, pattern := range windowsClientImagePatterns {


### PR DESCRIPTION
Simplifies having to import and run runtime.GOOS in every test suite targeting windows and linux.