### PR TITLE
Update networkperf test suite to support windows images

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -236,6 +236,11 @@ func (t *TestVM) SetStartupScript(script string) {
 	t.AddMetadata("startup-script", script)
 }
 
+// SetWindowsStartupScript sets the `windows-startup-script-ps1` metadata key for a VM.
+func (t *TestVM) SetWindowsStartupScript(script string) {
+	t.AddMetadata("windows-startup-script-ps1", script)
+}
+
 // SetNetworkPerformanceTier sets the performance tier of the VM.
 // The tier must be one of "DEFAULT" or "TIER_1"
 func (t *TestVM) SetNetworkPerformanceTier(tier string) error {

--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -5,7 +5,6 @@ package networkperf
 
 import (
 	"encoding/json"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,45 +18,43 @@ func TestEmpty(t *testing.T) {
 
 func TestNetworkPerformance(t *testing.T) {
 	// Check performance of the driver.
-	if runtime.GOOS != "windows" {
-		results, err := utils.GetMetadataGuestAttribute("testing/results")
-		if err != nil {
-			t.Fatalf("Error : %v", err)
-		}
-
-		// Get the performance target.
-		var targetMap map[string]int
-		targetMapString, err := utils.GetMetadataAttribute("perfmap")
-		if err != nil {
-			t.Fatalf("Error: %v", err)
-		}
-		if err := json.Unmarshal([]byte(targetMapString), &targetMap); err != nil {
-			t.Fatalf("Error: %v", err)
-		}
-		machineType, err := utils.GetMetadata("machine-type")
-		if err != nil {
-			t.Fatalf("Error: %v", err)
-		}
-		machineTypeSplit := strings.Split(machineType, "/")
-		machineTypeName := machineTypeSplit[len(machineTypeSplit)-1]
-		target, found := targetMap[machineTypeName]
-		if !found {
-			t.Logf("%v not supported in this test", machineTypeName)
-			return
-		}
-
-		// Find actual performance..
-		var result_perf float64
-		resultArray := strings.Split(results, " ")
-		result_perf, err = strconv.ParseFloat(resultArray[5], 64)
-		if err != nil {
-			t.Fatalf("Error: %v", err)
-		}
-
-		// Check if it matches the target.
-		if result_perf < 0.85*float64(target) {
-			t.Fatalf("Error: Did not meet performance expectation. Expected: %v Gbits/s, Actual: %v Gbits/s", 0.85*float64(target), result_perf)
-		}
-		t.Logf("Machine type: %v, Expected: %v Gbits/s, Actual: %v Gbits/s", machineTypeName, target, result_perf)
+	results, err := utils.GetMetadataGuestAttribute("testing/results")
+	if err != nil {
+		t.Fatalf("Error : Test results not found. %v", err)
 	}
+
+	// Get the performance target.
+	var targetMap map[string]int
+	targetMapString, err := utils.GetMetadataAttribute("perfmap")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	if err := json.Unmarshal([]byte(targetMapString), &targetMap); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	machineType, err := utils.GetMetadata("machine-type")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	machineTypeSplit := strings.Split(machineType, "/")
+	machineTypeName := machineTypeSplit[len(machineTypeSplit)-1]
+	target, found := targetMap[machineTypeName]
+	if !found {
+		t.Logf("%v not supported in this test", machineTypeName)
+		return
+	}
+
+	// Find actual performance..
+	var result_perf float64
+	resultArray := strings.Split(results, " ")
+	result_perf, err = strconv.ParseFloat(resultArray[5], 64)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	// Check if it matches the target.
+	if result_perf < 0.85*float64(target) {
+		t.Fatalf("Error: Did not meet performance expectation. Expected: %v Gbits/s, Actual: %v Gbits/s", 0.85*float64(target), result_perf)
+	}
+	t.Logf("Machine type: %v, Expected: %v Gbits/s, Actual: %v Gbits/s", machineTypeName, target, result_perf)
 }

--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
-func TestEmpty(t *testing.T) {
-	t.Logf("Empty test")
-}
-
 func TestNetworkPerformance(t *testing.T) {
 	// Check performance of the driver.
 	results, err := utils.GetMetadataGuestAttribute("testing/results")

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -79,7 +79,6 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-
 	// Default VMs.
 	serverVM, err := t.CreateTestVM(serverConfig.name)
 	if err != nil {

--- a/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
@@ -1,0 +1,20 @@
+$iperfurl="https://iperf.fr/download/windows/iperf-2.0.9-win64.zip"
+$metadata="http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/testing/results"
+$iperfzippath="iperf.zip"
+$zipdir="C:\iperf"
+$exepath="C:\iperf\iperf-2.0.9-win64/"
+$outfile="iperfoutput.txt"
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$iperftarget=Invoke-RestMethod -Uri "http://metadata.google.internal/computeMetadata/v1/instance/attributes/iperftarget" -Header @{"Metadata-Flavor" = "Google"} -UseBasicParsing
+
+Invoke-WebRequest -Uri $iperfurl -OutFile $iperfzippath
+Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
+New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
+
+cd $exepath
+Start-Sleep -s 15
+
+# Perform the test, and upload results.
+./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile
+(Get-Content -Path $outfile | Select-String -Pattern 'SUM') -replace "\s+"," " | Invoke-RestMethod -Method "Put" -Uri $metadata -Header @{"Metadata-Flavor" = "Google"} -ContentType "application/json; charset=utf-8" -UseBasicParsing

--- a/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
@@ -7,13 +7,12 @@ $outfile="iperfoutput.txt"
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $iperftarget=Invoke-RestMethod -Uri "http://metadata.google.internal/computeMetadata/v1/instance/attributes/iperftarget" -Header @{"Metadata-Flavor" = "Google"} -UseBasicParsing
-
 Invoke-WebRequest -Uri $iperfurl -OutFile $iperfzippath
 Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
 New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
 
 cd $exepath
-Start-Sleep -s 15
+Start-Sleep -s 5 # Wait for the server to start up.
 
 # Perform the test, and upload results.
 ./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile

--- a/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
@@ -1,0 +1,14 @@
+$iperfurl="https://iperf.fr/download/windows/iperf-2.0.9-win64.zip"
+$iperfzippath="iperf.zip"
+$zipdir="C:\iperf"
+$exepath="C:\iperf\iperf-2.0.9-win64"
+$timeout=60
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $iperfurl -OutFile $iperfzippath
+Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
+
+New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
+
+cd $exepath
+./iperf -s -P 16 -t $timeout

--- a/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
@@ -7,7 +7,6 @@ $timeout=60
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest -Uri $iperfurl -OutFile $iperfzippath
 Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
-
 New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
 
 cd $exepath


### PR DESCRIPTION
It's weird how the network performance test results don't reach anywhere close to the targets, especially in the non-Tier1 network tests (specifically for Windows)