### PR TITLE
Expand secure boot test to cover supported images on ARM

### DIFF
--- a/imagetest/test_suites/imageboot/image_boot_test.go
+++ b/imagetest/test_suites/imageboot/image_boot_test.go
@@ -222,14 +222,6 @@ func TestGuestSecureBoot(t *testing.T) {
 			t.Fatalf("SecureBoot test failed with: %v", err)
 		}
 	} else {
-		image, err := utils.GetMetadata("image")
-		if err != nil {
-			t.Fatalf("couldn't get image from metadata")
-		}
-		if strings.Contains(image, "debian-9") {
-			t.Skip("secure boot is not supported on Debian 9")
-		}
-
 		if err := testLinuxGuestSecureBoot(); err != nil {
 			t.Fatalf("SecureBoot test failed with: %v", err)
 		}

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -19,8 +19,8 @@ var sbUnsupported = []*regexp.Regexp{
 	regexp.MustCompile("debian-12.*arm64"),
 	// Waiting on MSFT signed shims:
 	regexp.MustCompile("rocky-linux-[89].*arm64"), // https://bugs.rockylinux.org/view.php?id=4027
-	regexp.MustCompile("rhel-9.*arm64"), // https://bugzilla.redhat.com/show_bug.cgi?id=2103803
-	regexp.MustCompile("sles-15.*arm64"), // https://bugzilla.suse.com/show_bug.cgi?id=1214761
+	regexp.MustCompile("rhel-9.*arm64"),           // https://bugzilla.redhat.com/show_bug.cgi?id=2103803
+	regexp.MustCompile("sles-15.*arm64"),          // https://bugzilla.suse.com/show_bug.cgi?id=1214761
 }
 
 // TestSetup sets up the test workflow.

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -15,7 +15,7 @@ var sbUnsupported = []*regexp.Regexp{
 	// Permanent exceptions
 	regexp.MustCompile("debian-9"),
 	regexp.MustCompile("debian-1[01].*arm64"),
-	regexp.MustCompile("windows-server-2012-r2-dc-core"),
+	regexp.MustCompile("windows-server-2012-r2-dc-core"), // Working but not easily testable and EOL in 1.5 months
 	// Temporary exceptions
 	regexp.MustCompile("debian-12.*arm64"),
 	// Waiting on MSFT signed shims:
@@ -41,18 +41,23 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	vm2.RunTests("TestGuestRebootOnHost")
 
-	for _, r := range sbUnsupported {
-		if r.MatchString(t.Image) {
-			return nil
-		}
-	}
-
 	vm3, err := t.CreateTestVM("vm3")
 	if err != nil {
 		return err
 	}
 	vm3.AddMetadata("start-time", strconv.Itoa(time.Now().Second()))
-	vm3.EnableSecureBoot()
-	vm3.RunTests("TestGuestSecureBoot|TestStartTime|TestBootTime")
+	vm3.RunTests("TestStartTime|TestBootTime")
+
+	for _, r := range sbUnsupported {
+		if r.MatchString(t.Image) {
+			return nil
+		}
+	}
+	vm4, err := t.CreateTestVM("vm4")
+	if err != nil {
+		return err
+	}
+	vm4.EnableSecureBoot()
+	vm4.RunTests("TestGuestSecureBoot")
 	return nil
 }

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -13,7 +13,6 @@ var Name = "imageboot"
 
 var sbUnsupported = []*regexp.Regexp{
 	// Permanent exceptions
-	regexp.MustCompile("debian-9"),
 	regexp.MustCompile("debian-1[01].*arm64"),
 	regexp.MustCompile("windows-server-2012-r2-dc-core"), // Working but not easily testable and EOL in 1.5 months
 	// Temporary exceptions


### PR DESCRIPTION
Reasons for exceptions to this test:

Debian 10 & 11 don't support secure boot on ARM.

Debian 12 supports secure boot on ARM and is currently working but it it's not enabled with the FAI build infra we're using for cloud images. Waiting to hear from Debian on whether they'll enable it upstream, otherwise we will do it and remove the exception.

Windows server 2012 core is working but difficult to test because the powershell secureboot cmdlet for checking if secure boot is enabled is not included by design on server core. It's EOL in less than 2 months anyway.

Rocky, RHEL, and SLES don't have signed shims for ARM. I've included a link to a ticket for tracking in the comments.