### PR TITLE
Rollback guest attribute call until fixed

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -24,10 +24,6 @@ func main() {
 	}
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
-		if err := utils.PutMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey); err != nil {
-			log.Printf("failed to put test completed key in guest attribute namespace")
-		}
-		log.Printf("successfully placed guest attribute for test completion")
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
The metadata test is sometimes failing: investigate whether this is due to putting the guest attributes as the instance signal