### PR TITLE
Ubuntu 16 fix

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -62,10 +62,19 @@ func RunFIOReadLinux(mode string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	// ubuntu 16.04 has a different option name due to an old fio version
+	image, err := utils.GetMetadata("image")
+	if err != nil {
+		return []byte{}, fmt.Errorf("couldn't get image from metadata")
+	}
+	if strings.Contains(image, "ubuntu-pro-1604") {
+		readOptions = strings.Replace(readOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
+	}
+
 	fioReadOptionsLinuxSlice := strings.Fields(readOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
 	readIOPSJson, err := exec.Command("fio", fioReadOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {
-		return []byte{}, fmt.Errorf("fio command failed with error: %v", err)
+		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", readIOPSJson, err)
 	}
 	return readIOPSJson, nil
 }

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -63,10 +63,19 @@ func RunFIOWriteLinux(mode string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	// ubuntu 16.04 has a different option name due to an old fio version
+	image, err := utils.GetMetadata("image")
+	if err != nil {
+		return []byte{}, fmt.Errorf("couldn't get image from metadata")
+	}
+	if strings.Contains(image, "ubuntu-pro-1604") {
+		writeOptions = strings.Replace(writeOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
+	}
+
 	fioWriteOptionsLinuxSlice := strings.Fields(writeOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
 	writeIOPSJson, err := exec.Command("fio", fioWriteOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {
-		return []byte{}, fmt.Errorf("fio command failed with error: %v", err)
+		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", writeIOPSJson, err)
 	}
 	return writeIOPSJson, nil
 }


### PR DESCRIPTION
Ubuntu 16 has an old version of fio, so one of the argument names is different.

Also, for unclear reasons, ubuntu 16 tests on the c3 machine type hang.