### PR TITLE
Create sql test suite

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/networkperf"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/oslogin"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/security"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/sql"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/ssh"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/storageperf"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/windows"
@@ -147,6 +148,10 @@ func main() {
 		{
 			ssh.Name,
 			ssh.TestSetup,
+		},
+		{
+			sql.Name,
+			sql.TestSetup,
 		},
 		{
 			metadata.Name,

--- a/imagetest/test_suites/sql/setup.go
+++ b/imagetest/test_suites/sql/setup.go
@@ -1,0 +1,19 @@
+package sql
+
+import (
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+)
+
+// Name is the name of the test package. It must match the directory name.
+var Name = "sql"
+
+// TestSetup sets up the test workflow.
+func TestSetup(t *imagetest.TestWorkflow) error {
+	vm, err := t.CreateTestVM("vm")
+	if err != nil {
+		return err
+	}
+	vm.RunTests("TestSqlVersion")
+
+	return nil
+}

--- a/imagetest/test_suites/sql/sql_test.go
+++ b/imagetest/test_suites/sql/sql_test.go
@@ -25,7 +25,6 @@ func TestSqlVersion(t *testing.T) {
 	}
 
 	imageNameSplit := strings.Split(imageName, "-")
-	fmt.Print(imageNameSplit)
 	sqlExpectedVer := imageNameSplit[1]
 	sqlExpectedEdition := imageNameSplit[2]
 	serverExpectedVer := imageNameSplit[4]

--- a/imagetest/test_suites/sql/sql_test.go
+++ b/imagetest/test_suites/sql/sql_test.go
@@ -1,0 +1,54 @@
+//go:build cit
+// +build cit
+
+package sql
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
+func TestSqlVersion(t *testing.T) {
+	utils.WindowsOnly(t)
+
+	image, err := utils.GetMetadata("image")
+	if err != nil {
+		t.Fatal("Failed to get image metadata")
+	}
+
+	imageName, err := utils.ExtractBaseImageName(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imageNameSplit := strings.Split(imageName, "-")
+	fmt.Print(imageNameSplit)
+	sqlExpectedVer := imageNameSplit[1]
+	sqlExpectedEdition := imageNameSplit[2]
+	serverExpectedVer := imageNameSplit[4]
+
+	command := fmt.Sprintf("Sqlcmd -Q \"select @@version\"")
+	output, err := utils.RunPowershellCmd(command)
+	if err != nil {
+		t.Fatalf("Unable to query SQL Server version: %v", err)
+	}
+
+	sqlOutput := strings.ToLower(strings.TrimSpace(output.Stdout))
+
+	if !strings.Contains(sqlOutput, sqlExpectedEdition) {
+		t.Fatalf("Installed SQL Server edition does not match image edition: %s not found in %s", sqlExpectedEdition, sqlOutput)
+	}
+
+	sqlVerString := "microsoft sql server " + sqlExpectedVer
+	if !strings.Contains(sqlOutput, sqlVerString) {
+		t.Fatalf("Installed SQL Server version does not match image version: %s not found in %s", sqlVerString, sqlOutput)
+	}
+
+	serverVerString := "on windows server " + serverExpectedVer
+	if !strings.Contains(sqlOutput, serverVerString) {
+		t.Fatalf("Installed Windows Server version does not match image version: %s not found in %s", serverVerString, sqlOutput)
+	}
+}


### PR DESCRIPTION
Initial commit of basic sql version testing.  Verifies 3 test cases:

1. Installed Sql Server edition matches the image (i.e. Web/Standard/Entierprise)
2. Installed Sql Server version matches the image (i.e. Sql Server 2022)
3. Installed Windows Server version matches the image (i.e. Windows Server 2022)