### PR TITLE
Windows write test fix

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -21,7 +21,6 @@ const (
 )
 
 func RunFIOReadWindows(mode string) ([]byte, error) {
-	//testdiskDrive := windowsDriveLetter + ":\\"
 	readIopsFile := "C:\\fio-read-iops.txt"
 	var readOptions string
 	if mode == sequentialMode {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -21,7 +21,6 @@ const (
 )
 
 func RunFIOWriteWindows(mode string) ([]byte, error) {
-	//testdiskDrive := windowsDriveLetter + ":\\"
 	writeIopsFile := "C:\\fio-write-iops.txt"
 	var writeOptions string
 	if mode == sequentialMode {

--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -78,7 +78,6 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		vm.AddMetadata(seqReadAttribute, fmt.Sprintf("%f", vmPerformanceTargets.seqReadBW))
 		vm.AddMetadata(seqWriteAttribute, fmt.Sprintf("%f", vmPerformanceTargets.seqWriteBW))
 		if strings.Contains(t.Image, "windows") {
-			vm.AddMetadata("windowsDriveLetter", windowsDriveLetter)
 			windowsStartup, err := scripts.ReadFile(windowsInstallFioScriptURL)
 			if err != nil {
 				return err

--- a/imagetest/test_suites/storageperf/startupscripts/install_fio.ps1
+++ b/imagetest/test_suites/storageperf/startupscripts/install_fio.ps1
@@ -1,9 +1,1 @@
 gsutil cp gs://gce-image-build-resources/windows/fio.exe 'C:\\fio.exe'
-try {
-	$windowsDriveLetter = (Invoke-RestMethod -Headers @{'Metadata-Flavor' = 'Google'} -Uri "http://metadata.google.internal/computeMetadata/v1/instance/attributes/windowsDriveLetter")
-	Initialize-Disk -PartitionStyle GPT -Number 1 -PassThru | New-Partition -DriveLetter $windowsDriveLetter -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel 'Perf-Test' -Confirm:$false
-}
-catch {
-	Write-Output "failed to initialize disk"
-	Write-Output $_
-}

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -27,7 +27,6 @@ const (
 	fioWindowsGCS = "gs://gce-image-build-resources/windows/fio.exe"
 	// The local path on the test VM where fio is stored.
 	fioWindowsLocalPath = "C:\\fio.exe"
-	windowsDriveLetter  = "F"
 	// constants for the mode of running the test
 	randomMode     = "random"
 	sequentialMode = "sequential"


### PR DESCRIPTION
Do not initialize the mount disk on windows. This fixes the fio write permissions issue.