### PR TITLE
Pass down machine types through TestWorkflow

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -241,7 +241,7 @@ func main() {
 			}
 
 			log.Printf("Add test workflow for test %s on image %s", testPackage.name, image)
-			test, err := imagetest.NewTestWorkflow(testPackage.name, image, *timeout)
+			test, err := imagetest.NewTestWorkflow(testPackage.name, image, *timeout, *x86Shape, *arm64Shape)
 			if err != nil {
 				log.Fatalf("Failed to create test workflow: %v", err)
 			}
@@ -266,18 +266,18 @@ func main() {
 	}
 
 	if *printwf {
-		imagetest.PrintTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *x86Shape, *arm64Shape)
+		imagetest.PrintTests(ctx, client, testWorkflows, *project, *zone, *gcsPath)
 		return
 	}
 
 	if *validate {
-		if err := imagetest.ValidateTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *x86Shape, *arm64Shape); err != nil {
+		if err := imagetest.ValidateTests(ctx, client, testWorkflows, *project, *zone, *gcsPath); err != nil {
 			log.Printf("Validate failed: %v\n", err)
 		}
 		return
 	}
 
-	suites, err := imagetest.RunTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *x86Shape, *arm64Shape, *parallelCount, testProjectsReal)
+	suites, err := imagetest.RunTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *parallelCount, testProjectsReal)
 	if err != nil {
 		log.Fatalf("Failed to run tests: %v", err)
 	}

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -488,26 +488,11 @@ func (t *TestWorkflow) CreateNetwork(networkName string, autoCreateSubnetworks b
 	return &Network{networkName, t, network}, nil
 }
 
-// CreateNetworkWithMTU creates a custom network with the specified MTU.
-func (t *TestWorkflow) CreateNetworkWithMTU(networkName string, mtu int, autoCreateSubnetworks bool) (*Network, error) {
-	// Check if the MTU is a valid MTU.
-	if mtu != DefaultMTU && mtu != JumboFramesMTU {
-		return nil, fmt.Errorf("Invalid MTU: %v not one of [%v, %v]", mtu, DefaultMTU, JumboFramesMTU)
+// SetMTU sets the MTU of the network. The MTU must be between 1460 and 8896, inclusively.
+func (n *Network) SetMTU(mtu int) {
+	if mtu >= DefaultMTU && mtu <= JumboFramesMTU {
+		n.network.Mtu = int64(mtu)
 	}
-
-	createNetworkStep, network, err := t.appendCreateNetworkStep(networkName, mtu, autoCreateSubnetworks)
-	if err != nil {
-		return nil, err
-	}
-
-	createVMsStep, ok := t.wf.Steps[createVMsStepName]
-	if ok {
-		if err := t.wf.AddDependency(createVMsStep, createNetworkStep); err != nil {
-			return nil, err
-		}
-	}
-
-	return &Network{networkName, t, network}, nil
 }
 
 // CreateSubnetwork creates custom subnetwork. Using AddCustomNetwork method

--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -10,7 +10,7 @@ import (
 // TestAddMetadata tests that *TestVM.AddMetadata succeeds and that it
 // populates the instance.Metadata map.
 func TestAddMetadata(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestAddMetadata(t *testing.T) {
 // TestReboot tests that *TestVM.Reboot succeeds and that the appropriate stop
 // and new final wait steps are created in the workflow.
 func TestReboot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestReboot(t *testing.T) {
 // TestCreateVMMultipleDisks tests that after creating a VM with multiple disks,
 // the correct step dependencies are in place.
 func TestCreateVMMultipleDisks(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestCreateVMMultipleDisks(t *testing.T) {
 // TestRebootMultipleDisks creates a VM using multiple disks, and then runs
 // the same tests as TestReboot.
 func TestRebootMultipleDisks(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestRebootMultipleDisks(t *testing.T) {
 // that the appropriate resize and new final wait steps are created in the
 // workflow.
 func TestResizeDiskAndReboot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestResizeDiskAndReboot(t *testing.T) {
 // TestEnableSecureBoot tests that *TestVM.EnableSecureBoot succeeds and
 // populates the ShieldedInstanceConfig struct.
 func TestEnableSecureBoot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestEnableSecureBoot(t *testing.T) {
 // TestUseGVNIC tests that *TestVM.UseGVNIC succeeds and
 // populates the Network Interface with a NIC type of GVNIC.
 func TestUseGVNIC(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestUseGVNIC(t *testing.T) {
 // TestAddAliasIPRanges tests that *TestVM.AddAliasIPRanges succeeds and that
 // it fails if *TestVM.AddCustomNetwork hasn't been called first.
 func TestAddAliasIPRanges(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestAddAliasIPRanges(t *testing.T) {
 // TestSetCustomNetwork tests that *TestVM.AddCustomNetwork succeeds and that
 // it fails if testworkflow.CreateNetwork has not been called first.
 func TestSetCustomNetwork(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestSetCustomNetwork(t *testing.T) {
 // succeeds with a subnet argument and that it fails if
 // *Network.CreateSubnetwork has not been called first.
 func TestSetCustomNetworkAndSubnetwork(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestSetCustomNetworkAndSubnetwork(t *testing.T) {
 // TestAddSecondaryRange tests that AddSecondaryRange populates the
 // subnet.SecondaryIpRanges struct.
 func TestAddSecondaryRange(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestAddSecondaryRange(t *testing.T) {
 // TestCreateNetworkDependenciesReverse tests that the create-vms step depends
 // on the create-networks step if they are created in order.
 func TestCreateNetworkDependencies(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestCreateNetworkDependencies(t *testing.T) {
 // TestCreateNetworkDependenciesReverse tests that the create-vms step depends
 // on the create-networks step if they are created in reverse.
 func TestCreateNetworkDependenciesReverse(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestCreateNetworkDependenciesReverse(t *testing.T) {
 }
 
 func TestAddUser(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -441,7 +441,7 @@ func TestAddUser(t *testing.T) {
 }
 
 func TestForceMachineType(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -459,7 +459,7 @@ func TestForceMachineType(t *testing.T) {
 }
 
 func TestForceZone(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}

--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -4,7 +4,6 @@
 package networkperf
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,26 +19,23 @@ func TestNetworkPerformance(t *testing.T) {
 	}
 
 	// Get the performance target.
-	var targetMap map[string]int
-	targetMapString, err := utils.GetMetadataAttribute("perfmap")
+	expectedPerfString, err := utils.GetMetadataAttribute("expectedperf")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	if err := json.Unmarshal([]byte(targetMapString), &targetMap); err != nil {
+	expectedPerf, err := strconv.Atoi(expectedPerfString)
+	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
+	expected := 0.85 * float64(expectedPerf)
+
+	// Get machine type name for logging.
 	machineType, err := utils.GetMetadata("machine-type")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
 	machineTypeSplit := strings.Split(machineType, "/")
 	machineTypeName := machineTypeSplit[len(machineTypeSplit)-1]
-	target, found := targetMap[machineTypeName]
-	if !found {
-		t.Logf("%v not supported in this test", machineTypeName)
-		return
-	}
-	expected := 0.85 * float64(target)
 
 	// Find actual performance..
 	var result_perf float64

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -2,7 +2,9 @@ package networkperf
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
@@ -39,6 +41,36 @@ const (
 	tier1TargetsURL               = "targets/tier1_targets.txt"
 )
 
+// getExpectedPerf gets the expected performance of the given machine type. Since the targets map only contains breakpoints in vCPUs at which
+// each machine type's expected performance changes, find the highest breakpoint at which the expected performance would change, then return
+// the performance at said breakpoint.
+func getExpectedPerf(targetMap map[string]int, machineType string) (int, error) {
+	// Return if already at breakpoint.
+	perf, found := targetMap[machineType]
+	if found {
+		return perf, nil
+	}
+
+	machineTypeSplit := strings.Split(machineType, "-")
+	family := machineTypeSplit[0]
+	familyType := machineTypeSplit[1]
+	numCPUs, err := strconv.Atoi(machineTypeSplit[2])
+	fmt.Printf("Current cpu: %v", numCPUs)
+	if err != nil {
+		return 0, nil
+	}
+
+	// Decrement numCPUs until a breakpoint is found.
+	for !found {
+		numCPUs--
+		perf, found = targetMap[strings.Join([]string{family, familyType, fmt.Sprint(numCPUs)}, "-")]
+		if !found && numCPUs <= 1 {
+			return 0, fmt.Errorf("Error: appropriate perf target not found for %v", machineType)
+		}
+	}
+	return perf, nil
+}
+
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
 	if strings.Contains(t.Image, "debian-10") || strings.Contains(t.Image, "rhel-7-7-sap") || strings.Contains(t.Image, "rhel-8-1-sap") {
@@ -61,7 +93,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 
 	// Jumbo frames network.
-	jfNetwork, err := t.CreateNetworkWithMTU("jf-network", imagetest.JumboFramesMTU, false)
+	jfNetwork, err := t.CreateNetwork("jf-network", false)
 	if err != nil {
 		return err
 	}
@@ -72,16 +104,22 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err := jfNetwork.CreateFirewallRule("jf-allow-tcp", "tcp", []string{"5001"}, []string{"192.168.1.0/24"}); err != nil {
 		return err
 	}
+	jfNetwork.SetMTU(imagetest.JumboFramesMTU)
 
 	// Get the targets.
-	defaultPerfTargets, err := targets.ReadFile(targetsURL)
+	var defaultPerfTargets map[string]int
+	defaultPerfTargetsString, err := targets.ReadFile(targetsURL)
 	if err != nil {
 		return err
 	}
-	tier1PerfTargets, err := targets.ReadFile(tier1TargetsURL)
+	if err := json.Unmarshal(defaultPerfTargetsString, &defaultPerfTargets); err != nil {
+		return err
+	}
+	defaultPerfTargetInt, err := getExpectedPerf(defaultPerfTargets, t.ShortMachineType)
 	if err != nil {
 		return err
 	}
+	defaultPerfTarget := fmt.Sprint(defaultPerfTargetInt)
 
 	// Default VMs.
 	serverVM, err := t.CreateTestVM(serverConfig.name)
@@ -107,7 +145,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	clientVM.AddMetadata("enable-guest-attributes", "TRUE")
 	clientVM.AddMetadata("iperftarget", serverConfig.ip)
-	clientVM.AddMetadata("perfmap", string(defaultPerfTargets))
+	clientVM.AddMetadata("expectedperf", defaultPerfTarget)
 
 	// Jumbo frames VMs.
 	jfServerVM, err := t.CreateTestVM(jfServerConfig.name)
@@ -133,7 +171,87 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	jfClientVM.AddMetadata("enable-guest-attributes", "TRUE")
 	jfClientVM.AddMetadata("iperftarget", jfServerConfig.ip)
-	jfClientVM.AddMetadata("perfmap", string(defaultPerfTargets))
+	jfClientVM.AddMetadata("expectedperf", defaultPerfTarget)
+
+	// Set startup scripts.
+	var serverStartup string
+	var clientStartup string
+	if strings.Contains(t.Image, "windows") {
+		serverStartupByteArr, err := scripts.ReadFile(windowsServerStartupScriptURL)
+		if err != nil {
+			return err
+		}
+		clientStartupByteArr, err := scripts.ReadFile(windowsClientStartupScriptURL)
+		if err != nil {
+			return err
+		}
+		serverStartup := string(serverStartupByteArr)
+		clientStartup := string(clientStartupByteArr)
+
+		serverVM.SetWindowsStartupScript(serverStartup)
+		clientVM.SetWindowsStartupScript(clientStartup)
+		jfServerVM.SetWindowsStartupScript(serverStartup)
+		jfClientVM.SetWindowsStartupScript(clientStartup)
+	} else {
+		serverStartupByteArr, err := scripts.ReadFile(serverStartupScriptURL)
+		if err != nil {
+			return err
+		}
+		clientStartupByteArr, err := scripts.ReadFile(clientStartupScriptURL)
+		if err != nil {
+			return err
+		}
+		serverStartup := string(serverStartupByteArr)
+		clientStartup := string(clientStartupByteArr)
+
+		serverVM.SetStartupScript(serverStartup)
+		clientVM.SetStartupScript(clientStartup)
+		jfServerVM.SetStartupScript(serverStartup)
+		jfClientVM.SetStartupScript(clientStartup)
+	}
+	clientVM.UseGVNIC()
+	serverVM.UseGVNIC()
+	jfClientVM.UseGVNIC()
+	jfServerVM.UseGVNIC()
+
+	// Run default tests.
+	serverVM.RunTests("TestGVNICExists")
+	clientVM.RunTests("TestGVNICExists|TestNetworkPerformance")
+	jfServerVM.RunTests("TestGVNICExists")
+	jfClientVM.RunTests("TestGVNICExists|TestNetworkPerformance")
+
+	// Check if machine type is valid for tier1 testing.
+	mt := t.ShortMachineType
+	if !strings.Contains(mt, "n2") && !strings.Contains(mt, "c2") && !strings.Contains(mt, "c3") && !strings.Contains(mt, "m3") {
+		// Must be N2, N2D, C2, C2D, C3, C3D, or M3 machine types.
+		fmt.Printf("%v: Skipping tier1 tests - %v not supported\n", t.ShortImage, mt)
+		return nil
+	} else {
+		numCPUs, err := strconv.Atoi(strings.Split(mt, "-")[2])
+		if err != nil {
+			return err
+		}
+		if numCPUs < 30 {
+			// Must have at least 30 vCPUs.
+			fmt.Printf("%v: Skipping tier1 tests - not enough vCPUs (need at least 30, have %v)\n", t.ShortImage, numCPUs)
+			return nil
+		}
+	}
+
+	// Get Tier1 targets.
+	var tier1PerfTargets map[string]int
+	tier1PerfTargetsString, err := targets.ReadFile(tier1TargetsURL)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(tier1PerfTargetsString, &tier1PerfTargets); err != nil {
+		return err
+	}
+	tier1PerfTargetInt, err := getExpectedPerf(tier1PerfTargets, t.ShortMachineType)
+	if err != nil {
+		return err
+	}
+	tier1PerfTarget := fmt.Sprint(tier1PerfTargetInt)
 
 	// Tier 1 VMs.
 	tier1ServerVM, err := t.CreateTestVM(tier1ServerConfig.name)
@@ -160,61 +278,19 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	tier1ClientVM.AddMetadata("enable-guest-attributes", "TRUE")
 	tier1ClientVM.AddMetadata("iperftarget", tier1ServerConfig.ip)
-	tier1ClientVM.AddMetadata("perfmap", string(tier1PerfTargets))
+	tier1ClientVM.AddMetadata("expectedperf", tier1PerfTarget)
 
 	// Set startup scripts.
-	var serverStartupByteArr []byte
-	var clientStartupByteArr []byte
 	if strings.Contains(t.Image, "windows") {
-		serverStartupByteArr, err = scripts.ReadFile(windowsServerStartupScriptURL)
-		if err != nil {
-			return err
-		}
-		clientStartupByteArr, err = scripts.ReadFile(windowsClientStartupScriptURL)
-		if err != nil {
-			return err
-		}
-		serverStartup := string(serverStartupByteArr)
-		clientStartup := string(clientStartupByteArr)
-
-		serverVM.SetWindowsStartupScript(serverStartup)
-		clientVM.SetWindowsStartupScript(clientStartup)
-		jfServerVM.SetWindowsStartupScript(serverStartup)
-		jfClientVM.SetWindowsStartupScript(clientStartup)
 		tier1ServerVM.SetWindowsStartupScript(serverStartup)
 		tier1ClientVM.SetWindowsStartupScript(clientStartup)
 	} else {
-		serverStartupByteArr, err = scripts.ReadFile(serverStartupScriptURL)
-		if err != nil {
-			return err
-		}
-		clientStartupByteArr, err = scripts.ReadFile(clientStartupScriptURL)
-		if err != nil {
-			return err
-		}
-		serverStartup := string(serverStartupByteArr)
-		clientStartup := string(clientStartupByteArr)
-
-		serverVM.SetStartupScript(serverStartup)
-		clientVM.SetStartupScript(clientStartup)
-		jfServerVM.SetStartupScript(serverStartup)
-		jfClientVM.SetStartupScript(clientStartup)
 		tier1ServerVM.SetStartupScript(serverStartup)
 		tier1ClientVM.SetStartupScript(clientStartup)
 	}
-
-	clientVM.UseGVNIC()
-	serverVM.UseGVNIC()
-	jfClientVM.UseGVNIC()
-	jfServerVM.UseGVNIC()
 	tier1ClientVM.UseGVNIC()
 	tier1ServerVM.UseGVNIC()
 
-	// Run tests.
-	serverVM.RunTests("TestGVNICExists")
-	clientVM.RunTests("TestGVNICExists|TestNetworkPerformance")
-	jfServerVM.RunTests("TestGVNICExists")
-	jfClientVM.RunTests("TestGVNICExists|TestNetworkPerformance")
 	tier1ServerVM.RunTests("TestGVNICExists")
 	tier1ClientVM.RunTests("TestGVNICExists|TestNetworkPerformance")
 

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -226,16 +226,15 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		// Must be N2, N2D, C2, C2D, C3, C3D, or M3 machine types.
 		fmt.Printf("%v: Skipping tier1 tests - %v not supported\n", t.ShortImage, mt)
 		return nil
-	} else {
-		numCPUs, err := strconv.Atoi(strings.Split(mt, "-")[2])
-		if err != nil {
-			return err
-		}
-		if numCPUs < 30 {
-			// Must have at least 30 vCPUs.
-			fmt.Printf("%v: Skipping tier1 tests - not enough vCPUs (need at least 30, have %v)\n", t.ShortImage, numCPUs)
-			return nil
-		}
+	}
+	numCPUs, err := strconv.Atoi(strings.Split(mt, "-")[2])
+	if err != nil {
+		return err
+	}
+	if numCPUs < 30 {
+		// Must have at least 30 vCPUs.
+		fmt.Printf("%v: Skipping tier1 tests - not enough vCPUs (need at least 30, have %v)\n", t.ShortImage, numCPUs)
+		return nil
 	}
 
 	// Get Tier1 targets.

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -448,7 +448,7 @@ func NewTestWorkflow(name, image, timeout string, x86Shape string, arm64Shape st
 		t.MachineType = x86Shape
 	}
 	machineTypeSplit := strings.Split(t.MachineType, "/")
-	t.ShortMachineType = machineTypeSplit[len(machineTypeSplit) - 1]
+	t.ShortMachineType = machineTypeSplit[len(machineTypeSplit)-1]
 
 	parts := strings.Split(image, "/")
 	t.ShortImage = parts[len(parts)-1]

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAddStartStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestAddStartStep(t *testing.T) {
 }
 
 func TestAddStopStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestAddStopStep(t *testing.T) {
 }
 
 func TestAddWaitStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestAddWaitStep(t *testing.T) {
 }
 
 func TestAddWaitStoppedStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestAddWaitStoppedStep(t *testing.T) {
 }
 
 func TestAppendCreateDisksStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestAppendCreateDisksStep(t *testing.T) {
 }
 
 func TestAppendCreateVMStep(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestAppendCreateVMStep(t *testing.T) {
 }
 
 func TestAppendCreateVMStepMultipleDisks(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestAppendCreateVMStepMultipleDisks(t *testing.T) {
 }
 
 func TestAppendCreateVMStepCustomHostname(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestAppendCreateVMStepCustomHostname(t *testing.T) {
 }
 
 func TestNewTestWorkflow(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestNewTestWorkflow(t *testing.T) {
 }
 
 func TestGetLastStepForVM(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestGetLastStepForVM(t *testing.T) {
 }
 
 func TestGetLastStepForVMWhenReboot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestGetLastStepForVMWhenReboot(t *testing.T) {
 }
 
 func TestGetLastStepForVMWhenMultipleReboot(t *testing.T) {
-	twf, err := NewTestWorkflow("name", "image", "30m")
+	twf, err := NewTestWorkflow("name", "image", "30m", "x86", "arm64")
 	if err != nil {
 		t.Errorf("failed to create test workflow: %v", err)
 	}


### PR DESCRIPTION
This PR also
- Does some minor cleanup in `fixtures.go` regarding `CreateNetwork`, making the MTU setting a separate method instead of a copy-paste of `CreateNetwork` with one extra parameter.
- Refactors `networkperf` test suite to take advantage of the now-available machine type field. We pass the target number directly instead of a large map string.
  - Also use the `MachineType` to prevent `Tier_1` tests from running if the machine type is not supported.