### PR TITLE
Install all dependencies for dockerfile

### DIFF
--- a/container_images/citpresubmit/Dockerfile
+++ b/container_images/citpresubmit/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 FROM golang:bullseye
 
-RUN apt-get update && apt-get install -y git && \
+RUN apt-get update && apt-get install -y bash ca-certificates curl git libssl-dev wget && \
     rm -rf /var/cache/apt/archives
 
 # Go test junit xml output


### PR DESCRIPTION
Make the citpresubmit Dockerfile match the one for gotest, in case some dependency prevents go-junit-report from being installed