### PR TITLE
Add back guest attributes with fix for metadata shutdown test

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -23,7 +23,7 @@ func main() {
 		log.Fatalf("failed to create cloud storage client: %v", err)
 	}
 	log.Printf("FINISHED-BOOTING")
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := utils.PutMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey); err != nil {
 			log.Printf("failed to put test completed key in guest attribute namespace")
 		}
@@ -32,7 +32,7 @@ func main() {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)
 		}
-	}()
+	}(ctx)
 
 	daisyOutsPath, err := utils.GetMetadataAttribute("daisy-outs-path")
 	if err != nil {

--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -24,7 +25,7 @@ func main() {
 	}
 	log.Printf("FINISHED-BOOTING")
 	defer func(ctx context.Context) {
-		if err := utils.PutMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey); err != nil {
+		if err := utils.QueryMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey, http.MethodPut); err != nil {
 			log.Printf("failed to put test completed key in guest attribute namespace")
 		}
 		log.Printf("successfully placed guest attribute for test completion")
@@ -32,6 +33,11 @@ func main() {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)
 		}
+		time.Sleep(10 * time.Second)
+		if err := utils.QueryMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey, http.MethodDelete); err != nil {
+			log.Printf("failed to delete completed key in guest attribute namespace")
+		}
+		log.Printf("successfuilly deleted guest attribute")
 	}(ctx)
 
 	daisyOutsPath, err := utils.GetMetadataAttribute("daisy-outs-path")

--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -24,6 +24,10 @@ func main() {
 	}
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
+		if err := utils.PutMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey); err != nil {
+			log.Printf("failed to put test completed key in guest attribute namespace")
+		}
+		log.Printf("successfully placed guest attribute for test completion")
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -237,7 +237,7 @@ func (t *TestWorkflow) addWaitStep(stepname, vmname string) (*daisy.Step, error)
 
 	instanceSignal.SerialOutput = serialOutput
 	instanceSignal.GuestAttribute = guestAttribute
-	instanceSignal.Interval = "45s"
+	instanceSignal.Interval = "50s"
 
 	waitForInstances := &daisy.WaitForInstancesSignal{instanceSignal}
 

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -231,7 +231,13 @@ func (t *TestWorkflow) addWaitStep(stepname, vmname string) (*daisy.Step, error)
 	instanceSignal.Name = vmname
 	instanceSignal.Stopped = false
 
+	guestAttribute := &daisy.GuestAttribute{}
+	guestAttribute.Namespace = utils.GuestAttributeTestNamespace
+	guestAttribute.KeyName = utils.GuestAttributeTestKey
+
 	instanceSignal.SerialOutput = serialOutput
+	instanceSignal.GuestAttribute = guestAttribute
+	instanceSignal.Interval = "45s"
 
 	waitForInstances := &daisy.WaitForInstancesSignal{instanceSignal}
 

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -237,6 +237,7 @@ func (t *TestWorkflow) addWaitStep(stepname, vmname string) (*daisy.Step, error)
 
 	instanceSignal.SerialOutput = serialOutput
 	instanceSignal.GuestAttribute = guestAttribute
+	instanceSignal.Interval = "8s"
 
 	waitForInstances := &daisy.WaitForInstancesSignal{instanceSignal}
 

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -237,7 +237,6 @@ func (t *TestWorkflow) addWaitStep(stepname, vmname string) (*daisy.Step, error)
 
 	instanceSignal.SerialOutput = serialOutput
 	instanceSignal.GuestAttribute = guestAttribute
-	instanceSignal.Interval = "50s"
 
 	waitForInstances := &daisy.WaitForInstancesSignal{instanceSignal}
 

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -109,22 +109,22 @@ func GetMetadataHTTPResponse(path string) (*http.Response, error) {
 	return resp, nil
 }
 
-// PutMetadataGuestAttribute sets the guest attribute in the namespace, and returns an error if this operation fails.
-func PutMetadataGuestAttribute(ctx context.Context, namespace, attribute string) error {
+// QueryMetadataGuestAttribute queries the guest attribute in the namespace using the given http method, and returns an error if this operation fails.
+func QueryMetadataGuestAttribute(ctx context.Context, namespace, attribute, httpMethod string) error {
 	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)
 	if err != nil {
 		return err
 	}
-	err = PutMetadataHTTPResponse(ctx, path)
+	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// PutMetadataHTTPResponse returns http response for the specified key without checking status code.
-func PutMetadataHTTPResponse(ctx context.Context, path string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, nil)
+// QueryMetadataHTTPResponse returns http response for the specified key and httpMethod without checking status code.
+func QueryMetadataHTTPResponse(ctx context.Context, path, httpMethod string) error {
+	req, err := http.NewRequestWithContext(ctx, httpMethod, path, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, guest attributes were leading to the metadata shutdown script test failing due to reboot behaviors. This should fix the issue.