### PR TITLE
Update image and sbom naming for MBR pipeline

### DIFF
--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -317,10 +317,10 @@ local ImgGroup(name, images, environments) = {
                for image in images
              ],
   jobs: [
-          ImgBuildJob('windows-server-2022-dc', 'win2022-64', 'windows_gcs_updates_server2022'),
-          ImgBuildJob('windows-server-2019-dc', 'win2019-64', 'windows_gcs_updates_server2019'),
-          ImgBuildJob('windows-server-2016-dc', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2-dc', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
+          ImgBuildJob('windows-server-2022-dc-bios', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2019-dc-bios', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2016-dc-bios', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2012-r2-dc-bios', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
         ] +
 
         [
@@ -330,9 +330,9 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-2012-mbr', windows_2012_images, envs),
-    ImgGroup('windows-2016-mbr', windows_2016_images, envs),
-    ImgGroup('windows-2019-mbr', windows_2019_images, envs),
-    ImgGroup('windows-2022-mbr', windows_2022_images, envs),
+    ImgGroup('windows-2012-bios', windows_2012_images, envs),
+    ImgGroup('windows-2016-bios', windows_2016_images, envs),
+    ImgGroup('windows-2019-bios', windows_2019_images, envs),
+    ImgGroup('windows-2022-bios', windows_2022_images, envs),
   ],
 }

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -251,7 +251,7 @@ local ImgBuildJob(image, iso_secret, updates_secret) = imgbuildjob {
   image: image,
   iso_secret: iso_secret,
   updates_secret: updates_secret,
-  workflow: 'windows/%s-bios.wf.json' % image,
+  workflow: 'windows/%s.wf.json' % image,
 };
 
 local ImgPublishJob(image, env, workflow_dir, gcs_dir) = imgpublishjob {
@@ -277,16 +277,16 @@ local ImgGroup(name, images, environments) = {
 // Start of output.
 {
   local windows_2012_images = [
-    'windows-server-2012-r2-dc',
+    'windows-server-2012-r2-dc-bios',
   ],
   local windows_2016_images = [
-    'windows-server-2016-dc',
+    'windows-server-2016-dc-bios',
   ],
   local windows_2019_images = [
-    'windows-server-2019-dc',
+    'windows-server-2019-dc-bios',
   ],
   local windows_2022_images = [
-    'windows-server-2022-dc',
+    'windows-server-2022-dc-bios',
   ],
 
   local images = windows_2012_images + windows_2016_images + windows_2019_images
@@ -313,7 +313,7 @@ local ImgGroup(name, images, environments) = {
                for image in images
              ] +
              [
-               common.GcsSbomResource(image, 'windows-server')
+               common.GcsSbomResource(image, 'windows-server-bios')
                for image in images
              ],
   jobs: [


### PR DESCRIPTION
Prevents collision for sboms, and makes job build names easier to distinguish from uefi