### PR TITLE
Update MBR build pipeline image/workflow naming

### DIFF
--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -277,16 +277,16 @@ local ImgGroup(name, images, environments) = {
 // Start of output.
 {
   local windows_2012_images = [
-    'windows-server-2012-r2-dc-mbr',
+    'windows-server-2012-r2-dc-bios',
   ],
   local windows_2016_images = [
-    'windows-server-2016-dc-mbr',
+    'windows-server-2016-dc-bios',
   ],
   local windows_2019_images = [
-    'windows-server-2019-dc-mbr',
+    'windows-server-2019-dc-bios',
   ],
   local windows_2022_images = [
-    'windows-server-2022-dc-mbr',
+    'windows-server-2022-dc-bios',
   ],
 
   local images = windows_2012_images + windows_2016_images + windows_2019_images
@@ -317,10 +317,10 @@ local ImgGroup(name, images, environments) = {
                for image in images
              ],
   jobs: [
-          ImgBuildJob('windows-server-2022-dc-mbr', 'win2022-64', 'windows_gcs_updates_server2022'),
-          ImgBuildJob('windows-server-2019-dc-mbr', 'win2019-64', 'windows_gcs_updates_server2019'),
-          ImgBuildJob('windows-server-2016-dc-mbr', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2-dc-mbr', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
+          ImgBuildJob('windows-server-2022-dc-bios', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2019-dc-bios', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2016-dc-bios', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2012-r2-dc-bios', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
         ] +
 
         [
@@ -330,9 +330,9 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
-    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
-    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
-    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
+    ImgGroup('windows-2012-bios', windows_2012_images, envs),
+    ImgGroup('windows-2016-bios', windows_2016_images, envs),
+    ImgGroup('windows-2019-bios', windows_2019_images, envs),
+    ImgGroup('windows-2022-bios', windows_2022_images, envs),
   ],
 }

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -277,16 +277,16 @@ local ImgGroup(name, images, environments) = {
 // Start of output.
 {
   local windows_2012_images = [
-    'windows-server-2012-r2-dc-bios',
+    'windows-server-2012-r2-dc',
   ],
   local windows_2016_images = [
-    'windows-server-2016-dc-bios',
+    'windows-server-2016-dc',
   ],
   local windows_2019_images = [
-    'windows-server-2019-dc-bios',
+    'windows-server-2019-dc',
   ],
   local windows_2022_images = [
-    'windows-server-2022-dc-bios',
+    'windows-server-2022-dc',
   ],
 
   local images = windows_2012_images + windows_2016_images + windows_2019_images
@@ -317,10 +317,10 @@ local ImgGroup(name, images, environments) = {
                for image in images
              ],
   jobs: [
-          ImgBuildJob('windows-server-2022-dc-bios', 'win2022-64', 'windows_gcs_updates_server2022'),
-          ImgBuildJob('windows-server-2019-dc-bios', 'win2019-64', 'windows_gcs_updates_server2019'),
-          ImgBuildJob('windows-server-2016-dc-bios', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2-dc-bios', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
+          ImgBuildJob('windows-server-2022-dc', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2019-dc', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2016-dc', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2012-r2-dc', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
         ] +
 
         [
@@ -330,9 +330,9 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-2012-bios', windows_2012_images, envs),
-    ImgGroup('windows-2016-bios', windows_2016_images, envs),
-    ImgGroup('windows-2019-bios', windows_2019_images, envs),
-    ImgGroup('windows-2022-bios', windows_2022_images, envs),
+    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
+    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
+    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
+    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
   ],
 }


### PR DESCRIPTION
Less confusing to read, also matching the naming convention used in the UEFI build pipeline.