### PR TITLE
Report network tier correctly in networkperf

### DIFF
--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -37,12 +37,10 @@ func TestNetworkPerformance(t *testing.T) {
 	machineTypeSplit := strings.Split(machineType, "/")
 	machineTypeName := machineTypeSplit[len(machineTypeSplit)-1]
 
-	network, err := utils.GetMetadata("network-interfaces/0/network")
+	network, err := utils.GetMetadataAttribute("network-tier")
 	if err != nil {
 		t.Fatal(err)
 	}
-	networkSplit := strings.Split(network, "/")
-	networkName := networkSplit[len(networkSplit)-1]
 
 	// Find actual performance..
 	var result_perf float64
@@ -54,7 +52,7 @@ func TestNetworkPerformance(t *testing.T) {
 
 	// Check if it matches the target.
 	if result_perf < expected {
-		t.Fatalf("Error: Did not meet performance expectation on machine type %s with network %s. Expected: %v Gbits/s, Actual: %v Gbits/s", machineTypeName, networkName, expected, result_perf)
+		t.Fatalf("Error: Did not meet performance expectation on machine type %s with network %s. Expected: %v Gbits/s, Actual: %v Gbits/s", machineTypeName, network, expected, result_perf)
 	}
 	t.Logf("Machine type: %v, Expected: %v Gbits/s, Actual: %v Gbits/s", machineTypeName, expected, result_perf)
 }

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -245,6 +245,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				clientVM.AddMetadata("enable-guest-attributes", "TRUE")
 				clientVM.AddMetadata("iperftarget", serverConfig.ip)
 				clientVM.AddMetadata("expectedperf", defaultPerfTarget)
+				clientVM.AddMetadata("network-tier", net)
 
 				// Jumbo frames VMs.
 				jfServerDisk := compute.Disk{Name: jfServerConfig.name + "-" + tc.machineType, Type: imagetest.PdBalanced, Zone: tc.zone}
@@ -277,6 +278,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				jfClientVM.AddMetadata("enable-guest-attributes", "TRUE")
 				jfClientVM.AddMetadata("iperftarget", jfServerConfig.ip)
 				jfClientVM.AddMetadata("expectedperf", defaultPerfTarget)
+				jfClientVM.AddMetadata("network-tier", net)
 
 				// Set startup scripts.
 				if utils.HasFeature(t.Image, "WINDOWS") {
@@ -354,6 +356,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				tier1ClientVM.AddMetadata("enable-guest-attributes", "TRUE")
 				tier1ClientVM.AddMetadata("iperftarget", tier1ServerConfig.ip)
 				tier1ClientVM.AddMetadata("expectedperf", tier1PerfTarget)
+				tier1ClientVM.AddMetadata("network-tier", net)
 
 				// Set startup scripts.
 				if utils.HasFeature(t.Image, "WINDOWS") {


### PR DESCRIPTION
```
<testsuites name="" errors="0" failures="2" disabled="0" skipped="0" tests="18" time="0">
	<testsuite name="networkperf-debian-12" tests="18" failures="2" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0">
			<failure type="">    performance_test.go:55: Error: Did not meet performance expectation on machine type n2-standard-32 with network TIER_1. Expected: 42.5 Gbits/s, Actual: 31.9 Gbits/s</failure>
		</testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0">
			<failure type="">    performance_test.go:55: Error: Did not meet performance expectation on machine type n2d-standard-48 with network TIER_1. Expected: 42.5 Gbits/s, Actual: 32 Gbits/s</failure>
		</testcase>
	</testsuite>
</testsuites>
```
/assign @zmarano 