### PR TITLE
Fix el7 disk partition condition

### DIFF
--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -426,11 +426,11 @@ func GetMountDiskPartition(diskExpectedSizeGB int) (string, error) {
 			if len(linetokens) != 3 {
 				continue
 			}
-			// we should have a slice of length 3, with fields name, size, type
+			// we should have a slice of length 3, with fields name, size, type. Search for the line with the partition of the correct size.
 			var blkname, blksize, blktype = linetokens[0], linetokens[1], linetokens[2]
 			blksizeInt, err := strconv.ParseInt(blksize, 10, 64)
 			if err != nil {
-				return "", fmt.Errorf("did not find int in output of lsblk: string %s error %v", blksize, err)
+				continue
 			}
 			if blktype == diskType && blksizeInt == diskExpectedSizeBytes {
 				return blkname, nil


### PR DESCRIPTION
On el7, there was a bug where lsblk parsing would cause an error.

This fix ensures that we only need to find one line with the correct disk partition size. The lsblk output has lines which we know are not the correct partition, such as the title line. For those lines, we want to keep parsing until we find the correct line, instead of returning an error.