### PR TITLE
Skip the c3d family during storageperf testing on windows 2012 and 2016

### DIFF
--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -37,6 +37,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		if machineTypeParam, foundKey := paramMap["machineType"]; foundKey {
 			machineType = machineTypeParam
 		}
+		if strings.HasPrefix(machineType, "c3d") && (strings.Contains(t.Image, "windows-2012") || strings.Contains(t.Image, "windows-2016")) {
+			continue
+		}
 		bootDisk := compute.Disk{Name: vmName + machineType, Type: imagetest.PdBalanced, SizeGb: bootdiskSizeGB}
 		mountDisk := compute.Disk{Name: mountDiskName + machineType, Type: imagetest.HyperdiskExtreme, SizeGb: hyperdiskSizeGB}
 		bootDisk.Zone = paramMap["zone"]


### PR DESCRIPTION
Timing out on testgrid: https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics-performance

Not 100% sure I skipped this correctly, lmk if this is a problem.