### PR TITLE
More windows migration

### DIFF
--- a/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
+++ b/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
@@ -19,8 +19,7 @@ import (
 
 const gcomment = "# Added by Google"
 
-
-func TestHostnameWindows(shortname string) error {
+func testHostnameWindows(shortname string) error {
 	command := "[System.Net.Dns]::GetHostName()"
 	output, err := utils.RunPowershellCmd(command)
 	if err != nil {
@@ -34,7 +33,7 @@ func TestHostnameWindows(shortname string) error {
 	return nil
 }
 
-func TestHostnameLinux(shortname string) error{
+func testHostnameLinux(shortname string) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return fmt.Errorf("couldn't determine local hostname")
@@ -61,11 +60,11 @@ func TestHostname(t *testing.T) {
 	shortname := strings.Split(metadataHostname, ".")[0]
 
 	if runtime.GOOS == "windows" {
-		if err = TestHostnameWindows(shortname); err != nil {
+		if err = testHostnameWindows(shortname); err != nil {
 			t.Fatalf("windows hostname error: %v", err)
 		}
 	} else {
-		if err = TestHostnameLinux(shortname); err != nil {
+		if err = testHostnameLinux(shortname); err != nil {
 			t.Fatalf("linux hostname error: %v", err)
 		}
 	}

--- a/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
+++ b/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
@@ -93,6 +93,7 @@ func TestCustomHostname(t *testing.T) {
 
 // TestFQDN tests the 'fully qualified domain name'.
 func TestFQDN(t *testing.T) {
+	utils.LinuxOnly(t)
 	// TODO Zonal DNS is breaking this test case in EL9.
 	image, err := utils.GetMetadata("image")
 	if err != nil {
@@ -155,6 +156,7 @@ type sshKeyHash struct {
 
 // TestHostKeysGeneratedOnces checks that the guest agent only generates host keys one time.
 func TestHostKeysGeneratedOnce(t *testing.T) {
+	utils.LinuxOnly(t)
 	sshDir := "/etc/ssh/"
 	sshfiles, err := ioutil.ReadDir(sshDir)
 	if err != nil {
@@ -221,6 +223,7 @@ func TestHostKeysGeneratedOnce(t *testing.T) {
 }
 
 func TestHostsFile(t *testing.T) {
+	utils.LinuxOnly(t)
 	image, err := utils.GetMetadata("image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")

--- a/imagetest/test_suites/hostnamevalidation/setup.go
+++ b/imagetest/test_suites/hostnamevalidation/setup.go
@@ -1,23 +1,37 @@
 package hostnamevalidation
 
-import "github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+import (
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
 
 // Name is the name of the test package. It must match the directory name.
 var Name = "hostnamevalidation"
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm1, err := t.CreateTestVM("vm1")
-	if err != nil {
-		return err
-	}
-	vm1.RunTests("TestHostname|TestFQDN|TestHostKeysGeneratedOnce|TestHostsFile")
+	// most of the tests are still linux specific for now, so skip most on windows.
+	if utils.HasFeature(t.Image, "WINDOWS") {
+		vm1, err := t.CreateTestVM("vm1")
+		if err != nil {
+			return err
+		}
+		vm1.RunTests("TestHostname")
+		return nil
+	} else {
+		vm1, err := t.CreateTestVM("vm1")
+		if err != nil {
+			return err
+		}
+		vm1.RunTests("TestHostname|TestFQDN|TestHostKeysGeneratedOnce|TestHostsFile")
 
-	vm2, err := t.CreateTestVM("vm2.custom.domain")
-	if err != nil {
-		return err
-	}
-	vm2.RunTests("TestCustomHostname")
+		vm2, err := t.CreateTestVM("vm2.custom.domain")
+		if err != nil {
+			return err
+		}
+		vm2.RunTests("TestCustomHostname")
 
-	return nil
+		return nil
+	}
 }

--- a/imagetest/test_suites/hostnamevalidation/setup.go
+++ b/imagetest/test_suites/hostnamevalidation/setup.go
@@ -11,27 +11,19 @@ var Name = "hostnamevalidation"
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	// most of the tests are still linux specific for now, so skip most on windows.
-	if utils.HasFeature(t.Image, "WINDOWS") {
-		vm1, err := t.CreateTestVM("vm1")
-		if err != nil {
-			return err
-		}
-		vm1.RunTests("TestHostname")
-		return nil
-	} else {
-		vm1, err := t.CreateTestVM("vm1")
-		if err != nil {
-			return err
-		}
-		vm1.RunTests("TestHostname|TestFQDN|TestHostKeysGeneratedOnce|TestHostsFile")
-
+	vm1, err := t.CreateTestVM("vm1")
+	if err != nil {
+		return err
+	}
+	vm1.RunTests("TestHostname|TestFQDN|TestHostKeysGeneratedOnce|TestHostsFile")
+	// custom host name test not yet implemented for windows
+	if !utils.HasFeature(t.Image, "WINDOWS") {
 		vm2, err := t.CreateTestVM("vm2.custom.domain")
 		if err != nil {
 			return err
 		}
 		vm2.RunTests("TestCustomHostname")
-
-		return nil
 	}
+
+	return nil
 }

--- a/imagetest/test_suites/hostnamevalidation/setup.go
+++ b/imagetest/test_suites/hostnamevalidation/setup.go
@@ -5,7 +5,6 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
-
 // Name is the name of the test package. It must match the directory name.
 var Name = "hostnamevalidation"
 

--- a/imagetest/test_suites/packagevalidation/clock_test.go
+++ b/imagetest/test_suites/packagevalidation/clock_test.go
@@ -5,6 +5,7 @@ package packagevalidation
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -21,12 +22,20 @@ const (
 	timedatectlCmd   = "timedatectl"
 )
 
+func TestNTP(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		TestNTPWindows(t)
+	} else {
+		TestNTPServiceLinux(t)
+	}
+}
+
 // TestNTPService Verify that ntp package exist and configuration is correct.
 // debian 9, ubuntu 16.04 ntp
 // debian 12 systemd-timesyncd
 // sles-12 ntpd
 // other distros chronyd
-func TestNTPService(t *testing.T) {
+func TestNTPServiceLinux(t *testing.T) {
 	image, err := utils.GetMetadata("image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
@@ -74,5 +83,49 @@ func TestNTPService(t *testing.T) {
 	systemctlCmd := exec.Command("systemctl", "is-active", servicename)
 	if err := systemctlCmd.Run(); err != nil {
 		t.Fatalf("%s service is not running", servicename)
+	}
+}
+
+func TestNTPWindows(t *testing.T) {
+	command := "w32tm /query /peers /verbose"
+	output, err := utils.RunPowershellCmd(command)
+	if err != nil {
+		t.Fatalf("Error getting NTP information: %v", err)
+	}
+
+	expected := []string{
+		"#Peers: 1",
+		"Peer: metadata.google.internal,0x1",
+		"LastSyncErrorMsgId: 0x00000000 (Succeeded)",
+	}
+
+	for _, exp := range expected {
+		if !strings.Contains(output.Stdout, exp) {
+			t.Fatalf("Expected info %s not found in peer_info: %s", exp, output.Stdout)
+		}
+	}
+
+	// NTP can take time to get to an active state.
+	if !(strings.Contains(output.Stdout, "State: Active") || strings.Contains(output.Stdout, "State: Pending")) {
+		t.Fatalf("Expected State: Active or Pending in: %s", output.Stdout)
+	}
+
+	r, err := regexp.Compile("Time Remaining: ([0-9\\.]+)s")
+	if err != nil {
+		t.Fatalf("Error creating regexp: %v", err)
+	}
+
+	remaining := r.FindStringSubmatch(output.Stdout)[1]
+	remainingTime, err := strconv.ParseFloat(remaining, 32)
+	if err != nil {
+		t.Fatalf("Unexpected remaining time value: %s", remaining)
+	}
+
+	if remainingTime < 0.0 {
+		t.Fatalf("Invalid remaining time: %f", remainingTime)
+	}
+
+	if remainingTime > 900.0 {
+		t.Fatalf("Time remaining is longer than the 15 minute poll interval: %f", remainingTime)
 	}
 }

--- a/imagetest/test_suites/packagevalidation/clock_test.go
+++ b/imagetest/test_suites/packagevalidation/clock_test.go
@@ -5,7 +5,9 @@ package packagevalidation
 
 import (
 	"os/exec"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -24,18 +26,18 @@ const (
 
 func TestNTP(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		TestNTPWindows(t)
+		testNTPWindows(t)
 	} else {
-		TestNTPServiceLinux(t)
+		testNTPServiceLinux(t)
 	}
 }
 
-// TestNTPService Verify that ntp package exist and configuration is correct.
+// testNTPService Verify that ntp package exist and configuration is correct.
 // debian 9, ubuntu 16.04 ntp
 // debian 12 systemd-timesyncd
 // sles-12 ntpd
 // other distros chronyd
-func TestNTPServiceLinux(t *testing.T) {
+func testNTPServiceLinux(t *testing.T) {
 	image, err := utils.GetMetadata("image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
@@ -86,7 +88,7 @@ func TestNTPServiceLinux(t *testing.T) {
 	}
 }
 
-func TestNTPWindows(t *testing.T) {
+func testNTPWindows(t *testing.T) {
 	command := "w32tm /query /peers /verbose"
 	output, err := utils.RunPowershellCmd(command)
 	if err != nil {

--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -36,6 +36,7 @@ func TestStandardPrograms(t *testing.T) {
 }
 
 func TestGuestPackages(t *testing.T) {
+	utils.LinuxOnly(t)
 	image, err := utils.GetMetadata("image")
 	if err != nil {
 		t.Fatalf("couldn't determine image from metadata")

--- a/imagetest/test_suites/packagevalidation/setup.go
+++ b/imagetest/test_suites/packagevalidation/setup.go
@@ -11,7 +11,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err != nil {
 		return err
 	}
-	vm1.RunTests("TestStandardPrograms|TestGuestPackages|TestNTPService")
+	vm1.RunTests("TestStandardPrograms|TestGuestPackages|TestNTP")
 
 	return nil
 }

--- a/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
+++ b/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
@@ -50,28 +50,6 @@ func TestDiskReadWrite(t *testing.T) {
 	}
 }
 
-func TestHostname(t *testing.T) {
-	metadataHostname, err := utils.GetMetadata("hostname")
-	if err != nil {
-		t.Fatalf(" still couldn't determine metadata hostname")
-	}
-
-	// 'hostname' in metadata is fully qualified domain name.
-	shortname := strings.Split(metadataHostname, ".")[0]
-
-	command := "[System.Net.Dns]::GetHostName()"
-	output, err := utils.RunPowershellCmd(command)
-	if err != nil {
-		t.Fatalf("Error getting hostname: %v", err)
-	}
-	hostname := strings.TrimSpace(output.Stdout)
-
-	if hostname != shortname {
-		t.Fatalf("Expected Hostname: '%s', Actual Hostname: '%s'", shortname, hostname)
-	}
-
-}
-
 func TestAutoUpdateEnabled(t *testing.T) {
 	command := `$au_path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
     $au = Get-Itemproperty -Path $au_path

--- a/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
+++ b/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
@@ -5,7 +5,6 @@ package windowsimagevalidation
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"

--- a/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
+++ b/imagetest/test_suites/windowsimagevalidation/image_validation_test.go
@@ -242,50 +242,6 @@ func TestServicesState(t *testing.T) {
 	}
 }
 
-func TestNtp(t *testing.T) {
-	command := "w32tm /query /peers /verbose"
-	output, err := utils.RunPowershellCmd(command)
-	if err != nil {
-		t.Fatalf("Error getting NTP information: %v", err)
-	}
-
-	expected := []string{
-		"#Peers: 1",
-		"Peer: metadata.google.internal,0x1",
-		"LastSyncErrorMsgId: 0x00000000 (Succeeded)",
-	}
-
-	for _, exp := range expected {
-		if !strings.Contains(output.Stdout, exp) {
-			t.Fatalf("Expected info %s not found in peer_info: %s", exp, output.Stdout)
-		}
-	}
-
-	// NTP can take time to get to an active state.
-	if !(strings.Contains(output.Stdout, "State: Active") || strings.Contains(output.Stdout, "State: Pending")) {
-		t.Fatalf("Expected State: Active or Pending in: %s", output.Stdout)
-	}
-
-	r, err := regexp.Compile("Time Remaining: ([0-9\\.]+)s")
-	if err != nil {
-		t.Fatalf("Error creating regexp: %v", err)
-	}
-
-	remaining := r.FindStringSubmatch(output.Stdout)[1]
-	remainingTime, err := strconv.ParseFloat(remaining, 32)
-	if err != nil {
-		t.Fatalf("Unexpected remaining time value: %s", remaining)
-	}
-
-	if remainingTime < 0.0 {
-		t.Fatalf("Invalid remaining time: %f", remainingTime)
-	}
-
-	if remainingTime > 900.0 {
-		t.Fatalf("Time remaining is longer than the 15 minute poll interval: %f", remainingTime)
-	}
-}
-
 func TestWindowsEdition(t *testing.T) {
 	image, err := utils.GetMetadata("image")
 	if err != nil {

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -326,6 +326,13 @@ func CheckLinuxCmdExists(cmd string) bool {
 	return false
 }
 
+// LinuxOnly skips tests not on Linux.
+func LinuxOnly(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Test only run on linux.")
+	}
+}
+
 // WindowsOnly skips tests not on Windows.
 func WindowsOnly(t *testing.T) {
 	if runtime.GOOS != "windows" {


### PR DESCRIPTION
Proposed paradigm for windows image migration: until all test behavior is merged, use utils.LinuxOnly() or utils.WindowsOnly()