### PR TITLE
Shutdown Script Minor Change

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -25,7 +25,7 @@ func main() {
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
 		if willRebootDuringTest, err := utils.GetMetadataAttribute("willRebootDuringTest"); err != nil {
-			log.Printf("found reboot metadata key")
+			log.Printf("found reboot metadata key %s", willRebootDuringTest)
 		}
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")

--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -24,9 +24,6 @@ func main() {
 	}
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
-		if willRebootDuringTest, err := utils.GetMetadataAttribute("willRebootDuringTest"); err != nil {
-			log.Printf("found reboot metadata key %s", willRebootDuringTest)
-		}
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)

--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -24,6 +24,9 @@ func main() {
 	}
 	log.Printf("FINISHED-BOOTING")
 	defer func() {
+		if willRebootDuringTest, err := utils.GetMetadataAttribute("willRebootDuringTest"); err != nil {
+			log.Printf("found reboot metadata key")
+		}
 		for f := 0; f < 5; f++ {
 			log.Printf("FINISHED-TEST")
 			time.Sleep(1 * time.Second)

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -165,7 +165,7 @@ func (t *TestWorkflow) CreateTestVMWithReboot(name string) (*TestVM, error) {
 		return nil, err
 	}
 
-	// this wait step will wait for a special guest attribute to indicate 
+	// this wait step will wait for a special guest attribute to indicate
 	// that it is the first boot before a reboot.
 	waitStep, err := t.addWaitRebootGAStep(vmname, vmname)
 	if err != nil {

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -34,6 +34,9 @@ const (
 	createFirewallStepName   = "create-firewalls"
 	createSubnetworkStepName = "create-sub-networks"
 	successMatch             = "FINISHED-TEST"
+	// ShouldRebootDuringTest is a local map key to indicate that the
+	// test will reboot and relies on results from the second boot.
+	ShouldRebootDuringTest = "shouldRebootDuringTest"
 	// DefaultSourceRange is the RFC-1918 range used in default rules.
 	DefaultSourceRange = "10.128.0.0/9"
 
@@ -141,56 +144,6 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	return &TestVM{name: vmname, testWorkflow: t, instance: i}, nil
 }
 
-// CreateTestVMWithReboot adds the necessary steps to create a VM with the
-// specified name to the workflow, while expecting that it will be rebooted.
-// This should only be used in cases where there is a special interaction
-// with the wrapper binary, such as in the shutdown script tests.
-func (t *TestWorkflow) CreateTestVMWithReboot(name string) (*TestVM, error) {
-	parts := strings.Split(name, ".")
-	vmname := strings.ReplaceAll(parts[0], "_", "-")
-
-	bootDisk := &compute.Disk{Name: vmname}
-	createDisksStep, err := t.appendCreateDisksStep(bootDisk)
-	if err != nil {
-		return nil, err
-	}
-
-	// createDisksStep doesn't depend on any other steps.
-	createVMStep, i, err := t.appendCreateVMStep([]*compute.Disk{bootDisk}, map[string]string{"hostname": name, "shouldRebootDuringTest": "true"})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
-		return nil, err
-	}
-
-	// this wait step will wait for a special guest attribute to indicate
-	// that it is the first boot before a reboot.
-	waitStep, err := t.addWaitRebootGAStep(vmname, vmname)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := t.wf.AddDependency(waitStep, createVMStep); err != nil {
-		return nil, err
-	}
-
-	if createSubnetworkStep, ok := t.wf.Steps[createSubnetworkStepName]; ok {
-		if err := t.wf.AddDependency(createVMStep, createSubnetworkStep); err != nil {
-			return nil, err
-		}
-	}
-
-	if createNetworkStep, ok := t.wf.Steps[createNetworkStepName]; ok {
-		if err := t.wf.AddDependency(createVMStep, createNetworkStep); err != nil {
-			return nil, err
-		}
-	}
-
-	return &TestVM{name: vmname, testWorkflow: t, instance: i}, nil
-}
-
 // CreateTestVMMultipleDisks adds the necessary steps to create a VM with the specified
 // name to the workflow.
 func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instanceParams map[string]string) (*TestVM, error) {
@@ -231,7 +184,15 @@ func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instance
 		}
 	}
 
-	waitStep, err := t.addWaitStep(vmname, vmname)
+	// In a follow-up, guest attribute support will be added.
+	// If this is the first boot before a reboot, this should use a
+	// different guest attribute when waiting for the instance signal.
+	var waitStep *daisy.Step
+	if _, foundKey := instanceParams[ShouldRebootDuringTest]; foundKey {
+		waitStep, err = t.addWaitRebootGAStep(vmname, vmname)
+	} else {
+		waitStep, err = t.addWaitStep(vmname, vmname)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/imagetest/test_suites/metadata/setup.go
+++ b/imagetest/test_suites/metadata/setup.go
@@ -37,7 +37,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm2, err := t.CreateTestVM("vm2")
+	vm2, err := t.CreateTestVMWithReboot("vm2")
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm3, err := t.CreateTestVM("vm3")
+	vm3, err := t.CreateTestVMWithReboot("vm3")
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm4, err := t.CreateTestVM("vm4")
+	vm4, err := t.CreateTestVMWithReboot("vm4")
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm5, err := t.CreateTestVM("vm5")
+	vm5, err := t.CreateTestVMWithReboot("vm5")
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/metadata/setup.go
+++ b/imagetest/test_suites/metadata/setup.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+	"google.golang.org/api/compute/v1"
 )
 
 // Name is the name of the test package. It must match the directory name.
@@ -37,7 +38,8 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm2, err := t.CreateTestVMWithReboot("vm2")
+	shutdownScriptParams := map[string]string{imagetest.ShouldRebootDuringTest: "true"}
+	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm2"}}, shutdownScriptParams)
 	if err != nil {
 		return err
 	}
@@ -46,7 +48,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm3, err := t.CreateTestVMWithReboot("vm3")
+	vm3, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm3"}}, shutdownScriptParams)
 	if err != nil {
 		return err
 	}
@@ -55,7 +57,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm4, err := t.CreateTestVMWithReboot("vm4")
+	vm4, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm4"}}, shutdownScriptParams)
 	if err != nil {
 		return err
 	}
@@ -64,7 +66,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm5, err := t.CreateTestVMWithReboot("vm5")
+	vm5, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm5"}}, shutdownScriptParams)
 	if err != nil {
 		return err
 	}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -123,8 +123,8 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 
 	instance.Metadata = make(map[string]string)
 	// set this metadata key to indicate to the wrapper that the we are running a test with both a boot and a reboot.
-	if willRebootDuringTest, foundKey := instanceParams["willRebootDuringTest"]; foundKey {
-		instance.Metadata["willRebootDuringTest"] = willRebootDuringTest
+	if shouldRebootDuringTest, foundKey := instanceParams[ShouldRebootDuringTest]; foundKey {
+		instance.Metadata[ShouldRebootDuringTest] = shouldRebootDuringTest
 	}
 	instance.Metadata["_test_vmname"] = name
 	instance.Metadata["_test_package_url"] = "${SOURCESPATH}/testpackage"


### PR DESCRIPTION
Minor change to the wait step for tests running the shutdown scripts.

This is in preparation for adding guest attributes: after a follow up change, the first boot of the shutdown script will wait for a guest attribute with a special name. This should make the shutdown script test robust even after using guest attributes instead of the serial log.