### PR TITLE
Catch up Windows Staging pipeline to current state

### DIFF
--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -544,10 +544,6 @@ local ImgGroup(name, images) = {
   local windows_11_images = [
     'windows-11-21h2-ent-x64',
   ],
-  local windows_2012_images = [
-    'windows-server-2012-r2-dc',
-    'windows-server-2012-r2-dc-core',
-  ],
   local windows_2016_images = [
     'windows-server-2016-dc',
     'windows-server-2016-dc-core',
@@ -561,19 +557,13 @@ local ImgGroup(name, images) = {
     'windows-server-2022-dc-core',
   ],
   local sql_2014_images = [
-    'sql-2014-enterprise-windows-2012-r2-dc',
     'sql-2014-enterprise-windows-2016-dc',
-    'sql-2014-standard-windows-2012-r2-dc',
-    'sql-2014-web-windows-2012-r2-dc',
   ],
   local sql_2016_images = [
-    'sql-2016-enterprise-windows-2012-r2-dc',
     'sql-2016-enterprise-windows-2016-dc',
     'sql-2016-enterprise-windows-2019-dc',
-    'sql-2016-standard-windows-2012-r2-dc',
     'sql-2016-standard-windows-2016-dc',
     'sql-2016-standard-windows-2019-dc',
-    'sql-2016-web-windows-2012-r2-dc',
     'sql-2016-web-windows-2016-dc',
     'sql-2016-web-windows-2019-dc',
   ],
@@ -581,7 +571,6 @@ local ImgGroup(name, images) = {
     'sql-2017-enterprise-windows-2016-dc',
     'sql-2017-enterprise-windows-2019-dc',
     'sql-2017-enterprise-windows-2022-dc',
-    'sql-2017-express-windows-2012-r2-dc',
     'sql-2017-express-windows-2016-dc',
     'sql-2017-express-windows-2019-dc',
     'sql-2017-standard-windows-2016-dc',
@@ -618,7 +607,7 @@ local ImgGroup(name, images) = {
   ],
 
   local windows_client_images = windows_10_images + windows_11_images,
-  local windows_server_images = windows_2012_images + windows_2016_images + windows_2019_images
+  local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images,
   local sql_images = sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
 
@@ -661,30 +650,20 @@ local ImgGroup(name, images) = {
           ImgBuildJob('windows-server-2019-dc-core', 'win2019-64', 'windows_gcs_updates_server2019'),
           ImgBuildJob('windows-server-2016-dc', 'win2016-64', 'windows_gcs_updates_server2016'),
           ImgBuildJob('windows-server-2016-dc-core', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2-dc', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
-          ImgBuildJob('windows-server-2012-r2-dc-core', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
-
           // SQL derivative builds
 
-          SQLImgBuildJob('sql-2014-enterprise-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2014-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2014-standard-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2014-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2014-web-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2014-web', 'windows_gcs_ssms_exe'),
 
-          SQLImgBuildJob('sql-2016-enterprise-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-standard-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-standard-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-web-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-web-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
 
           SQLImgBuildJob('sql-2017-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2022-dc', 'windows-server-2022-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2017-express-windows-2012-r2-dc', 'windows-server-2012-r2-dc', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-express-windows-2016-dc', 'windows-server-2016-dc', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-express-windows-2019-dc', 'windows-server-2019-dc', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-standard-windows-2016-dc', 'windows-server-2016-dc', 'sql-2017-standard', 'windows_gcs_ssms_exe'),
@@ -754,7 +733,6 @@ local ImgGroup(name, images) = {
   groups: [
     ImgGroup('windows-10-testing', windows_10_images),
     ImgGroup('windows-11-testing', windows_11_images),
-    ImgGroup('windows-2012-testing', windows_2012_images),
     ImgGroup('windows-2016-testing', windows_2016_images),
     ImgGroup('windows-2019-testing', windows_2019_images),
     ImgGroup('windows-2022-testing', windows_2022_images),

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -632,6 +632,18 @@ local ImgGroup(name, images) = {
                for image in windows_client_images + windows_server_images + container_images
              ] +
              [
+               common.GcsSbomResource(image, 'windows-client')
+               for image in windows_client_images
+             ] +
+             [
+               common.GcsSbomResource(image, 'windows-server')
+               for image in windows_server_images
+             ] +
+             [
+               common.GcsSbomResource(image, 'sql')
+               for image in sql_images
+             ] +
+             [
                common.GcsImgResource(image, 'sqlserver-uefi')
                for image in sql_images
              ] +


### PR DESCRIPTION
Separating a PR to catch up the staging pipeline to the current state of the release pipeline before testing additional changes.