### PR TITLE
Fix json unmarshal error

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -261,7 +261,7 @@ func (t *TestVM) SetWindowsStartupScript(script string) {
 // SetNetworkPerformanceTier sets the performance tier of the VM.
 // The tier must be one of "DEFAULT" or "TIER_1"
 func (t *TestVM) SetNetworkPerformanceTier(tier string) error {
-	if tier != "DEFAULT" || tier != "TIER_1" {
+	if tier != "DEFAULT" && tier != "TIER_1" {
 		return fmt.Errorf("Error: %v not one of DEFAULT or TIER_1", tier)
 	}
 	if t.instance.NetworkPerformanceConfig == nil {

--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -32,7 +32,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		// {"machineType": "c3d-standard-180", "zone": "us-east4-c", "diskType": imagetest.HyperdiskExtreme},
 		{"machineType": "n2-standard-80", "diskType": imagetest.HyperdiskExtreme},
 		{"machineType": "c3-standard-88", "diskType": imagetest.PdBalanced},
-		// {"machineType": "c3d-standard-180", "zone": "us-east4-c", "diskType": imagetest.PdBalanced},
+		{"machineType": "c3d-standard-180", "zone": "us-east4-c", "diskType": imagetest.PdBalanced},
 	}
 	testVMs := []*imagetest.TestVM{}
 	for _, paramMap := range paramMaps {
@@ -45,9 +45,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		if diskTypeParam, foundKey := paramMap["diskType"]; foundKey {
 			diskType = diskTypeParam
 		}
-		//if strings.HasPrefix(machineType, "c3d") && (strings.Contains(t.Image, "windows-2012") || strings.Contains(t.Image, "windows-2016")) {
-		//	continue
-		//}
+		if strings.HasPrefix(machineType, "c3d") && (strings.Contains(t.Image, "windows-2012") || strings.Contains(t.Image, "windows-2016")) {
+			continue
+		}
 		bootDisk := compute.Disk{Name: vmName + machineType + diskType, Type: imagetest.PdBalanced, SizeGb: bootdiskSizeGB}
 		mountDisk := compute.Disk{Name: mountDiskName + machineType + diskType, Type: diskType, SizeGb: mountdiskSizeGB}
 		bootDisk.Zone = paramMap["zone"]

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -436,7 +436,7 @@ func GetMountDiskPartition(diskExpectedSizeGB int) (string, error) {
 				return blkname, nil
 			}
 		}
-		return "", fmt.Errorf("failed to find disk partition with expected size %s", diskExpectedSizeBytes)
+		return "", fmt.Errorf("failed to find disk partition with expected size %d", diskExpectedSizeBytes)
 	}
 
 	var blockDevices BlockDeviceList

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -447,7 +447,7 @@ func GetMountDiskPartition(diskExpectedSizeGB int) (string, error) {
 		// deal with the case where the unmarshalled size field can be a number with or without quotes on different operating systems.
 		blockDevSizeInt, err := blockDev.Size.Int64()
 		if err != nil {
-			return "", fmt.Errorf("block dev size %v was not an int: error %v", blockDev.Size, err)
+			return "", fmt.Errorf("block dev size %s was not an int: error %v", blockDev.Size.String(), err)
 		}
 		if strings.ToLower(blockDev.Type) == diskType && blockDevSizeInt == diskExpectedSizeBytes {
 			return blockDev.Name, nil

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -43,8 +43,10 @@ type BlockDeviceList struct {
 // BlockDevice defines information about a single partition or disk in the output of lsblk.
 type BlockDevice struct {
 	Name string `json:"name,omitempty"`
-	Size int64  `json:"size,omitempty"`
-	Type string `json:"type,omitempty"`
+	// on some OSes, size is a string, and on some OSes, size is a number.
+	// This allows both to be parsed
+	Size json.Number `json:"size,omitempty"`
+	Type string      `json:"type,omitempty"`
 	// Other fields are not currently used.
 	X map[string]interface{} `json:"-"`
 }
@@ -439,10 +441,15 @@ func GetMountDiskPartition(diskExpectedSizeGB int) (string, error) {
 
 	var blockDevices BlockDeviceList
 	if err := json.Unmarshal(lsblkout, &blockDevices); err != nil {
-		return "", fmt.Errorf("failed to unmarshal lsblk output with error: %v", err)
+		return "", fmt.Errorf("failed to unmarshal lsblk output %s with error: %v", lsblkout, err)
 	}
 	for _, blockDev := range blockDevices.BlockDevices {
-		if strings.ToLower(blockDev.Type) == diskType && blockDev.Size == diskExpectedSizeBytes {
+		// deal with the case where the unmarshalled size field can be a number with or without quotes on different operating systems.
+		blockDevSizeInt, err := blockDev.Size.Int64()
+		if err != nil {
+			return "", fmt.Errorf("block dev size %v was not an int: error %v", blockDev.Size, err)
+		}
+		if strings.ToLower(blockDev.Type) == diskType && blockDevSizeInt == diskExpectedSizeBytes {
 			return blockDev.Name, nil
 		}
 	}


### PR DESCRIPTION
On some operating systems such as centos-stream-8 and rhel-7, the lsblk json size field is enclosed in quotes, making it a string.

On other operating systems, it can be directly parsed as an int64 number.

This change allows both cases to be handled.