### PR TITLE
Update OSLogin Tests.

### DIFF
--- a/imagetest/test_suites/README.md
+++ b/imagetest/test_suites/README.md
@@ -252,6 +252,7 @@ Linux (same as the `ip` command).
 ### Test suite: networkperf ###
 
 #### TestNetworkPerformance ####
+
 Validate the network performance of an image reaches at least 85% of advertised
 speeds.
 

--- a/imagetest/test_suites/README.md
+++ b/imagetest/test_suites/README.md
@@ -252,7 +252,6 @@ Linux (same as the `ip` command).
 ### Test suite: networkperf ###
 
 #### TestNetworkPerformance ####
-
 Validate the network performance of an image reaches at least 85% of advertised
 speeds.
 


### PR DESCRIPTION
Also move away from the deprecated `ioutil` library, using `os` package's `ReadFile` instead.