### PR TITLE
Skip arm images in CVM testing

### DIFF
--- a/imagetest/test_suites/cvm/setup.go
+++ b/imagetest/test_suites/cvm/setup.go
@@ -14,6 +14,9 @@ const vmName = "vm"
 
 // TestSetup sets up test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
+	if strings.Contains(t.Image, "arm64") || strings.Contains(t.Image, "aarch64") {
+		t.Skip("CVM is not supported on arm")
+	}
 	if strings.Contains(t.Image, "windows") || strings.Contains(t.Image, "rhel-7") || strings.Contains(t.Image, "centos-7") || strings.Contains(t.Image, "debian-10") {
 		t.Skip(fmt.Sprintf("%v does not support CVM", t.Image))
 	}


### PR DESCRIPTION
This is an x86 only feature.