### PR TITLE
Revert "Add back guest attributes with fix for metadata shutdown test…

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -24,21 +23,12 @@ func main() {
 		log.Fatalf("failed to create cloud storage client: %v", err)
 	}
 	log.Printf("FINISHED-BOOTING")
-	defer func(ctx context.Context) {
-		if err := utils.QueryMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey, http.MethodPut); err != nil {
-			log.Printf("failed to put test completed key in guest attribute namespace")
-		}
-		log.Printf("successfully placed guest attribute for test completion")
+	defer func() {
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)
 		}
-		time.Sleep(10 * time.Second)
-		if err := utils.QueryMetadataGuestAttribute(ctx, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey, http.MethodDelete); err != nil {
-			log.Printf("failed to delete completed key in guest attribute namespace")
-		}
-		log.Printf("successfuilly deleted guest attribute")
-	}(ctx)
+	}()
 
 	daisyOutsPath, err := utils.GetMetadataAttribute("daisy-outs-path")
 	if err != nil {

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -231,13 +231,7 @@ func (t *TestWorkflow) addWaitStep(stepname, vmname string) (*daisy.Step, error)
 	instanceSignal.Name = vmname
 	instanceSignal.Stopped = false
 
-	guestAttribute := &daisy.GuestAttribute{}
-	guestAttribute.Namespace = utils.GuestAttributeTestNamespace
-	guestAttribute.KeyName = utils.GuestAttributeTestKey
-
 	instanceSignal.SerialOutput = serialOutput
-	instanceSignal.GuestAttribute = guestAttribute
-	instanceSignal.Interval = "8s"
 
 	waitForInstances := &daisy.WaitForInstancesSignal{instanceSignal}
 

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -109,22 +109,22 @@ func GetMetadataHTTPResponse(path string) (*http.Response, error) {
 	return resp, nil
 }
 
-// QueryMetadataGuestAttribute queries the guest attribute in the namespace using the given http method, and returns an error if this operation fails.
-func QueryMetadataGuestAttribute(ctx context.Context, namespace, attribute, httpMethod string) error {
+// PutMetadataGuestAttribute sets the guest attribute in the namespace, and returns an error if this operation fails.
+func PutMetadataGuestAttribute(ctx context.Context, namespace, attribute string) error {
 	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)
 	if err != nil {
 		return err
 	}
-	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
+	err = PutMetadataHTTPResponse(ctx, path)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// QueryMetadataHTTPResponse returns http response for the specified key and httpMethod without checking status code.
-func QueryMetadataHTTPResponse(ctx context.Context, path, httpMethod string) error {
-	req, err := http.NewRequestWithContext(ctx, httpMethod, path, nil)
+// PutMetadataHTTPResponse returns http response for the specified key without checking status code.
+func PutMetadataHTTPResponse(ctx context.Context, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
… (#826)"

This reverts commit 79985dd33b529a7f949d8cfcb2fa6f6cfaa11394.

On some operating systems, the delete guest attribute operation might not be happening. 

To make this robust, we will eventually add back guest attributes. However, we also plan to add a guest-attribute flag, so that if a test needs to run on the reboot, the test "wrapper" binary does not run on the first boot. 