### PR TITLE
Add wait for vm quota test workflow step, and functions to append quotas

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -59,7 +59,7 @@ local prepublishtesttask = {
       '-test_projects=compute-image-test-pool-005',
       // Run tests not ran in publish-to-testing
       // TODO enable oslogin
-      '-filter=(shapevalidation)|(hotattach)',
+      '-filter=(shapevalidation)',
       '-images=' + task.images,
     ] + task.extra_args,
   },
@@ -319,6 +319,10 @@ local imgpublishjob = {
             },
             attempts: 3,
           }
+          else
+          {
+          },
+          if tl.env == 'prod' then
           // Prod releases use a different final publish step that invokes ARLE.
           {
             task: 'publish-' + tl.image,


### PR DESCRIPTION
During testing I ran into a lot of problems with finding free quota that was taken by the time vm creation started. Some of this is unavoidable because daisy takes a second to switch between steps, but I mitigated the problem by staggering parallel workers. Most of this can be avoided by just waiting 60-90 seconds after starting a workflow.

The other thing I did was break this up from one large wait-for-quota step that all creation steps depend on, to quota steps for each create step. But the only create step that actually needs enough quota to worry about right now is the create VMs step, so I just took the others out avoid to avoiding leaving in unused code.


If it's not clear enough that the existing API is only for quota that gates VM creation I can add some comments expanding on this in the code.