### PR TITLE
Double boot changes

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -22,17 +22,23 @@ func main() {
 	log.Printf("FINISHED-BOOTING")
 	ctx := context.Background()
 	skipOnBootAttributeKey := "skipOnBoot"
+	rebootedNamespace := "reboot"
+	rebootedKey := "rebooted"
+	log.Printf("checking skipboot case")
 	// Special case where we want to boot twice but skip running the wrapper on the first boot
 	skipOnBoot, err := utils.GetMetadataAttribute(skipOnBootAttributeKey)
 	if err != nil {
-		log.Printf("did not find skip on boot metadata key")
+		log.Printf("did not find skip on boot metadata key %v", err)
 	}
-	if skipOnBoot == "true" {
-		if err = utils.QueryMetadataAttribute(ctx, skipOnBootAttributeKey, http.MethodDelete); err != nil {
-			log.Fatalf("could not delete skipOnBoot metadata attribute")
+	err = utils.QueryMetadataGuestAttribute(ctx, rebootedNamespace, rebootedKey, http.MethodGet)
+	log.Printf("rebooted error was %v", err)
+	if skipOnBoot == "true" && err != nil {
+		if err = utils.QueryMetadataGuestAttribute(ctx, rebootedNamespace, rebootedKey, http.MethodPut); err != nil {
+			log.Printf("could not place guest attribute rebooted key")
 		}
 		os.Exit(0)
 	}
+	log.Printf("continuing past skipboot")
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		log.Fatalf("failed to create cloud storage client: %v", err)

--- a/imagetest/test_suites/metadata/setup.go
+++ b/imagetest/test_suites/metadata/setup.go
@@ -37,14 +37,14 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm2, err := t.CreateTestVM("vm2")
+	vm2, err := t.CreateTestVMAndReboot("vm2")
 	if err != nil {
 		return err
 	}
 	vm2.AddMetadata("enable-guest-attributes", "TRUE")
-	if err := vm2.Reboot(); err != nil {
-		return err
-	}
+	//if err := vm2.Reboot(); err != nil {
+	//	return err
+	//}
 
 	vm3, err := t.CreateTestVM("vm3")
 	if err != nil {

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -122,6 +122,11 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 	}
 
 	instance.Metadata = make(map[string]string)
+	// skipOnBoot should be set to any string if this is the first boot and we want to skip
+	// running the test until the reboot
+	if skipOnBoot, foundKey := instanceParams["skipOnBoot"]; foundKey {
+		instance.Metadata["skipOnBoot"] = skipOnBoot
+	}
 	instance.Metadata["_test_vmname"] = name
 	instance.Metadata["_test_package_url"] = "${SOURCESPATH}/testpackage"
 	instance.Metadata["_test_results_url"] = fmt.Sprintf("${OUTSPATH}/%s.txt", name)

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -109,22 +109,35 @@ func GetMetadataHTTPResponse(path string) (*http.Response, error) {
 	return resp, nil
 }
 
-// PutMetadataGuestAttribute sets the guest attribute in the namespace, and returns an error if this operation fails.
-func PutMetadataGuestAttribute(ctx context.Context, namespace, attribute string) error {
-	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)
+// QueryMetadataAttribute queries the attribute using the given http method, and returns an error if this operation fails.
+func QueryMetadataAttribute(ctx context.Context, attribute, httpMethod string) error {
+	path, err := url.JoinPath(metadataURLPrefix, attribute)
 	if err != nil {
 		return err
 	}
-	err = PutMetadataHTTPResponse(ctx, path)
+	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// PutMetadataHTTPResponse returns http response for the specified key without checking status code.
-func PutMetadataHTTPResponse(ctx context.Context, path string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, nil)
+// QueryMetadataGuestAttribute queries the guest attribute in the namespace using the given http method, and returns an error if this operation fails.
+func QueryMetadataGuestAttribute(ctx context.Context, namespace, attribute, httpMethod string) error {
+	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)
+	if err != nil {
+		return err
+	}
+	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// QueryMetadataHTTPResponse returns http response for the specified key and httpMethod without checking status code.
+func QueryMetadataHTTPResponse(ctx context.Context, path, httpMethod string) error {
+	req, err := http.NewRequestWithContext(ctx, httpMethod, path, nil)
 	if err != nil {
 		return err
 	}

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -109,19 +109,6 @@ func GetMetadataHTTPResponse(path string) (*http.Response, error) {
 	return resp, nil
 }
 
-// QueryMetadataAttribute queries the attribute using the given http method, and returns an error if this operation fails.
-func QueryMetadataAttribute(ctx context.Context, attribute, httpMethod string) error {
-	path, err := url.JoinPath(metadataURLPrefix, attribute)
-	if err != nil {
-		return err
-	}
-	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // QueryMetadataGuestAttribute queries the guest attribute in the namespace using the given http method, and returns an error if this operation fails.
 func QueryMetadataGuestAttribute(ctx context.Context, namespace, attribute, httpMethod string) error {
 	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)


### PR DESCRIPTION
Revamp the shutdown script tests a little bit, so that the boot does not need to wait for a signal before reboot.