### PR TITLE
Fix existing presubmit failures that slipped through the presubmit gap.

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -261,7 +261,7 @@ func (t *TestVM) SetWindowsStartupScript(script string) {
 // SetNetworkPerformanceTier sets the performance tier of the VM.
 // The tier must be one of "DEFAULT" or "TIER_1"
 func (t *TestVM) SetNetworkPerformanceTier(tier string) error {
-	if tier != "DEFAULT" || tier != "TIER_1" {
+	if tier != "DEFAULT" && tier != "TIER_1" {
 		return fmt.Errorf("Error: %v not one of DEFAULT or TIER_1", tier)
 	}
 	if t.instance.NetworkPerformanceConfig == nil {

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -434,7 +434,7 @@ func GetMountDiskPartition(diskExpectedSizeGB int) (string, error) {
 				return blkname, nil
 			}
 		}
-		return "", fmt.Errorf("failed to find disk partition with expected size %s", diskExpectedSizeBytes)
+		return "", fmt.Errorf("failed to find disk partition with expected size %d", diskExpectedSizeBytes)
 	}
 
 	var blockDevices BlockDeviceList


### PR DESCRIPTION
A format string in test_utils.go was using the wrong formatter for an int64

A check for networking tier in fixtures.go always returns true. I changed it to be in line with what the log message implies.