### PR TITLE
Wait for CPUS instead of N1 CPUs during N1 shape validation

### DIFF
--- a/imagetest/test_suites/shapevalidation/setup.go
+++ b/imagetest/test_suites/shapevalidation/setup.go
@@ -84,7 +84,7 @@ var x86shapes = map[string]*shape{
 		mem:   624,
 		numa:  2,
 		disks: []*compute.Disk{{Name: "N1", Type: imagetest.PdStandard}},
-		quota: &daisy.QuotaAvailable{Metric: "N1_CPUS", Units: 96},
+		quota: &daisy.QuotaAvailable{Metric: "CPUS", Units: 96},
 	},
 }
 


### PR DESCRIPTION
/assign @zmarano 