### PR TITLE
Add CIT presubmit container

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -121,6 +121,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
     BuildContainerImage('jsonnet-go'),
     BuildContainerImage('fly-validate-pipelines') { passed: 'build-jsonnet-go' },
     BuildContainerImage('pytest'),
+    BuildContainerImage('citpresubmit'),
 
     // Non-standard dockerfile location and public image.
     BuildContainerImage('registry-image-forked') {

--- a/container_images/citpresubmit/Dockerfile
+++ b/container_images/citpresubmit/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:bullseye
+
+RUN apt-get update && apt-get install -y git && \
+    rm -rf /var/cache/apt/archives
+
+# Copy this Dockerfile for debugging.
+COPY Dockerfile Dockerfile
+COPY main.sh main.sh
+ENTRYPOINT ["./main.sh"]

--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+BUILD_DIR=$1
+[[ -n $BUILD_DIR ]] && cd $BUILD_DIR/imagetest
+
+RET=0
+
+GOARCH=amd64
+GOOS=linux
+CGO_ENABLED=0
+GO111MODULE=on
+go mod download || RET=$?
+
+go vet --structtag=false ./... || RET=$?
+
+# Test the testworkflow package and generate code coverage
+go test -v -coverprofile=/tmp/coverage.out . >${ARTIFACTS}/go-test.txt || RET=$?
+go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
+cat ${ARTIFACTS}/go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
+
+# Build wrapper for all necessary architectures
+go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
+GOARCH=arm64 go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
+GOOS=windows go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
+GOOS=windows GOARCH=386 go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
+
+# Manager is only built for amd64 linux
+go build -o /dev/null ./cmd/manager/main.go
+
+for suite in test_suites/*; do
+  [[ -d $suite ]] || continue
+  go test -C $suite -c -o /dev/null -tags cit || RET=$?
+  GOARCH=arm64 go test -C $suite -c -o /dev/null -tags cit || RET=$?
+  GOOS=windows go test -C $suite -c -o /dev/null -tags cit || RET=$?
+  GOOS=windows GOARCH=386 go test -C $suite -c -o /dev/null -tags cit || RET=$?
+done
+
+exit $RET


### PR DESCRIPTION
There are multiple things wrong with the way presubmits are running on CIT:

1) The globbing on the go cli is package globbing not file globbing, so it doesn't pick up the imagetest folder in gobuild because it has it's own go.mod file

2) Even if it did run the logic in those cases it wouldn't make a lot of sense because the "test code" in CIT isn't really test code in the usual sense so running `go test` on it is incorrect, it just needs to build instead of pass

3) The test code that is typical test code (testworkflow_test.go, etc). isn't being run during gotest because of issue 1.

The only thing that does get picked up is gofmt, because that uses `find . -name *.go` to select files instead of the go cli globbing.