### PR TITLE
Skip broken secureboot test on opensuse-leap arm

### DIFF
--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -17,9 +17,9 @@ var sbUnsupported = []*regexp.Regexp{
 	regexp.MustCompile("windows-server-2012-r2-dc-core"), // Working but not easily testable and EOL in 1.5 months
 	// Temporary exceptions
 	// Waiting on MSFT signed shims:
-	regexp.MustCompile("rocky-linux-[89].*arm64"), // https://bugs.rockylinux.org/view.php?id=4027
-	regexp.MustCompile("rhel-9.*arm64"),           // https://bugzilla.redhat.com/show_bug.cgi?id=2103803
-	regexp.MustCompile("sles-15.*arm64"),          // https://bugzilla.suse.com/show_bug.cgi?id=1214761
+	regexp.MustCompile("rocky-linux-[89].*arm64"),        // https://bugs.rockylinux.org/view.php?id=4027
+	regexp.MustCompile("rhel-9.*arm64"),                  // https://bugzilla.redhat.com/show_bug.cgi?id=2103803
+	regexp.MustCompile("(sles-15|opensuse-leap).*arm64"), // https://bugzilla.suse.com/show_bug.cgi?id=1214761
 }
 
 // TestSetup sets up the test workflow.


### PR DESCRIPTION
"imageboot-opensuse-leap-arm64: TestGuestSecureBoot" failing repeatedly: https://oss.gprow.dev/view/gs/oss-prow/logs/cit-periodics/1712071098494881792
/cc @zmarano @jjerger @drewhli @koln67 