### PR TITLE
Swap testing platform in registry image task definition

### DIFF
--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -13,7 +13,7 @@ local imagetesttask = {
   images:: error 'must set images in imagetesttask',
 
   // Start of task
-  platform: 'windows',
+  platform: 'linux',
   image_resource: {
     type: 'registry-image',
     source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },


### PR DESCRIPTION
Mistook it for something else; there's no Windows platform for it