### PR TITLE
Fork Concourse windows image build pipeline for MBR

### DIFF
--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -276,25 +276,13 @@ local ImgGroup(name, images, environments) = {
 
 // Start of output.
 {
-  local windows_2012_images = [
+  local images = [
     'windows-server-2012-r2-dc-mbr',
     'windows-server-2012-r2-dc-core-mbr',
-  ],
-  local windows_2016_images = [
     'windows-server-2016-dc-mbr',
-    'windows-server-2016-dc-core-mbr',
-  ],
-  local windows_2019_images = [
     'windows-server-2019-dc-mbr',
-    'windows-server-2019-dc-core-mbr',
-  ],
-  local windows_2022_images = [
     'windows-server-2022-dc-mbr',
-    'windows-server-2022-dc-core-mbr',
   ],
-
-  local windows_server_images = windows_2012_images + windows_2016_images + windows_2019_images
-                              + windows_2022_images,
 
   resource_types: [
     {
@@ -314,11 +302,11 @@ local ImgGroup(name, images, environments) = {
              ] +
              [
                common.GcsImgResource(image, 'windows-bios')
-               for image in windows_server_images
+               for image in images
              ] +
              [
                common.GcsSbomResource(image, 'windows-server')
-               for image in windows_server_images
+               for image in images
              ],
   jobs: [
           ImgBuildJob('windows-server-2022-dc-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
@@ -333,14 +321,11 @@ local ImgGroup(name, images, environments) = {
 
         [
           ImgPublishJob(image, env, 'windows', 'windows-bios')
-          for image in windows_server_images
+          for image in images
           for env in envs
         ],
 
   groups: [
-    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
-    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
-    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
-    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
+    ImgGroup('windows-mbr', images, envs),
   ],
 }

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -278,11 +278,17 @@ local ImgGroup(name, images, environments) = {
 {
   local images = [
     'windows-server-2012-r2-dc-mbr',
-    'windows-server-2012-r2-dc-core-mbr',
+  ],
+  local windows_2016_images = [
     'windows-server-2016-dc-mbr',
+  ],
+  local windows_2019_images = [
     'windows-server-2019-dc-mbr',
+  ],
+  local windows_2022_images = [
     'windows-server-2022-dc-mbr',
   ],
+
 
   resource_types: [
     {
@@ -310,13 +316,9 @@ local ImgGroup(name, images, environments) = {
              ],
   jobs: [
           ImgBuildJob('windows-server-2022-dc-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
-          ImgBuildJob('windows-server-2022-dc-core-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-2019-dc-mbr', 'win2019-64', 'windows_gcs_updates_server2019'),
-          ImgBuildJob('windows-server-2019-dc-core-mbr', 'win2019-64', 'windows_gcs_updates_server2019'),
           ImgBuildJob('windows-server-2016-dc-mbr', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2016-dc-core-mbr', 'win2016-64', 'windows_gcs_updates_server2016'),
           ImgBuildJob('windows-server-2012-r2-dc-mbr', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
-          ImgBuildJob('windows-server-2012-r2-dc-core-mbr', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
         ] +
 
         [
@@ -326,6 +328,9 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-mbr', images, envs),
+    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
+    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
+    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
+    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
   ],
 }

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -1,0 +1,346 @@
+// Imports.
+local arle = import '../templates/arle.libsonnet';
+local common = import '../templates/common.libsonnet';
+local daisy = import '../templates/daisy.libsonnet';
+local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
+
+local envs = ['testing'];
+local underscore(input) = std.strReplace(input, '-', '_');
+
+// Templates.
+local imgbuildjob = {
+  local job = self,
+
+  image:: error 'must set image in imgbuildjob',
+  workflow:: error 'must set workflow in imgbuildjob',
+  iso_secret:: error 'must set iso_secret in imgbuildjob',
+  updates_secret:: error 'must set updates_secret in imgbuildjob',
+
+  // Start of job.
+  name: 'build-' + job.image,
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  plan: [
+    { get: 'compute-image-tools' },
+    { get: 'guest-test-infra' },
+    {
+      task: 'generate-timestamp',
+      file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+    },
+    {
+      load_var: 'start-timestamp-ms',
+      file: 'timestamp/timestamp-ms',
+    },
+    {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
+      task: 'generate-build-id',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
+      vars: { prefix: job.image, id: '((.:id))'},
+    },
+    {
+      put: job.image + '-gcs',
+      params: { file: 'build-id-dir/%s*' % job.image },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'gcs-url',
+      file: '%s-gcs/url' % job.image,
+    },
+    {
+      task: 'generate-build-id-sbom',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-sbom.yaml',
+      vars: { prefix: job.image, id: '((.:id))'},
+    },
+    {
+      put: job.image + '-sbom',
+      params: {
+        file: 'build-id-dir-sbom/%s*' % job.image,
+      },
+      get_params: {
+        skip_download: 'true',
+      },
+    },
+    {
+      load_var: 'sbom-destination',
+      file: '%s-sbom/url' % job.image,
+    },
+    {
+      task: 'generate-build-date',
+      file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+    },
+    {
+      load_var: 'build-date',
+      file: 'publish-version/version',
+    },
+    {
+      task: 'get-secret-iso',
+      config: gcp_secret_manager.getsecrettask { secret_name: job.iso_secret },
+    },
+    {
+      load_var: 'windows-iso',
+      file: 'gcp-secret-manager/' + job.iso_secret,
+    },
+    {
+      task: 'get-secret-updates',
+      config: gcp_secret_manager.getsecrettask { secret_name: job.updates_secret },
+    },
+    {
+      load_var: 'windows-updates',
+      file: 'gcp-secret-manager/' + job.updates_secret,
+    },
+    {
+      task: 'get-secret-pwsh',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_pwsh' },
+    },
+    // We download and then load each of the 3 following secrets; they could be merged.
+    {
+      load_var: 'windows-gcs-pwsh',
+      file: 'gcp-secret-manager/windows_gcs_pwsh',
+    },
+    {
+      task: 'get-secret-cloud-sdk',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_cloud_sdk' },
+    },
+    {
+      load_var: 'windows-cloud-sdk',
+      file: 'gcp-secret-manager/windows_gcs_cloud_sdk',
+    },
+    {
+      task: 'get-secret-dotnet48',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_dotnet48' },
+    },
+    {
+      load_var: 'windows-gcs-dotnet48',
+      file: 'gcp-secret-manager/windows_gcs_dotnet48',
+    },
+    {
+      task: 'get-secret-sbom-util',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'sbom-util-secret' },
+    },
+    {
+      load_var: 'sbom-util-secret',
+      file: 'gcp-secret-manager/sbom-util-secret',
+    },
+    {
+      task: 'daisy-build',
+      config: daisy.daisyimagetask {
+        gcs_url: '((.:gcs-url))',
+        sbom_destination: '((.:sbom-destination))',
+        workflow: job.workflow,
+        vars+: [
+          'cloudsdk=((.:windows-cloud-sdk))',
+          'dotnet48=((.:windows-gcs-dotnet48))',
+          'media=((.:windows-iso))',
+          'pwsh=((.:windows-gcs-pwsh))',
+          'updates=((.:windows-updates))',
+          'google_cloud_repo=stable',
+          'sbom_util_gcs_root=((.:sbom-util-secret))',
+        ],
+      },
+    },
+  ],
+};
+
+local imgpublishjob = {
+  local job = self,
+
+  image:: error 'must set image in imgpublishjob',
+  env:: error 'must set publish env in imgpublishjob',
+  workflow:: error 'must set workflow in imgpublishjob',
+  gcs_dir:: error 'must set gcs_dir in imgpublishjob',
+  gcs:: 'gs://%s/%s' % [self.gcs_bucket, self.gcs_dir],
+  gcs_bucket:: common.prod_bucket,
+  topic:: common.prod_topic,
+
+  // Publish can proceed if build passes.
+  passed:: if job.env == 'testing' then
+    'build-' + job.image
+  else
+    'publish-to-testing-' + job.image,
+
+  // Builds are automatically pushed to testing.
+  trigger:: if job.env == 'testing' then true
+    else false,
+
+  // Start of job.
+  name: 'publish-to-%s-%s' % [job.env, job.image],
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'windows-image-build',
+      job: job.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  plan: [
+    { get: 'guest-test-infra' },
+    { get: 'compute-image-tools' },
+    {
+      task: 'generate-timestamp',
+      file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+    },
+    {
+      load_var: 'start-timestamp-ms',
+      file: 'timestamp/timestamp-ms',
+    },
+    {
+      get: '%s-gcs' % job.image,
+      params: { skip_download: 'true' },
+      passed: [job.passed],
+      trigger: job.trigger,
+    },
+    {
+      load_var: 'source-version',
+      file: '%s-gcs/version' % job.image,
+    },
+    {
+      task: 'generate-version',
+      file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+    },
+    {
+      load_var: 'publish-version',
+      file: 'publish-version/version',
+    },
+    {
+      task: 'gce-image-publish-' + job.image,
+      config: arle.gcepublishtask {
+        source_gcs_path: job.gcs,
+        source_version: 'v((.:source-version))',
+        publish_version: '((.:publish-version))',
+        wf: job.workflow,
+        environment: if job.env == 'testing' then 'test' else job.env,
+      },
+    },
+  ],
+};
+
+local ImgBuildJob(image, iso_secret, updates_secret) = imgbuildjob {
+  image: image,
+  iso_secret: iso_secret,
+  updates_secret: updates_secret,
+  workflow: 'windows/%s-bios.wf.json' % image,
+};
+
+local ImgPublishJob(image, env, workflow_dir, gcs_dir) = imgpublishjob {
+  image: image,
+  env: env,
+  gcs_dir: gcs_dir,
+  passed:: 'build-' + image,
+  workflow: '%s/%s' % [workflow_dir, image + '-bios.publish.json'],
+};
+
+local ImgGroup(name, images, environments) = {
+  name: name,
+  jobs: [
+    'build-' + image
+    for image in images
+  ] + [
+    'publish-to-%s-%s' % [env, image]
+    for env in environments
+    for image in images
+  ],
+};
+
+// Start of output.
+{
+  local windows_2012_images = [
+    'windows-server-2012-r2-dc-mbr',
+    'windows-server-2012-r2-dc-core-mbr',
+  ],
+  local windows_2016_images = [
+    'windows-server-2016-dc-mbr',
+    'windows-server-2016-dc-core-mbr',
+  ],
+  local windows_2019_images = [
+    'windows-server-2019-dc-mbr',
+    'windows-server-2019-dc-core-mbr',
+  ],
+  local windows_2022_images = [
+    'windows-server-2022-dc-mbr',
+    'windows-server-2022-dc-core-mbr',
+  ],
+
+  local windows_server_images = windows_2012_images + windows_2016_images + windows_2019_images
+                              + windows_2022_images,
+
+  resource_types: [
+    {
+      name: 'gcs',
+      source: { repository: 'frodenas/gcs-resource' },
+      type: 'registry-image',
+    },
+    {
+      name: 'registry-image-forked',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
+    },
+  ],
+  resources: [
+               common.GitResource('compute-image-tools'),
+               common.GitResource('guest-test-infra'),
+             ] +
+             [
+               common.GcsImgResource(image, 'windows-bios')
+               for image in windows_server_images
+             ] +
+             [
+               common.GcsSbomResource(image, 'windows-server')
+               for image in windows_server_images
+             ],
+  jobs: [
+          ImgBuildJob('windows-server-2022-dc-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2022-dc-core-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2019-dc-mbr', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2019-dc-core-mbr', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2016-dc-mbr', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2016-dc-core-mbr', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2012-r2-dc-mbr', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
+          ImgBuildJob('windows-server-2012-r2-dc-core-mbr', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
+        ] +
+
+        [
+          ImgPublishJob(image, env, 'windows', 'windows-bios')
+          for image in windows_server_images
+          for env in envs
+        ],
+
+  groups: [
+    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
+    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
+    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
+    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
+  ],
+}

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -276,7 +276,7 @@ local ImgGroup(name, images, environments) = {
 
 // Start of output.
 {
-  local images = [
+  local windows_2012_images = [
     'windows-server-2012-r2-dc-mbr',
   ],
   local windows_2016_images = [
@@ -289,6 +289,8 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2022-dc-mbr',
   ],
 
+  local images = windows_2012_images + windows_2016_images + windows_2019_images
+               + windows_2022_images,
 
   resource_types: [
     {


### PR DESCRIPTION
Adds MBR builds as a separate pipeline to be run ad-hoc