### PR TITLE
Add wait for vm quota test workflow step, and functions to append quotas

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -32,21 +32,22 @@ import (
 )
 
 var (
-	project       = flag.String("project", "", "project to use for test runner")
-	testProjects  = flag.String("test_projects", "", "comma separated list of projects to be used for tests. defaults to the test runner project")
-	zone          = flag.String("zone", "us-central1-a", "zone to be used for tests")
-	printwf       = flag.Bool("print", false, "print out the parsed test workflows and exit")
-	validate      = flag.Bool("validate", false, "validate all the test workflows and exit")
-	outPath       = flag.String("out_path", "junit.xml", "junit xml path")
-	gcsPath       = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
-	images        = flag.String("images", "", "comma separated list of images to test")
-	timeout       = flag.String("timeout", "45m", "timeout for the test suite")
-	parallelCount = flag.Int("parallel_count", 5, "TestParallelCount")
-	filter        = flag.String("filter", "", "only run tests matching filter")
-	exclude       = flag.String("exclude", "", "skip tests matching filter")
-	machineType   = flag.String("machine_type", "", "deprecated, use -x86_shape and/or -arm64_shape instead")
-	x86Shape      = flag.String("x86_shape", "n1-standard-1", "default x86(-32 and -64) vm shape for tests not requiring a specific shape")
-	arm64Shape    = flag.String("arm64_shape", "t2a-standard-1", "default arm64 vm shape for tests not requiring a specific shape")
+	project         = flag.String("project", "", "project to use for test runner")
+	testProjects    = flag.String("test_projects", "", "comma separated list of projects to be used for tests. defaults to the test runner project")
+	zone            = flag.String("zone", "us-central1-a", "zone to be used for tests")
+	printwf         = flag.Bool("print", false, "print out the parsed test workflows and exit")
+	validate        = flag.Bool("validate", false, "validate all the test workflows and exit")
+	outPath         = flag.String("out_path", "junit.xml", "junit xml path")
+	gcsPath         = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
+	images          = flag.String("images", "", "comma separated list of images to test")
+	timeout         = flag.String("timeout", "45m", "timeout for the test suite")
+	parallelCount   = flag.Int("parallel_count", 5, "TestParallelCount")
+	parallelStagger = flag.String("parallel_stagger", "60s", "parseable time.Duration to stagger each parallel test")
+	filter          = flag.String("filter", "", "only run tests matching filter")
+	exclude         = flag.String("exclude", "", "skip tests matching filter")
+	machineType     = flag.String("machine_type", "", "deprecated, use -x86_shape and/or -arm64_shape instead")
+	x86Shape        = flag.String("x86_shape", "n1-standard-1", "default x86(-32 and -64) vm shape for tests not requiring a specific shape")
+	arm64Shape      = flag.String("arm64_shape", "t2a-standard-1", "default arm64 vm shape for tests not requiring a specific shape")
 )
 
 var (
@@ -277,7 +278,7 @@ func main() {
 		return
 	}
 
-	suites, err := imagetest.RunTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *parallelCount, testProjectsReal)
+	suites, err := imagetest.RunTests(ctx, client, testWorkflows, *project, *zone, *gcsPath, *parallelCount, *parallelStagger, testProjectsReal)
 	if err != nil {
 		log.Fatalf("Failed to run tests: %v", err)
 	}

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -82,11 +82,6 @@ func (t *TestWorkflow) LockProject() {
 
 // WaitForVMQuota appends a list of quotas to the wait for vm quota step. Quotas with a blank region will be populated with the region corresponding to the workflow zone.
 func (t *TestWorkflow) WaitForVMQuota(qa ...*daisy.QuotaAvailable) error {
-	for _, q := range qa {
-		if q == nil {
-			return fmt.Errorf("not append a nil pointer to quota")
-		}
-	}
 	step, ok := t.wf.Steps[waitForVMQuotaStepName]
 	if !ok {
 		step, err := t.wf.NewStep(waitForVMQuotaStepName)

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	waitForVMQuotaStepName   = "wait-for-vm-quota"
 	createVMsStepName        = "create-vms"
 	createDisksStepName      = "create-disks"
 	createNetworkStepName    = "create-networks"
@@ -77,6 +78,25 @@ func (t *TestWorkflow) SkippedMessage() string {
 // exclusive use of the project.
 func (t *TestWorkflow) LockProject() {
 	t.lockProject = true
+}
+
+// WaitForVMQuota appends a list of quotas to the wait for vm quota step. Quotas with a blank region will be populated with the region corresponding to the workflow zone.
+func (t *TestWorkflow) WaitForVMQuota(qa ...*daisy.QuotaAvailable) error {
+	for _, q := range qa {
+		if q == nil {
+			return fmt.Errorf("not append a nil pointer to quota")
+		}
+	}
+	step, ok := t.wf.Steps[waitForVMQuotaStepName]
+	if !ok {
+		step, err := t.wf.NewStep(waitForVMQuotaStepName)
+		if err != nil {
+			return err
+		}
+		step.WaitForAvailableQuotas = &daisy.WaitForAvailableQuotas{}
+	}
+	step.WaitForAvailableQuotas.Quotas = append(step.WaitForAvailableQuotas.Quotas, qa...)
+	return nil
 }
 
 // CreateTestVM adds the necessary steps to create a VM with the specified

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -81,7 +81,7 @@ func (t *TestWorkflow) LockProject() {
 }
 
 // WaitForVMQuota appends a list of quotas to the wait for vm quota step. Quotas with a blank region will be populated with the region corresponding to the workflow zone.
-func (t *TestWorkflow) WaitForVMQuota(qa ...*daisy.QuotaAvailable) error {
+func (t *TestWorkflow) WaitForVMQuota(qa *daisy.QuotaAvailable) error {
 	step, ok := t.wf.Steps[waitForVMQuotaStepName]
 	if !ok {
 		step, err := t.wf.NewStep(waitForVMQuotaStepName)
@@ -90,7 +90,7 @@ func (t *TestWorkflow) WaitForVMQuota(qa ...*daisy.QuotaAvailable) error {
 		}
 		step.WaitForAvailableQuotas = &daisy.WaitForAvailableQuotas{}
 	}
-	step.WaitForAvailableQuotas.Quotas = append(step.WaitForAvailableQuotas.Quotas, qa...)
+	step.WaitForAvailableQuotas.Quotas = append(step.WaitForAvailableQuotas.Quotas, qa)
 	return nil
 }
 

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cloud.google.com/go/storage v1.31.0
-	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230630215637-031fb762c645
+	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f
 	github.com/go-ping/ping v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/jstemmer/go-junit-report v1.0.0

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -21,6 +21,8 @@ cloud.google.com/go/storage v1.31.0/go.mod h1:81ams1PrhW16L4kF7qg+4mTq7SRs5HsbDT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230630215637-031fb762c645 h1:wUeW0BetFkhINHcxtAt/5HkYKfsyyD5mcNVOKzzhwHQ=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230630215637-031fb762c645/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f h1:fHLga6U5ibwILQYGom/Fta6xJpn8DJ/XbIRmVaySLjA=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/imagetest/test_suites/shapevalidation/setup.go
+++ b/imagetest/test_suites/shapevalidation/setup.go
@@ -119,8 +119,10 @@ Familyloop:
 				continue Familyloop
 			}
 		}
-		if err := t.WaitForVMQuota(shape.quota); shape.quota != nil && err != nil {
-			return err
+		if shape.quota != nil {
+			if err := t.WaitForVMQuota(shape.quota); err != nil {
+				return err
+			}
 		}
 		vm, err := t.CreateTestVMMultipleDisks(shape.disks, map[string]string{})
 		if err != nil {

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -584,7 +584,7 @@ func RunTests(ctx context.Context, storageClient *storage.Client, testWorkflows 
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			time.Sleep(time.Duration(int64(id) * int64(stagger)))
+			time.Sleep(time.Duration(id) * stagger)
 			for test := range testchan {
 				if test.lockProject {
 					// This will block until an exclusive project is available.


### PR DESCRIPTION
During testing I ran into a lot of problems with finding free quota that was taken by the time vm creation started. Some of this is unavoidable because daisy takes a second to switch between steps, but I mitigated the problem by staggering parallel workers. Most of this can be avoided by just waiting 60-90 seconds after starting a workflow.

The other thing I did was break this up from one large wait-for-quota step that all creation steps depend on, to quota steps for each create step. But the only create step that actually needs enough quota to worry about right now is the create VMs step, so I just took the others out avoid to avoiding leaving in unused code.

If it's not clear enough that the existing API is only for quota that gates VM creation I can add some comments expanding on this in the code.

Previous PR before I reset my branch and dropped changes on master: https://github.com/GoogleCloudPlatform/guest-test-infra/pull/823 This one is not identical, I went back and revised the API a bit.