### PR TITLE
Create disks for networkperf images based on VM zone

### DIFF
--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -220,7 +220,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				defaultPerfTarget := fmt.Sprint(defaultPerfTargetInt)
 
 				// Default VMs.
-			    serverDisk := compute.Disk{Name: serverConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
+				serverDisk := compute.Disk{Name: serverConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
 				serverVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&serverDisk}, map[string]string{})
 				if err != nil {
 					return err
@@ -252,7 +252,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				clientVM.AddMetadata("expectedperf", defaultPerfTarget)
 
 				// Jumbo frames VMs.
-				jfServerDisk := compute.Disk{Name: jfServerConfig.name +"-"+ tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
+				jfServerDisk := compute.Disk{Name: jfServerConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
 				jfServerVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&jfServerDisk}, map[string]string{})
 				if err != nil {
 					return err
@@ -266,7 +266,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 					return err
 				}
 
-				jfClientDisk := compute.Disk{Name: jfClientConfig.name +"-"+ tc.machineType , Type: imagetest.PdBalanced, Zone: tc.zone}
+				jfClientDisk := compute.Disk{Name: jfClientConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
 				jfClientVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&jfClientDisk}, map[string]string{})
 				jfClientVM.ForceMachineType(tc.machineType)
 				jfClientVM.ForceZone(tc.zone)
@@ -332,7 +332,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				tier1PerfTarget := fmt.Sprint(tier1PerfTargetInt)
 
 				// Tier 1 VMs.
-				t1ServerDisk := compute.Disk{Name: tier1ServerConfig.name+"-"+ tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
+				t1ServerDisk := compute.Disk{Name: tier1ServerConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
 				tier1ServerVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&t1ServerDisk}, map[string]string{})
 				if err != nil {
 					return err
@@ -347,7 +347,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				}
 				tier1ServerVM.SetNetworkPerformanceTier("TIER_1")
 
-				t1ClientDisk := compute.Disk{Name: tier1ClientConfig.name +"-"+ tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
+				t1ClientDisk := compute.Disk{Name: tier1ClientConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
 				tier1ClientVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&t1ClientDisk}, map[string]string{})
 				if err != nil {
 					return err

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -28,50 +28,50 @@ var networkPerfTestConfig = []networkPerfTest{
 		machineType: "n1-standard-2",
 		arch:        "X86_84",
 		networks:    []string{"DEFAULT"},
-		quota:       &daisy.QuotaAvailable{Metric: "CPUS", Units: 4},
+		quota:       &daisy.QuotaAvailable{Metric: "CPUS", Units: 8},
 	},
 	{
 		machineType: "n2-standard-2",
 		arch:        "X86_84",
 		networks:    []string{"DEFAULT"},
-		quota:       &daisy.QuotaAvailable{Metric: "N2_CPUS", Units: 4},
+		quota:       &daisy.QuotaAvailable{Metric: "N2_CPUS", Units: 8},
 	},
 	{
 		machineType: "n2d-standard-2",
 		arch:        "X86_84",
 		networks:    []string{"DEFAULT"},
-		quota:       &daisy.QuotaAvailable{Metric: "N2D_CPUS", Units: 4},
+		quota:       &daisy.QuotaAvailable{Metric: "N2D_CPUS", Units: 8},
 	},
 	{
 		machineType: "e2-standard-2",
 		arch:        "X86_84",
 		networks:    []string{"DEFAULT"},
-		quota:       &daisy.QuotaAvailable{Metric: "E2_CPUS", Units: 4},
+		quota:       &daisy.QuotaAvailable{Metric: "E2_CPUS", Units: 8},
 	},
 	{
 		machineType: "t2d-standard-1",
 		arch:        "X86_84",
 		networks:    []string{"DEFAULT"},
-		quota:       &daisy.QuotaAvailable{Metric: "T2D_CPUS", Units: 2},
+		quota:       &daisy.QuotaAvailable{Metric: "T2D_CPUS", Units: 4},
 	},
 	{
 		machineType: "t2a-standard-1",
 		arch:        "ARM64",
 		networks:    []string{"DEFAULT"},
 		zone:        "us-central1-a",
-		quota:       &daisy.QuotaAvailable{Metric: "T2A_CPUS", Units: 2, Region: "us-central1"},
+		quota:       &daisy.QuotaAvailable{Metric: "T2A_CPUS", Units: 4, Region: "us-central1"},
 	},
 	{
 		machineType: "n2-standard-32",
 		arch:        "X86_64",
 		networks:    []string{"DEFAULT", "TIER_1"},
-		quota:       &daisy.QuotaAvailable{Metric: "N2_CPUS", Units: 128}, // 32 cpus x 2 tiers x 2 vms per tier
+		quota:       &daisy.QuotaAvailable{Metric: "N2_CPUS", Units: 192}, // 32 cpus x 2 vms per tier 1 test + 32 x 4 vms per default test
 	},
 	{
 		machineType: "n2d-standard-48",
 		arch:        "X86_64",
 		networks:    []string{"DEFAULT", "TIER_1"},
-		quota:       &daisy.QuotaAvailable{Metric: "N2D_CPUS", Units: 192},
+		quota:       &daisy.QuotaAvailable{Metric: "N2D_CPUS", Units: 288},
 	},
 }
 


### PR DESCRIPTION
Multiply quotas correctly to wait on the appropriate number of CPUs
Wait for even small quotas of CPUs


Fixes for failures in testgrid
/cc @jjerger @koln67 @zmarano @drewhli 