### PR TITLE
OsLogin Tests

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -656,7 +656,7 @@ local buildpackageimagetask = {
                     args: [
                       '-project=gcp-guest',
                       '-zone=us-central1-a',
-                      '-test_projects=oslogin-testing-project',
+                      '-test_projects=oslogin-cit',
                       '-images=projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id))',
                       '-filter=oslogin',
                     ],
@@ -677,7 +677,7 @@ local buildpackageimagetask = {
                     args: [
                       '-project=gcp-guest',
                       '-zone=us-central1-a',
-                      '-test_projects=oslogin-testing-project',
+                      '-test_projects=oslogin-cit',
                       '-images=projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
                       '-machine_type=t2a-standard-2',
                       '-filter=oslogin',

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -377,6 +377,11 @@ func (t *TestVM) AddMetadata(key, value string) {
 	}
 }
 
+// AddScope adds the specified auth scope to the service account on the VM.
+func (t *TestVM) AddScope(scope string) {
+	t.instance.Scopes = append(t.instance.Scopes, scope)
+}
+
 // RunTests runs only the named tests on the testVM.
 //
 // From go help test:

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -379,7 +379,11 @@ func (t *TestVM) AddMetadata(key, value string) {
 
 // AddScope adds the specified auth scope to the service account on the VM.
 func (t *TestVM) AddScope(scope string) {
-	t.instance.Scopes = append(t.instance.Scopes, scope)
+	if t.instance != nil {
+		t.instance.Scopes = append(t.instance.Scopes, scope)
+	} else if t.instancebeta != nil {
+		t.instancebeta.Scopes = append(t.instancebeta.Scopes, scope)
+	}
 }
 
 // RunTests runs only the named tests on the testVM.

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/compute v1.22.0
+	cloud.google.com/go/oslogin v1.10.1
 	cloud.google.com/go/secretmanager v1.11.2
 	cloud.google.com/go/storage v1.31.0
 	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/compute v1.22.0
+	cloud.google.com/go/secretmanager v1.11.2
 	cloud.google.com/go/storage v1.31.0
 	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f
 	github.com/go-ping/ping v1.1.0

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -12,6 +12,10 @@ cloud.google.com/go/logging v1.7.0 h1:CJYxlNNNNAMkHp9em/YEXcfJg+rPDg7YfwoRpMU+t5
 cloud.google.com/go/logging v1.7.0/go.mod h1:3xjP2CjkM3ZkO73aj4ASA5wRPGGCRrPIAeNqVNkzY8M=
 cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tErFDWI=
 cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
+cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
+cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
+cloud.google.com/go/secretmanager v1.11.2 h1:52Z78hH8NBWIqbvIG0wi0EoTaAmSx99KIOAmDXIlX0M=
+cloud.google.com/go/secretmanager v1.11.2/go.mod h1:MQm4t3deoSub7+WNwiC4/tRYgDBHJgJPvswqQVB1Vss=
 cloud.google.com/go/storage v1.31.0 h1:+S3LjjEN2zZ+L5hOwj4+1OkGCsLVe0NzpXKQ1pSdTCI=
 cloud.google.com/go/storage v1.31.0/go.mod h1:81ams1PrhW16L4kF7qg+4mTq7SRs5HsbDTM0bWvrwJ0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -14,6 +14,8 @@ cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tE
 cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
 cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
+cloud.google.com/go/oslogin v1.10.1 h1:LdSuG3xBYu2Sgr3jTUULL1XCl5QBx6xwzGqzoDUw1j0=
+cloud.google.com/go/oslogin v1.10.1/go.mod h1:x692z7yAue5nE7CsSnoG0aaMbNoRJRXO4sn73R+ZqAs=
 cloud.google.com/go/secretmanager v1.11.2 h1:52Z78hH8NBWIqbvIG0wi0EoTaAmSx99KIOAmDXIlX0M=
 cloud.google.com/go/secretmanager v1.11.2/go.mod h1:MQm4t3deoSub7+WNwiC4/tRYgDBHJgJPvswqQVB1Vss=
 cloud.google.com/go/storage v1.31.0 h1:+S3LjjEN2zZ+L5hOwj4+1OkGCsLVe0NzpXKQ1pSdTCI=

--- a/imagetest/test_suites/README.md
+++ b/imagetest/test_suites/README.md
@@ -252,6 +252,7 @@ Linux (same as the `ip` command).
 ### Test suite: networkperf ###
 
 #### TestNetworkPerformance ####
+
 Validate the network performance of an image reaches at least 85% of advertised
 speeds.
 

--- a/imagetest/test_suites/README.md
+++ b/imagetest/test_suites/README.md
@@ -252,7 +252,6 @@ Linux (same as the `ip` command).
 ### Test suite: networkperf ###
 
 #### TestNetworkPerformance ####
-
 Validate the network performance of an image reaches at least 85% of advertised
 speeds.
 

--- a/imagetest/test_suites/oslogin/oslogin_test.go
+++ b/imagetest/test_suites/oslogin/oslogin_test.go
@@ -1,6 +1,20 @@
 //go:build cit
 // +build cit
 
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oslogin
 
 import (

--- a/imagetest/test_suites/oslogin/oslogin_test.go
+++ b/imagetest/test_suites/oslogin/oslogin_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
-//const testUsername = "sa_105020877179577573373"
-//const testUUID = "3651018652"
+// const testUsername = "sa_105020877179577573373"
+// const testUUID = "3651018652"
 const (
 	testUsername = "sa_115308896887453382826"
-	testUUID = "2260770985"
+	testUUID     = "2260770985"
 )
 
 var testUserEntry = fmt.Sprintf("%s:*:%s:%s::/home/%s:", testUsername, testUUID, testUUID, testUsername)
@@ -60,7 +60,7 @@ func isTwoFactorAuthEnabled(ctx context.Context) (bool, error) {
 	return instanceFlag || projectFlag, nil
 }
 
-func isOsLoginEnabled(ctx context.Context) (error) {
+func isOsLoginEnabled(ctx context.Context) error {
 	data, err := os.ReadFile("/etc/nsswitch.conf")
 	if err != nil {
 		return fmt.Errorf("cannot read /etc/nsswitch.conf")

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -98,7 +98,7 @@ func isOsLoginEnabled(ctx context.Context) error {
 			continue
 		}
 		if strings.Contains(line, "passwd:") && !strings.Contains(line, "oslogin") {
-			return fmt.Errorf("OS Login not enabled in /etc/nsswitch.conf.")
+			return fmt.Errorf("OS Login not enabled in /etc/nsswitch.conf")
 		}
 	}
 
@@ -119,7 +119,7 @@ func isOsLoginEnabled(ctx context.Context) error {
 	}
 
 	if !foundAuthorizedKeys {
-		return fmt.Errorf("AuthorizedKeysCommand not set up for OS Login.")
+		return fmt.Errorf("AuthorizedKeysCommand not set up for OS Login")
 	}
 
 	if err = testSSHDPamConfig(ctx); err != nil {
@@ -142,7 +142,7 @@ func testSSHDPamConfig(ctx context.Context) error {
 		}
 
 		if !strings.Contains(string(data), "pam_oslogin_login.so") {
-			return fmt.Errorf("OS Login PAM module missing from pam.d/sshd.")
+			return fmt.Errorf("OS Login PAM module missing from pam.d/sshd")
 		}
 	}
 	return nil

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -182,4 +182,3 @@ func getTwoFactorAuthMetadata(ctx context.Context, root string, elem ...string) 
 	}
 	return flag, nil
 }
-

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -144,8 +144,9 @@ func testSSHDPamConfig(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("cannot read /etc/pam.d/sshd: %+v", err)
 		}
+		dataString := string(data)
 
-		if !strings.Contains(string(data), "pam_oslogin_login.so") || !strings.Contains(string(data), "") {
+		if err = fileContainsLine(dataString, "auth", "[success=done perm_denied=die default=ignore]", "pam_oslogin_login.so"); err != nil {
 			return fmt.Errorf("OS Login PAM module missing from pam.d/sshd")
 		}
 	}

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 // From the contents of a file, check if a line contains all the provided elements.
-func FileContainsLine(data string, elem ...string) error {
+func fileContainsLine(data string, elem ...string) error {
 	var found bool
 	for _, line := range strings.Split(string(data), "\n") {
 		found = true

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -111,7 +111,7 @@ func isOsLoginEnabled(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot read /etc/nsswitch.conf: %v", err)
 	}
-	if err = FileContainsLine(string(data), "passwd:", "oslogin"); err != nil {
+	if err = fileContainsLine(string(data), "passwd:", "oslogin"); err != nil {
 		return fmt.Errorf("oslogin passwd entry not found in /etc/nsswitch.conf")
 	}
 
@@ -120,8 +120,8 @@ func isOsLoginEnabled(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot read /etc/ssh/sshd_config: %v", err)
 	}
-	if err = FileContainsLine(string(data), "AuthorizedKeysCommand", "/usr/bin/google_authorized_keys"); err != nil {
-		if err = FileContainsLine(string(data), "AuthorizedKeysCommand", "/usr/bin/google_authorized_keys_sk"); err != nil {
+	if err = fileContainsLine(string(data), "AuthorizedKeysCommand", "/usr/bin/google_authorized_keys"); err != nil {
+		if err = fileContainsLine(string(data), "AuthorizedKeysCommand", "/usr/bin/google_authorized_keys_sk"); err != nil {
 			return fmt.Errorf("AuthorizedKeysCommand not set up for OSLogin: %v", err)
 		}
 	}

--- a/imagetest/test_suites/oslogin/oslogin_utils.go
+++ b/imagetest/test_suites/oslogin/oslogin_utils.go
@@ -1,0 +1,199 @@
+package oslogin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	oslogin "cloud.google.com/go/oslogin/apiv1"
+	osloginpb "cloud.google.com/go/oslogin/apiv1/osloginpb"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
+// Creates the posix name from the given username.
+func getPosix(user string) string {
+	return strings.Join(strings.FieldsFunc(user, getPosixSplit), "_")
+}
+
+func getPosixSplit(r rune) bool {
+	return r == '.' || r == '@' || r == '-'
+}
+
+// Gets the name of the instance running the test.
+func getInstanceName(ctx context.Context) (string, error) {
+	name, err := utils.GetMetadata(ctx, "instance", "name")
+	if err != nil {
+		return "", fmt.Errorf("failed to get instance name: %v", err)
+	}
+	return name, nil
+}
+
+// Gets the project and zone of the instance.
+func getProjectZone(ctx context.Context) (string, string, error) {
+	projectZone, err := utils.GetMetadata(ctx, "instance", "zone")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get instance zone: %v", err)
+	}
+	projectZoneSplit := strings.Split(string(projectZone), "/")
+	project := projectZoneSplit[1]
+	zone := projectZoneSplit[3]
+	return project, zone, nil
+}
+
+// Gets the service account currently operating on the instance.
+func getServiceAccount(ctx context.Context) (string, error) {
+	serviceAccount, err := utils.GetMetadata(ctx, "instance", "service-accounts", "default", "email")
+	if err != nil {
+		return "", fmt.Errorf("failed to get service account: %v", err)
+	}
+	return serviceAccount, nil
+}
+
+// Gets the test user entry for getent tests. Returns the username, uuid, and entry.
+func getTestUserEntry(ctx context.Context) (string, string, string, error) {
+	account, err := getServiceAccount(ctx)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	// Create OSLogin client
+	client, err := oslogin.NewClient(ctx)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to create client: %v", err)
+	}
+
+	// Get the LoginProfile for the service account.
+	req := &osloginpb.GetLoginProfileRequest{
+		Name: fmt.Sprintf("users/%s", account),
+	}
+
+	resp, err := client.GetLoginProfile(ctx, req)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to get login profile: %v", err)
+	}
+	posixAccount := resp.PosixAccounts[0]
+
+	// Get necessary information.
+	uuid := posixAccount.GetUid()
+	username := posixAccount.GetUsername()
+	entry := fmt.Sprintf("%s:*:%d:%d::/home/%s:", username, uuid, uuid, username)
+	return username, strconv.FormatInt(uuid, 10), entry, nil
+}
+
+// Checks if OSLogin is enabled. Returns an error if it is not, or there is trouble
+// reading a file.
+func isOsLoginEnabled(ctx context.Context) error {
+	data, err := os.ReadFile("/etc/nsswitch.conf")
+	if err != nil {
+		return fmt.Errorf("cannot read /etc/nsswitch.conf")
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "passwd:") && !strings.Contains(line, "oslogin") {
+			return fmt.Errorf("OS Login not enabled in /etc/nsswitch.conf.")
+		}
+	}
+
+	// Check AuthorizedKeys Command
+	data, err = os.ReadFile("/etc/ssh/sshd_config")
+	if err != nil {
+		return fmt.Errorf("cannot read /etc/ssh/sshd_config")
+	}
+	var foundAuthorizedKeys bool
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "AuthorizedKeysCommand") && strings.Contains(line, "/usr/bin/google_authorized_keys") {
+			foundAuthorizedKeys = true
+		}
+	}
+
+	if !foundAuthorizedKeys {
+		return fmt.Errorf("AuthorizedKeysCommand not set up for OS Login.")
+	}
+
+	if err = testSSHDPamConfig(ctx); err != nil {
+		return fmt.Errorf("error checking pam config: %v", err)
+	}
+	return nil
+}
+
+func testSSHDPamConfig(ctx context.Context) error {
+	twoFactorAuthEnabled, err := isTwoFactorAuthEnabled(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to query two factor authentication metadata entry: %+v", err)
+	}
+
+	if twoFactorAuthEnabled {
+		// Check Pam Modules
+		data, err := os.ReadFile("/etc/pam.d/sshd")
+		if err != nil {
+			return fmt.Errorf("cannot read /etc/pam.d/sshd: %+v", err)
+		}
+
+		if !strings.Contains(string(data), "pam_oslogin_login.so") {
+			return fmt.Errorf("OS Login PAM module missing from pam.d/sshd.")
+		}
+	}
+	return nil
+}
+
+func isTwoFactorAuthEnabled(ctx context.Context) (bool, error) {
+	var (
+		instanceFlag, projectFlag bool
+		err                       error
+	)
+
+	elem := []string{"attributes", "enable-oslogin-2fa"}
+
+	instanceFlag, err = getTwoFactorAuth(ctx, "instance", elem...)
+	if err != nil && !errors.Is(err, utils.ErrMDSEntryNotFound) {
+		return false, err
+	}
+	projectFlag, err = getTwoFactorAuth(ctx, "project", elem...)
+	if err != nil && !errors.Is(err, utils.ErrMDSEntryNotFound) {
+		return false, err
+	}
+	return instanceFlag || projectFlag, nil
+}
+
+func getTwoFactorAuth(ctx context.Context, root string, elem ...string) (bool, error) {
+	data, err := utils.GetMetadata(ctx, append([]string{root}, elem...)...)
+	if err != nil {
+		return false, err
+	}
+	flag, err := strconv.ParseBool(data)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse enable-oslogin-2fa metadata entry: %+v", err)
+	}
+	return flag, nil
+}
+
+// Gets the given secret.
+func getSecret(ctx context.Context, client *secretmanager.Client, secretName string) (string, error) {
+	// Get project
+	project, _, err := getProjectZone(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get project: %v", err)
+	}
+
+	// Make request call to Secret Manager.
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),
+	}
+	resp, err := client.AccessSecretVersion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %v", err)
+	}
+	return string(resp.Payload.Data), nil
+}

--- a/imagetest/test_suites/oslogin/setup.go
+++ b/imagetest/test_suites/oslogin/setup.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package oslogin
 
 import (

--- a/imagetest/test_suites/oslogin/setup.go
+++ b/imagetest/test_suites/oslogin/setup.go
@@ -2,6 +2,7 @@ package oslogin
 
 import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
 // Name is the name of the test package. It must match the directory name.
@@ -14,6 +15,11 @@ const (
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
+	if utils.HasFeature(t.Image, "WINDOWS") {
+		t.Skip("OSLogin not supported on windows")
+		return nil
+	}
+
 	defaultVM, err := t.CreateTestVM("default")
 	if err != nil {
 		return err

--- a/imagetest/test_suites/oslogin/setup.go
+++ b/imagetest/test_suites/oslogin/setup.go
@@ -7,20 +7,36 @@ import (
 // Name is the name of the test package. It must match the directory name.
 var Name = "oslogin"
 
+const (
+	computeScope  = "https://www.googleapis.com/auth/compute"
+	platformScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm, err := t.CreateTestVM("vm")
+	defaultVM, err := t.CreateTestVM("default")
 	if err != nil {
 		return err
 	}
-	vm.AddMetadata("enable-oslogin", "true")
-	vm.RunTests("TestOsLoginEnabled|TestGetentPasswd")
+	defaultVM.AddScope(computeScope)
+	defaultVM.AddMetadata("enable-oslogin", "true")
+	defaultVM.RunTests("TestOsLoginEnabled|TestGetentPasswd|TestAgent")
 
-	vm2, err := t.CreateTestVM("vm2")
+	ssh, err := t.CreateTestVM("ssh")
 	if err != nil {
 		return err
 	}
-	vm2.AddMetadata("enable-oslogin", "false")
-	vm2.RunTests("TestOsLoginDisabled")
+	ssh.AddScope(platformScope)
+	ssh.AddMetadata("enable-oslogin", "false")
+	ssh.RunTests("TestOsLoginDisabled|TestSSH|TestAdminSSH")
+
+	twofa, err := t.CreateTestVM("twofa")
+	if err != nil {
+		return err
+	}
+	twofa.AddScope(computeScope)
+	twofa.AddMetadata("enable-oslogin", "true")
+	twofa.AddMetadata("enable-oslogin-2fa", "true")
+	twofa.RunTests("TestAgent")
 	return nil
 }

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -168,16 +168,6 @@ func sessionOSLoginEnabled(client *ssh.Client) error {
 		return fmt.Errorf("failed to read /etc/nsswitch.conf: %v", err)
 	}
 
-	session, err = client.NewSession()
-	if err != nil {
-		return fmt.Errorf("failed to create ssh session: %v", err)
-	}
-	data, err = session.Output("pwd")
-	if err != nil {
-		return fmt.Errorf("failed to execute pwd: %v", err)
-	}
-	fmt.Printf("working directory: %v\n", string(data))
-
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "#") {
@@ -245,7 +235,7 @@ func TestAgent(t *testing.T) {
 
 // Checks whether SSH-ing works correctly with OSLogin enabled.
 // After successfully creating an SSH connection, check whether OSLogin is enabled on the host VM.
-func TestSsh(t *testing.T) {
+func TestSSH(t *testing.T) {
 	// TODO: Come up with better way to ensure the target VMs finished their guest agent checks.
 	time.Sleep(20 * time.Second)
 	ctx := utils.Context(t)
@@ -288,7 +278,7 @@ func TestSsh(t *testing.T) {
 	}
 }
 
-func TestAdminSsh(t *testing.T) {
+func TestAdminSSH(t *testing.T) {
 	time.Sleep(20 * time.Second)
 	ctx := utils.Context(t)
 

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -140,7 +140,7 @@ func changeMetadata(ctx context.Context, client *compute.InstancesClient, key, v
 	}
 
 	// Update the metadata on the instance.
-	setMetadataReq := &computepb.SetMetadataInstanceRequest {
+	setMetadataReq := &computepb.SetMetadataInstanceRequest{
 		Instance:         vmname,
 		MetadataResource: metadata,
 		Project:          project,

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -329,4 +329,3 @@ func TestAdminSsh(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 }
-

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -123,7 +123,7 @@ func sessionOSLoginEnabled(client *ssh.Client) error {
 }
 
 // Checks what's in the /var/google-sudoers.d directory.
-func getSudoFile(client *ssh.Client, user, sudo string) (string, error) {
+func getSudoFile(client *ssh.Client, user string) (string, error) {
 	session, err := client.NewSession()
 	if err != nil {
 		return "", fmt.Errorf("failed to create ssh session: %v", err)
@@ -263,11 +263,7 @@ func TestAdminSSH(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	sudo, err := utils.AccessSecret(ctx, secretClient, adminUserSudo)
-	if err != nil {
-		t.Fatalf("failed to get sudo: %v", err)
-	}
-	data, err := getSudoFile(client, posix, sudo)
+	data, err := getSudoFile(client, posix)
 	if err != nil {
 		t.Fatalf("failed to get sudo file: %v", err)
 	}

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -30,8 +30,8 @@ const (
 	admin2FAUser  = "admin-2fa-user"
 
 	// 2fa keys
-	normal2FAKey  = "normal-2fa-key"
-	admin2FAKey   = "admin-2fa-key"
+	normal2FAKey = "normal-2fa-key"
+	admin2FAKey  = "admin-2fa-key"
 
 	// keys
 	normalUserSshKey = "normal-user-ssh-key"
@@ -114,10 +114,10 @@ func changeMetadata(ctx context.Context, client *compute.InstancesClient, key, v
 	}
 
 	// Get instance info.
-	instancesGetReq := &computepb.GetInstanceRequest {
+	instancesGetReq := &computepb.GetInstanceRequest{
 		Instance: vmname,
-		Project: project,
-		Zone: zone,
+		Project:  project,
+		Zone:     zone,
 	}
 
 	instance, err := client.Get(ctx, instancesGetReq)
@@ -141,10 +141,10 @@ func changeMetadata(ctx context.Context, client *compute.InstancesClient, key, v
 
 	// Update the metadata on the instance.
 	setMetadataReq := &computepb.SetMetadataInstanceRequest {
-		Instance: vmname,
+		Instance:         vmname,
 		MetadataResource: metadata,
-		Project: project,
-		Zone: zone,
+		Project:          project,
+		Zone:             zone,
 	}
 	_, err = client.SetMetadata(ctx, setMetadataReq)
 	if err != nil {
@@ -211,7 +211,7 @@ func TestAgent(t *testing.T) {
 	defer client.Close()
 
 	// First check if OSLogin is on.
-	if err := isOsLoginEnabled(ctx); err != nil  {
+	if err := isOsLoginEnabled(ctx); err != nil {
 		t.Fatalf("OSLogin disabled when it should be enabled: %v", err)
 	}
 	// Turn off OsLogin.
@@ -219,7 +219,7 @@ func TestAgent(t *testing.T) {
 		t.Fatalf("Error changing metadata: %v", err)
 	}
 	// Give the API time to update.
-	time.Sleep(time.Second*5)
+	time.Sleep(time.Second * 5)
 	// Check if OSLogin is disabled.
 	err = isOsLoginEnabled(ctx)
 	if err == nil {
@@ -232,7 +232,7 @@ func TestAgent(t *testing.T) {
 	if err = changeMetadata(ctx, client, "enable-oslogin", "true"); err != nil {
 		t.Fatalf("Error changing metadata: %v", err)
 	}
-	time.Sleep(time.Second*5)
+	time.Sleep(time.Second * 5)
 
 	// Check if OSLogin is back on.
 	if err = isOsLoginEnabled(ctx); err != nil {

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -176,7 +176,7 @@ func sessionOSLoginEnabled(client *ssh.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed to execute pwd: %v", err)
 	}
-	fmt.Printf("working directory: %v\n", data)
+	fmt.Printf("working directory: %v\n", string(data))
 
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -145,6 +145,7 @@ func getSudoFile(client *ssh.Client, sudo string) (string, error) {
 		return "", fmt.Errorf("failed to get session stdout: %v", err)
 	}
 
+	// Monitor the output stream of the ssh session.
 	go func(in io.WriteCloser, out io.Reader, output *[]byte) {
 		var line string
 		r := bufio.NewReader(out)
@@ -160,6 +161,7 @@ func getSudoFile(client *ssh.Client, sudo string) (string, error) {
 				continue
 			}
 			line += string(b)
+			// If we find we need to enter a sudo password, pass in the sudo password.
 			if strings.HasPrefix(line, "[sudo] password for ") {
 				_, err = in.Write([]byte(sudo + "\n"))
 				if err != nil {
@@ -173,7 +175,9 @@ func getSudoFile(client *ssh.Client, sudo string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting /var/google-sudoers.d: %v", err)
 	}
-	time.Sleep(time.Second * 5)
+
+	// Give time for the command to finish and output.
+	time.Sleep(time.Second * 3)
 	return string(output), nil
 }
 

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -1,0 +1,329 @@
+package oslogin
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	instanceMetadataURL       = "http://metadata.google.internal/computeMetadata/v1/instance"
+	osloginMetadataURL        = "http://metadata.google.internal/computeMetadata/v1/oslogin"
+	serviceAccountMetadataURL = "service-accounts/default/email"
+	projectZoneURL            = "zone"
+
+	// users
+	nopermsUser   = "non-user"
+	normalUser    = "normal-user"
+	adminUser     = "admin-user"
+	normal2FAUser = "normal-2fa-user"
+	admin2FAUser  = "admin-2fa-user"
+
+	// 2fa keys
+	normal2FAKey  = "normal-2fa-key"
+	admin2FAKey   = "admin-2fa-key"
+
+	// keys
+	normalUserSshKey = "normal-user-ssh-key"
+	adminUserSshKey  = "admin-user-ssh-key"
+	normal2FASshKey  = "normal-2fa-ssh-key"
+	admin2FASshKey   = "admin-2fa-ssh-key"
+)
+
+// Creates the posix name from the given username.
+func getPosix(user string) string {
+	return strings.Join(strings.FieldsFunc(user, getPosixSplit), "_")
+}
+
+func getPosixSplit(r rune) bool {
+	return r == '.' || r == '@' || r == '-'
+}
+
+// Gets the given secret.
+func getSecret(ctx context.Context, client *secretmanager.Client, secretName string) (string, error) {
+	// Get project
+	project, _, err := getProjectZone()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project: %v", err)
+	}
+
+	// Make request call to Secret Manager.
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),
+	}
+	resp, err := client.AccessSecretVersion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %v", err)
+	}
+	return string(resp.Payload.Data), nil
+}
+
+// Gets the project and zone of the instance.
+func getProjectZone() (string, string, error) {
+	projectZone, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/%s", instanceMetadataURL, projectZoneURL)).Output()
+	if err != nil {
+		return "", "", err
+	}
+	projectZoneSplit := strings.Split(string(projectZone), "/")
+	project := projectZoneSplit[1]
+	zone := projectZoneSplit[3]
+	return project, zone, nil
+}
+
+// Gets the service account currently operating on the instance.
+func getServiceAccount() (string, error) {
+	serviceAccountBytes, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/%s", instanceMetadataURL, serviceAccountMetadataURL)).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get service account: %v", err)
+	}
+	serviceAccount := string(serviceAccountBytes)
+	return serviceAccount, nil
+}
+
+// Gets the name of the instance running the test.
+func getInstanceName() (string, error) {
+	name, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/name", instanceMetadataURL)).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(name), nil
+}
+
+// Changes the given metadata key to have the given value on the given instance.. If the key does not exist,
+// then this will create the key-value pair in the instance's metadata.
+func changeMetadata(ctx context.Context, client *compute.InstancesClient, key, value string) error {
+	vmname, err := getInstanceName()
+	if err != nil {
+		return fmt.Errorf("error getting vm name: %v", err)
+	}
+
+	// Get project and zone of instance.
+	project, zone, err := getProjectZone()
+	if err != nil {
+		return err
+	}
+
+	// Get instance info.
+	instancesGetReq := &computepb.GetInstanceRequest {
+		Instance: vmname,
+		Project: project,
+		Zone: zone,
+	}
+
+	instance, err := client.Get(ctx, instancesGetReq)
+	if err != nil {
+		return fmt.Errorf("error getting instance info: %v", err)
+	}
+	metadata := instance.Metadata
+
+	// Find the key in the metadata. If it doesn't exist, create a new metadata item.
+	found := false
+	for _, item := range metadata.Items {
+		if *(item.Key) == key {
+			item.Value = &value
+			found = true
+			break
+		}
+	}
+	if !found {
+		metadata.Items = append(metadata.Items, &computepb.Items{Key: &key, Value: &value})
+	}
+
+	// Update the metadata on the instance.
+	setMetadataReq := &computepb.SetMetadataInstanceRequest {
+		Instance: vmname,
+		MetadataResource: metadata,
+		Project: project,
+		Zone: zone,
+	}
+	_, err = client.SetMetadata(ctx, setMetadataReq)
+	if err != nil {
+		return fmt.Errorf("error setting metadata: %v", err)
+	}
+	return nil
+}
+
+func sessionOSLoginEnabled(client *ssh.Client) error {
+	// We do not close the session as Run() implicitly closes the session after it's done running.
+	// Otherwise we run into an EOF error.
+	session, err := client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create ssh session: %v", err)
+	}
+	data, err := session.Output("cat /etc/nsswitch.conf")
+	if err != nil {
+		return fmt.Errorf("failed to read /etc/nsswitch.conf: %v", err)
+	}
+
+	session, err = client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create ssh session: %v", err)
+	}
+	data, err = session.Output("pwd")
+	if err != nil {
+		return fmt.Errorf("failed to execute pwd: %v", err)
+	}
+	fmt.Printf("working directory: %v\n", data)
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "passwd:") && !strings.Contains(line, "oslogin") {
+			return fmt.Errorf("OS Login not enabled in /etc/nsswitch.conf.")
+		}
+	}
+
+	return nil
+}
+
+func getSudoFile(client *ssh.Client) error {
+	/**
+	session, err := client.NewSession()
+	if err != nil {
+		return fmt.Errorf("failed to create ssh session: %v", err)
+	}
+	data, err := session.Output("ls /var/sudoers.d")
+	*/
+	return nil
+}
+
+// TestAgent checks whether the guest agent responds correctly to switching
+// oslogin on and off.
+func TestAgent(t *testing.T) {
+	// Create instances client
+	ctx := utils.Context(t)
+	client, err := compute.NewInstancesRESTClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create instances client: %v", err)
+	}
+	defer client.Close()
+
+	// First check if OSLogin is on.
+	if err := isOsLoginEnabled(ctx); err != nil  {
+		t.Fatalf("OSLogin disabled when it should be enabled: %v", err)
+	}
+	// Turn off OsLogin.
+	if err := changeMetadata(ctx, client, "enable-oslogin", "false"); err != nil {
+		t.Fatalf("Error changing metadata: %v", err)
+	}
+	// Give the API time to update.
+	time.Sleep(time.Second*5)
+	// Check if OSLogin is disabled.
+	err = isOsLoginEnabled(ctx)
+	if err == nil {
+		t.Fatalf("OSLogin enabled when it should be disabled: %v", err)
+	} else if strings.Contains(err.Error(), "cannot read") {
+		t.Fatalf("%v", err)
+	}
+
+	// Turn OSLogin back on.
+	if err = changeMetadata(ctx, client, "enable-oslogin", "true"); err != nil {
+		t.Fatalf("Error changing metadata: %v", err)
+	}
+	time.Sleep(time.Second*5)
+
+	// Check if OSLogin is back on.
+	if err = isOsLoginEnabled(ctx); err != nil {
+		t.Fatalf("OSLogin disabled when it should be enabled: %v", err)
+	}
+}
+
+// Checks whether SSH-ing works correctly with OSLogin enabled.
+// After successfully creating an SSH connection, check whether OSLogin is enabled on the host VM.
+func TestSsh(t *testing.T) {
+	// TODO: Come up with better way to ensure the target VMs finished their guest agent checks.
+	time.Sleep(20 * time.Second)
+	ctx := utils.Context(t)
+
+	// Secret Manager Client.
+	secretClient, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create secrets client: %v", err)
+	}
+	defer secretClient.Close()
+
+	// Get user email.
+	user, err := getSecret(ctx, secretClient, normalUser)
+	if err != nil {
+		t.Fatalf("failed to get user: %v", err)
+	}
+
+	// Get important name resources.
+	hostname, err := utils.GetRealVMName("default")
+	if err != nil {
+		t.Fatalf("failed to get real vm name: %v", err)
+	}
+	posix := getPosix(user)
+
+	// Get Ssh keys.
+	privateSshKey, err := getSecret(ctx, secretClient, normalUserSshKey)
+	if err != nil {
+		t.Fatalf("failed to get private key: %v", err)
+	}
+
+	// Create ssh client to target VM.
+	client, err := utils.CreateClient(posix, fmt.Sprintf("%s:22", hostname), []byte(privateSshKey))
+	if err != nil {
+		t.Fatalf("error creating ssh client: %v", err)
+	}
+	defer client.Close()
+
+	if err = sessionOSLoginEnabled(client); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestAdminSsh(t *testing.T) {
+	time.Sleep(20 * time.Second)
+	ctx := utils.Context(t)
+
+	// Secret Manager Client.
+	secretClient, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create secrets client: %v", err)
+	}
+	defer secretClient.Close()
+
+	// Get user email.
+	user, err := getSecret(ctx, secretClient, adminUser)
+	if err != nil {
+		t.Fatalf("failed to get user: %v", err)
+	}
+
+	// Get important name resources.
+	hostname, err := utils.GetRealVMName("default")
+	if err != nil {
+		t.Fatalf("failed to get real vm name: %v", err)
+	}
+	posix := getPosix(user)
+
+	// Get Ssh keys.
+	privateSshKey, err := getSecret(ctx, secretClient, adminUserSshKey)
+	if err != nil {
+		t.Fatalf("failed to get private key: %v", err)
+	}
+
+	// Create ssh client to target VM.
+	client, err := utils.CreateClient(posix, fmt.Sprintf("%s:22", hostname), []byte(privateSshKey))
+	if err != nil {
+		t.Fatalf("error creating ssh client: %v", err)
+	}
+	defer client.Close()
+
+	if err = sessionOSLoginEnabled(client); err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -6,7 +6,6 @@ package oslogin
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -14,17 +13,11 @@ import (
 	compute "cloud.google.com/go/compute/apiv1"
 	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
-	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 	"golang.org/x/crypto/ssh"
 )
 
 const (
-	instanceMetadataURL       = "http://metadata.google.internal/computeMetadata/v1/instance"
-	osloginMetadataURL        = "http://metadata.google.internal/computeMetadata/v1/oslogin"
-	serviceAccountMetadataURL = "service-accounts/default/email"
-	projectZoneURL            = "zone"
-
 	// users
 	nopermsUser   = "non-user"
 	normalUser    = "normal-user"
@@ -43,75 +36,16 @@ const (
 	admin2FASshKey   = "admin-2fa-ssh-key"
 )
 
-// Creates the posix name from the given username.
-func getPosix(user string) string {
-	return strings.Join(strings.FieldsFunc(user, getPosixSplit), "_")
-}
-
-func getPosixSplit(r rune) bool {
-	return r == '.' || r == '@' || r == '-'
-}
-
-// Gets the given secret.
-func getSecret(ctx context.Context, client *secretmanager.Client, secretName string) (string, error) {
-	// Get project
-	project, _, err := getProjectZone()
-	if err != nil {
-		return "", fmt.Errorf("failed to get project: %v", err)
-	}
-
-	// Make request call to Secret Manager.
-	req := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),
-	}
-	resp, err := client.AccessSecretVersion(ctx, req)
-	if err != nil {
-		return "", fmt.Errorf("failed to get secret: %v", err)
-	}
-	return string(resp.Payload.Data), nil
-}
-
-// Gets the project and zone of the instance.
-func getProjectZone() (string, string, error) {
-	projectZone, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/%s", instanceMetadataURL, projectZoneURL)).Output()
-	if err != nil {
-		return "", "", err
-	}
-	projectZoneSplit := strings.Split(string(projectZone), "/")
-	project := projectZoneSplit[1]
-	zone := projectZoneSplit[3]
-	return project, zone, nil
-}
-
-// Gets the service account currently operating on the instance.
-func getServiceAccount() (string, error) {
-	serviceAccountBytes, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/%s", instanceMetadataURL, serviceAccountMetadataURL)).Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get service account: %v", err)
-	}
-	serviceAccount := string(serviceAccountBytes)
-	return serviceAccount, nil
-}
-
-// Gets the name of the instance running the test.
-func getInstanceName() (string, error) {
-	name, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("curl -H \"Metadata-Flavor: Google\" %s/name", instanceMetadataURL)).Output()
-	if err != nil {
-		return "", err
-	}
-	return string(name), nil
-}
-
 // Changes the given metadata key to have the given value on the given instance.. If the key does not exist,
 // then this will create the key-value pair in the instance's metadata.
 func changeMetadata(ctx context.Context, client *compute.InstancesClient, key, value string) error {
-	vmname, err := getInstanceName()
+	vmname, err := getInstanceName(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting vm name: %v", err)
 	}
 
 	// Get project and zone of instance.
-	project, zone, err := getProjectZone()
+	project, zone, err := getProjectZone(ctx)
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -316,7 +316,6 @@ func TestAdminSSH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get sudo file: %v", err)
 	}
-	fmt.Printf("sudo directory: %s", string(data))
 	if !strings.Contains(string(data), posix) {
 		t.Fatalf("sudoers directory does not contain user")
 	}

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -1,3 +1,6 @@
+//go:build cit
+// +build cit
+
 package oslogin
 
 import (

--- a/imagetest/test_suites/oslogin/ssh_test.go
+++ b/imagetest/test_suites/oslogin/ssh_test.go
@@ -267,7 +267,7 @@ func TestAdminSSH(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get sudo file: %v", err)
 	}
-	if !strings.Contains(data, posix) && !strings.Contains(data, "ALL=(ALL)") || !strings.Contains(data, "NOPASSWD: ALL") {
+	if !strings.Contains(data, posix) || !strings.Contains(data, "ALL=(ALL)") || !strings.Contains(data, "NOPASSWD: ALL") {
 		t.Fatalf("sudoers file does not contain user or necessary configurations")
 	}
 }

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -187,7 +187,7 @@ func ParseHostKey(bytes []byte) (map[string]string, error) {
 	return hostkeyMap, nil
 }
 
-// Gets the project and zone of the instance.
+// GetProjectZone gets the project and zone of the instance.
 func GetProjectZone(ctx context.Context) (string, string, error) {
 	projectZone, err := GetMetadata(ctx, "instance", "zone")
 	if err != nil {
@@ -199,7 +199,7 @@ func GetProjectZone(ctx context.Context) (string, string, error) {
 	return project, zone, nil
 }
 
-// Accesses the given secret.
+// AccessSecret accesses the given secret.
 func AccessSecret(ctx context.Context, client *secretmanager.Client, secretName string) (string, error) {
 	// Get project
 	project, _, err := GetProjectZone(ctx)

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/api/compute/v1"
@@ -183,6 +185,37 @@ func ParseHostKey(bytes []byte) (map[string]string, error) {
 		hostkeyMap[keyType] = keyValue
 	}
 	return hostkeyMap, nil
+}
+
+// Gets the project and zone of the instance.
+func GetProjectZone(ctx context.Context) (string, string, error) {
+	projectZone, err := GetMetadata(ctx, "instance", "zone")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get instance zone: %v", err)
+	}
+	projectZoneSplit := strings.Split(string(projectZone), "/")
+	project := projectZoneSplit[1]
+	zone := projectZoneSplit[3]
+	return project, zone, nil
+}
+
+// Accesses the given secret.
+func AccessSecret(ctx context.Context, client *secretmanager.Client, secretName string) (string, error) {
+	// Get project
+	project, _, err := GetProjectZone(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get project: %v", err)
+	}
+
+	// Make request call to Secret Manager.
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName),
+	}
+	resp, err := client.AccessSecretVersion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %v", err)
+	}
+	return string(resp.Payload.Data), nil
 }
 
 // CreateClient create a ssh client to connect host.


### PR DESCRIPTION
Also move from using the deprecated `ioutil` to using the `os` package for reading files.

The tests include
- Checking 2FA enabled and appropriate headers related to turning 2FA on.
- SSH-ing with OSLogin enabled works as intended
- TODO: SSH-ing with OSLogin 2FA enabled works as intended.