### PR TITLE
Enable MBR Windows pipeline, remove standard Windows pipeline

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -40,6 +40,8 @@ jobs:
     file: rendered/windows-image-build.json
   - set_pipeline: windows-image-build-staging
     file: rendered/windows-image-build-staging.json
+  - set_pipeline: windows-image-build-standard
+    file: rendered/windows-image-build-standard.json
   - set_pipeline: windows-image-build-mbr
     file: rendered/windows-image-build-mbr.json
   - set_pipeline: container-build

--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -40,8 +40,8 @@ jobs:
     file: rendered/windows-image-build.json
   - set_pipeline: windows-image-build-staging
     file: rendered/windows-image-build-staging.json
-  - set_pipeline: windows-image-build-standard
-    file: rendered/windows-image-build-standard.json
+  - set_pipeline: windows-image-build-mbr
+    file: rendered/windows-image-build-mbr.json
   - set_pipeline: container-build
     file: rendered/container-build.json
   - set_pipeline: artifact-releaser-test


### PR DESCRIPTION
Adds the MBR pipeline to the setting of pipelines. Also removes the Standard edition Windows Server from the active pipelines (but not removing the config in case it is needed later).