### PR TITLE
util: unify metadata code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+imagetest/cmd/manager/manager
+imagetest/cmd/wrapper/wrapper

--- a/imagetest/build.sh
+++ b/imagetest/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -x
+
+build_for() {
+  GOOS=$2
+  go build -C $1 ../... || { exit 1; }
+  go test -C $1 -c -o /dev/null -tags cit || { exit 1; }
+}
+
+build() {
+  build_for $1 linux
+  build_for $1 windows
+}
+
+if golint &> /dev/null; then
+  golint -set_exit_status ./...
+fi
+
+build cmd/manager/
+build cmd/wrapper/
+
+for suite in `find test_suites/* -maxdepth 0 -type d`; do
+  build $suite
+done

--- a/imagetest/test_suites/disk/disk_resize_test.go
+++ b/imagetest/test_suites/disk/disk_resize_test.go
@@ -25,7 +25,7 @@ const (
 func TestDiskResize(t *testing.T) {
 	// TODO: test disk resizing on windows
 	utils.LinuxOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}

--- a/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
+++ b/imagetest/test_suites/hostnamevalidation/hostname_validation_test.go
@@ -51,7 +51,7 @@ func testHostnameLinux(shortname string) error {
 }
 
 func TestHostname(t *testing.T) {
-	metadataHostname, err := utils.GetMetadata("hostname")
+	metadataHostname, err := utils.GetMetadata(utils.Context(t), "instance", "hostname")
 	if err != nil {
 		t.Fatalf(" still couldn't determine metadata hostname")
 	}
@@ -72,7 +72,7 @@ func TestHostname(t *testing.T) {
 
 // TestCustomHostname tests the 'fully qualified domain name'.
 func TestCustomHostname(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
 	}
@@ -93,8 +93,9 @@ func TestCustomHostname(t *testing.T) {
 // TestFQDN tests the 'fully qualified domain name'.
 func TestFQDN(t *testing.T) {
 	utils.LinuxOnly(t)
+	ctx := utils.Context(t)
 	// TODO Zonal DNS is breaking this test case in EL9.
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(ctx, "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
 	}
@@ -115,7 +116,7 @@ func TestFQDN(t *testing.T) {
 		t.Skip("Broken on EL9")
 	}
 
-	metadataHostname, err := utils.GetMetadata("hostname")
+	metadataHostname, err := utils.GetMetadata(ctx, "instance", "hostname")
 	if err != nil {
 		t.Fatalf("couldn't determine metadata hostname")
 	}
@@ -174,7 +175,7 @@ func TestHostKeysGeneratedOnce(t *testing.T) {
 		hashes = append(hashes, sshKeyHash{file, hash})
 	}
 
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
 	}
@@ -223,7 +224,8 @@ func TestHostKeysGeneratedOnce(t *testing.T) {
 
 func TestHostsFile(t *testing.T) {
 	utils.LinuxOnly(t)
-	image, err := utils.GetMetadata("image")
+	ctx := utils.Context(t)
+	image, err := utils.GetMetadata(ctx, "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
@@ -260,11 +262,11 @@ func TestHostsFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't read /etc/hosts")
 	}
-	ip, err := utils.GetMetadata("network-interfaces/0/ip")
+	ip, err := utils.GetMetadata(ctx, "instance", "network-interfaces", "0", "ip")
 	if err != nil {
 		t.Fatalf("Couldn't get ip from metadata")
 	}
-	hostname, err := utils.GetMetadata("hostname")
+	hostname, err := utils.GetMetadata(ctx, "instance", "hostname")
 	if err != nil {
 		t.Fatalf("Couldn't get hostname from metadata")
 	}

--- a/imagetest/test_suites/imageboot/image_boot_test.go
+++ b/imagetest/test_suites/imageboot/image_boot_test.go
@@ -99,7 +99,7 @@ func lookForGuestAgentProcessWindows() error {
 	return fmt.Errorf("Guest Agent not found.")
 }
 
-func verifyBootTime() error {
+func verifyBootTime(t *testing.T) error {
 	// Reading the system uptime once both guest agent and sshd are found in the processes
 	uptimeData, err := os.ReadFile("/proc/uptime")
 	if err != nil {
@@ -116,7 +116,7 @@ func verifyBootTime() error {
 	//Validating the uptime against the allowed threshold value
 	var maxThreshold int
 
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		return fmt.Errorf("couldn't get image from metadata")
 	}
@@ -272,7 +272,7 @@ func testWindowsGuestSecureBoot() error {
 }
 
 func TestStartTime(t *testing.T) {
-	metadata, err := utils.GetMetadataAttribute("start-time")
+	metadata, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "start-time")
 	if err != nil {
 		t.Fatalf("couldn't get start time from metadata")
 	}
@@ -311,7 +311,7 @@ func TestBootTime(t *testing.T) {
 			t.Fatalf("Failed to verify boot time: %v", err)
 		}
 	} else {
-		err := verifyBootTime()
+		err := verifyBootTime(t)
 		if err != nil {
 			t.Fatalf("Failed to verify boot time: %v", err)
 		}

--- a/imagetest/test_suites/licensevalidation/license_test.go
+++ b/imagetest/test_suites/licensevalidation/license_test.go
@@ -176,7 +176,7 @@ func isValidLicenseText(licenseCheck string) bool {
 }
 
 func TestArePackagesLegal(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
@@ -204,7 +204,7 @@ func TestArePackagesLegal(t *testing.T) {
 }
 
 func TestWindowsActivationStatus(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}

--- a/imagetest/test_suites/licensevalidation/linux_license_test.go
+++ b/imagetest/test_suites/licensevalidation/linux_license_test.go
@@ -47,11 +47,11 @@ var imageLicenseCodeMap = map[string]string{
 
 func TestLinuxLicense(t *testing.T) {
 	// Assume only one license exist in image
-	licenseCode, err := utils.GetMetadata("licenses/0/id")
+	licenseCode, err := utils.GetMetadata(utils.Context(t), "instance", "licenses", "0", "id")
 	if err != nil {
 		t.Fatal("Failed to get license code metadata")
 	}
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatal("Failed to get image metadata")
 	}

--- a/imagetest/test_suites/metadata/metadata_test.go
+++ b/imagetest/test_suites/metadata/metadata_test.go
@@ -23,7 +23,7 @@ type Token struct {
 
 // TestTokenFetch test service-accounts token could be retrieved from metadata.
 func TestTokenFetch(t *testing.T) {
-	metadata, err := utils.GetMetadata("service-accounts/default/token")
+	metadata, err := utils.GetMetadata(utils.Context(t), "instance", "service-accounts", "default", "token")
 	if err != nil {
 		t.Fatalf("couldn't get token from metadata, err % v", err)
 	}
@@ -34,11 +34,11 @@ func TestTokenFetch(t *testing.T) {
 
 // TestMetaDataResponseHeaders verify that HTTP response headers do not include confidential data.
 func TestMetaDataResponseHeaders(t *testing.T) {
-	resp, err := utils.GetMetadataHTTPResponse("id")
+	_, headers, err := utils.GetMetadataWithHeaders(utils.Context(t), "instance", "id")
 	if err != nil {
 		t.Fatalf("couldn't get id from metadata, err % v", err)
 	}
-	for key, values := range resp.Header {
+	for key, values := range headers {
 		if key != "Metadata-Flavor" {
 			for _, v := range values {
 				if strings.Contains(strings.ToLower(v), "google") {

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -19,8 +19,8 @@ const (
 )
 
 // TestShutdownScriptFailedLinux tests that a script failed execute doesn't crash the vm.
-func testShutdownScriptFailedLinux() error {
-	if _, err := utils.GetMetadataAttribute("shutdown-script"); err != nil {
+func testShutdownScriptFailedLinux(t *testing.T) error {
+	if _, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "shutdown-script"); err != nil {
 		return fmt.Errorf("couldn't get shutdown-script from metadata")
 	}
 
@@ -29,8 +29,8 @@ func testShutdownScriptFailedLinux() error {
 }
 
 // TestShutdownScriptFailedWindows tests that a script failed execute doesn't crash the vm.
-func testShutdownScriptFailedWindows() error {
-	if _, err := utils.GetMetadataAttribute("windows-shutdown-script-ps1"); err != nil {
+func testShutdownScriptFailedWindows(t *testing.T) error {
+	if _, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "windows-shutdown-script-ps1"); err != nil {
 		return fmt.Errorf("couldn't get windows-shutdown-script-ps1 from metadata")
 	}
 
@@ -73,7 +73,7 @@ func testShutdownScriptTimeWindows() error {
 // TestShutdownScripts verifies that the standard metadata script could run successfully
 // by checking the output content of the Shutdown script.
 func TestShutdownScripts(t *testing.T) {
-	result, err := utils.GetMetadataGuestAttribute("testing/result")
+	result, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read shutdown script result key: %v", err)
 	}
@@ -85,11 +85,11 @@ func TestShutdownScripts(t *testing.T) {
 // Determine if the OS is Windows or Linux and run the appropriate failure test.
 func TestShutdownScriptsFailed(t *testing.T) {
 	if utils.IsWindows() {
-		if err := testShutdownScriptFailedWindows(); err != nil {
+		if err := testShutdownScriptFailedWindows(t); err != nil {
 			t.Fatalf("Shutdown script failure test failed with error: %v", err)
 		}
 	} else {
-		if err := testShutdownScriptFailedLinux(); err != nil {
+		if err := testShutdownScriptFailedLinux(t); err != nil {
 			t.Fatalf("Shutdown script failure test failed with error: %v", err)
 		}
 	}
@@ -97,7 +97,7 @@ func TestShutdownScriptsFailed(t *testing.T) {
 
 // Determine if the OS is Windows or Linux and run the appropriate daemon test.
 func TestShutdownURLScripts(t *testing.T) {
-	result, err := utils.GetMetadataGuestAttribute("testing/result")
+	result, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read shutdown script result key: %v", err)
 	}

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -18,8 +18,8 @@ const (
 )
 
 // TestStartupScriptFailedLinux tests that a script failed execute doesn't crash the vm.
-func testStartupScriptFailedLinux() error {
-	if _, err := utils.GetMetadataAttribute("startup-script"); err != nil {
+func testStartupScriptFailedLinux(t *testing.T) error {
+	if _, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "startup-script"); err != nil {
 		return fmt.Errorf("couldn't get startup-script from metadata, %v", err)
 	}
 
@@ -27,8 +27,8 @@ func testStartupScriptFailedLinux() error {
 }
 
 // TestStartupScriptFailedWindows tests that a script failed execute doesn't crash the vm.
-func testStartupScriptFailedWindows() error {
-	if _, err := utils.GetMetadataAttribute("windows-startup-script-ps1"); err != nil {
+func testStartupScriptFailedWindows(t *testing.T) error {
+	if _, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "windows-startup-script-ps1"); err != nil {
 		return fmt.Errorf("couldn't get windows-startup-script-ps1 from metadata, %v", err)
 	}
 
@@ -72,7 +72,7 @@ func testDaemonScriptWindows() error {
 // TestStartupScripts verifies that the standard metadata script could run successfully
 // by checking the output content of the Startup script.
 func TestStartupScripts(t *testing.T) {
-	result, err := utils.GetMetadataGuestAttribute("testing/result")
+	result, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read startup script result key: %v", err)
 	}
@@ -84,11 +84,11 @@ func TestStartupScripts(t *testing.T) {
 // Determine if the OS is Windows or Linux and run the appropriate failure test.
 func TestStartupScriptsFailed(t *testing.T) {
 	if utils.IsWindows() {
-		if err := testStartupScriptFailedWindows(); err != nil {
+		if err := testStartupScriptFailedWindows(t); err != nil {
 			t.Fatalf("Startup script failure test failed with error: %v", err)
 		}
 	} else {
-		if err := testStartupScriptFailedLinux(); err != nil {
+		if err := testStartupScriptFailedLinux(t); err != nil {
 			t.Fatalf("Shutdown script failure test failed with error: %v", err)
 		}
 	}

--- a/imagetest/test_suites/network/dhcp_test.go
+++ b/imagetest/test_suites/network/dhcp_test.go
@@ -47,7 +47,7 @@ func TestDHCP(t *testing.T) {
 	}
 
 	// Base dhcp case for debian 10, debian 11, ubuntu 16, etc.
-	if err = checkDHCPProcess(); err != nil {
+	if err = checkDHCPProcess(t); err != nil {
 		t.Fatalf("did not find dhcp process: %v", err)
 	}
 
@@ -120,8 +120,8 @@ func parseWickedOutput(cmd *exec.Cmd) error {
 	return fmt.Errorf("dhcpv4 or ip address not found in wicked output")
 }
 
-func checkDHCPProcess() error {
-	iface, err := utils.GetInterface(1)
+func checkDHCPProcess(t *testing.T) error {
+	iface, err := utils.GetInterface(utils.Context(t), 1)
 	if err != nil {
 		return fmt.Errorf("couldn't get secondary interface: %v", err)
 	}

--- a/imagetest/test_suites/network/gvnic_test.go
+++ b/imagetest/test_suites/network/gvnic_test.go
@@ -46,7 +46,7 @@ func CheckGVNICPresentWindows(interfaceName string) error {
 }
 
 func TestGVNIC(t *testing.T) {
-	iface, err := utils.GetInterface(0)
+	iface, err := utils.GetInterface(utils.Context(t), 0)
 
 	// Check whether the driver exists.
 	if err != nil {

--- a/imagetest/test_suites/network/mtu_test.go
+++ b/imagetest/test_suites/network/mtu_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func TestDefaultMTU(t *testing.T) {
-	iface, err := utils.GetInterface(0)
+	iface, err := utils.GetInterface(utils.Context(t), 0)
 	if err != nil {
 		t.Fatalf("couldn't find primary NIC: %v", err)
 	}

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestPingVMToVM(t *testing.T) {
-	primaryIP, err := utils.GetMetadata("network-interfaces/0/ip")
+	primaryIP, err := utils.GetMetadata(utils.Context(t), "instance", "network-interfaces", "0", "ip")
 	if err != nil {
 		t.Fatalf("couldn't get internal network IP from metadata, %v", err)
 	}
-	secondaryIP, err := utils.GetMetadata("network-interfaces/1/ip")
+	secondaryIP, err := utils.GetMetadata(utils.Context(t), "instance", "network-interfaces", "1", "ip")
 	if err != nil {
 		t.Fatalf("couldn't get internal network IP from metadata, %v", err)
 	}

--- a/imagetest/test_suites/networkperf/gvnic_test.go
+++ b/imagetest/test_suites/networkperf/gvnic_test.go
@@ -46,7 +46,7 @@ func CheckGVNICPresentWindows(interfaceName string) error {
 }
 
 func TestGVNICExists(t *testing.T) {
-	iface, err := utils.GetInterface(0)
+	iface, err := utils.GetInterface(utils.Context(t), 0)
 	if err != nil {
 		t.Fatalf("couldn't find primary NIC: %v", err)
 	}

--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestNetworkPerformance(t *testing.T) {
 	// Check performance of the driver.
-	results, err := utils.GetMetadataGuestAttribute("testing/results")
+	results, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "results")
 	if err != nil {
 		t.Fatalf("Error : Test results not found. %v", err)
 	}
 
 	// Get the performance target.
-	expectedPerfString, err := utils.GetMetadataAttribute("expectedperf")
+	expectedPerfString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "expectedperf")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -30,14 +30,14 @@ func TestNetworkPerformance(t *testing.T) {
 	expected := 0.85 * float64(expectedPerf)
 
 	// Get machine type and network name for logging.
-	machineType, err := utils.GetMetadata("machine-type")
+	machineType, err := utils.GetMetadata(utils.Context(t), "instance", "machine-type")
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
 	machineTypeSplit := strings.Split(machineType, "/")
 	machineTypeName := machineTypeSplit[len(machineTypeSplit)-1]
 
-	network, err := utils.GetMetadataAttribute("network-tier")
+	network, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "network-tier")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/imagetest/test_suites/packagevalidation/clock_test.go
+++ b/imagetest/test_suites/packagevalidation/clock_test.go
@@ -38,7 +38,7 @@ func TestNTP(t *testing.T) {
 // sles-12 ntpd
 // other distros chronyd
 func testNTPServiceLinux(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata")
 	}

--- a/imagetest/test_suites/packagevalidation/googet_test.go
+++ b/imagetest/test_suites/packagevalidation/googet_test.go
@@ -138,7 +138,7 @@ func TestRepoManagement(t *testing.T) {
 
 func TestPackagesInstalled(t *testing.T) {
 	utils.WindowsOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestPackagesInstalled(t *testing.T) {
 
 func TestPackagesAvailable(t *testing.T) {
 	utils.WindowsOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}
@@ -167,7 +167,7 @@ func TestPackagesAvailable(t *testing.T) {
 func TestPackagesSigned(t *testing.T) {
 	utils.WindowsOnly(t)
 	utils.Skip32BitWindows(t, "Packages not signed on 32-bit client images")
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}

--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestStandardPrograms(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
@@ -37,7 +37,7 @@ func TestStandardPrograms(t *testing.T) {
 
 func TestGuestPackages(t *testing.T) {
 	utils.LinuxOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't determine image from metadata")
 	}

--- a/imagetest/test_suites/packagevalidation/windows_version_test.go
+++ b/imagetest/test_suites/packagevalidation/windows_version_test.go
@@ -200,7 +200,7 @@ func TestDotNETVersion(t *testing.T) {
 
 func TestServicesState(t *testing.T) {
 	utils.WindowsOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}
@@ -231,7 +231,7 @@ func TestServicesState(t *testing.T) {
 
 func TestWindowsEdition(t *testing.T) {
 	utils.WindowsOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}
@@ -250,7 +250,7 @@ func TestWindowsEdition(t *testing.T) {
 
 func TestWindowsCore(t *testing.T) {
 	utils.WindowsOnly(t)
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata %v", err)
 	}

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -5,6 +5,7 @@ package security
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
@@ -74,7 +75,7 @@ func TestKernelSecuritySettings(t *testing.T) {
 
 // TestAutomaticUpdates Check automatic security updates are installed or enabled.
 func TestAutomaticUpdates(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
@@ -121,7 +122,8 @@ func TestAutomaticUpdates(t *testing.T) {
 
 // TestPasswordSecurity Ensure that the system enforces strong passwords and correct lockouts.
 func TestPasswordSecurity(t *testing.T) {
-	image, err := utils.GetMetadata("image")
+	ctx := utils.Context(t)
+	image, err := utils.GetMetadata(ctx, "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}
@@ -140,13 +142,13 @@ func TestPasswordSecurity(t *testing.T) {
 	}
 
 	// Root password/login is disabled.
-	if err := verifyPassword(); err != nil {
+	if err := verifyPassword(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func verifyPassword() error {
-	image, err := utils.GetMetadata("image")
+func verifyPassword(ctx context.Context) error {
+	image, err := utils.GetMetadata(ctx, "instance", "image")
 	if err != nil {
 		return fmt.Errorf("couldn't get image from metadata")
 	}
@@ -409,7 +411,7 @@ func TestSockets(t *testing.T) {
 		// SSH. If we didn't match any above, test logic is faulty.
 		t.Fatalf("No listening sockets")
 	}
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("couldn't get image from metadata")
 	}

--- a/imagetest/test_suites/sql/sql_test.go
+++ b/imagetest/test_suites/sql/sql_test.go
@@ -15,7 +15,7 @@ import (
 func TestSqlVersion(t *testing.T) {
 	utils.WindowsOnly(t)
 
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		t.Fatal("Failed to get image metadata")
 	}

--- a/imagetest/test_suites/ssh/host_key_test.go
+++ b/imagetest/test_suites/ssh/host_key_test.go
@@ -21,7 +21,7 @@ func TestMatchingKeysInGuestAttributes(t *testing.T) {
 		t.Fatalf("failed to get host key from disk %v", err)
 	}
 
-	hostkeys, err := utils.GetMetadataGuestAttribute("hostkeys/")
+	hostkeys, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "hostkeys")
 	if err != nil {
 		t.Fatal(err)
 
@@ -32,7 +32,7 @@ func TestMatchingKeysInGuestAttributes(t *testing.T) {
 		if keyType == "" {
 			continue
 		}
-		keyValue, err := utils.GetMetadataGuestAttribute("hostkeys/" + keyType)
+		keyValue, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "hostkeys", keyType)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,7 +52,7 @@ func TestHostKeysAreUnique(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get real vm name: %v", err)
 	}
-	pembytes, err := utils.DownloadPrivateKey(user)
+	pembytes, err := utils.DownloadPrivateKey(utils.Context(t), user)
 	if err != nil {
 		t.Fatalf("failed to download private key: %v", err)
 	}

--- a/imagetest/test_suites/ssh/image_ssh_test.go
+++ b/imagetest/test_suites/ssh/image_ssh_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestEmptyTest(t *testing.T) {
-	_, err := utils.GetMetadataAttribute("ssh-keys")
+	_, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", "ssh-keys")
 	if err != nil {
 		t.Fatalf("couldn't get ssh public key from metadata")
 	}
@@ -26,7 +26,7 @@ func TestSSHInstanceKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get real vm name: %v", err)
 	}
-	pembytes, err := utils.DownloadPrivateKey(user)
+	pembytes, err := utils.DownloadPrivateKey(utils.Context(t), user)
 	if err != nil {
 		t.Fatalf("failed to download private key: %v", err)
 	}

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -51,7 +51,7 @@ func getLinuxSymlinkRead() (string, error) {
 	}
 	return symlinkRealPath, nil
 }
-func RunFIOReadLinux(mode string) ([]byte, error) {
+func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 	var readOptions string
 	if mode == sequentialMode {
 		readOptions = commonFIOSeqReadOptions
@@ -63,7 +63,7 @@ func RunFIOReadLinux(mode string) ([]byte, error) {
 		return []byte{}, err
 	}
 	// ubuntu 16.04 has a different option name due to an old fio version
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		return []byte{}, fmt.Errorf("couldn't get image from metadata")
 	}
@@ -88,7 +88,7 @@ func TestRandomReadIOPS(t *testing.T) {
 			t.Fatalf("windows fio rand read failed with error: %v", err)
 		}
 	} else {
-		if randReadIOPSJson, err = RunFIOReadLinux(randomMode); err != nil {
+		if randReadIOPSJson, err = RunFIOReadLinux(t, randomMode); err != nil {
 			t.Fatalf("linux fio rand read failed with error: %v", err)
 		}
 	}
@@ -99,7 +99,7 @@ func TestRandomReadIOPS(t *testing.T) {
 	}
 
 	finalIOPSValue := fioOut.Jobs[0].ReadResult.IOPS
-	expectedRandReadIOPSString, err := utils.GetMetadataAttribute(randReadAttribute)
+	expectedRandReadIOPSString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", randReadAttribute)
 	if err != nil {
 		t.Fatalf("could not get metadata attribute %s: err %v", randReadAttribute, err)
 	}
@@ -125,7 +125,7 @@ func TestSequentialReadIOPS(t *testing.T) {
 			t.Fatalf("windows fio seq read failed with error: %v", err)
 		}
 	} else {
-		if seqReadIOPSJson, err = RunFIOReadLinux(sequentialMode); err != nil {
+		if seqReadIOPSJson, err = RunFIOReadLinux(t, sequentialMode); err != nil {
 			t.Fatalf("linux fio seq read failed with error: %v", err)
 		}
 	}
@@ -142,7 +142,7 @@ func TestSequentialReadIOPS(t *testing.T) {
 	}
 	var finalBandwidthMBps float64 = float64(finalBandwidthBytesPerSecond) / bytesInMB
 
-	expectedSeqReadIOPSString, err := utils.GetMetadataAttribute(seqReadAttribute)
+	expectedSeqReadIOPSString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", seqReadAttribute)
 	if err != nil {
 		t.Fatalf("could not get guest metadata %s: err r%v", seqReadAttribute, err)
 	}

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -52,7 +52,7 @@ func getLinuxSymlinkWrite() (string, error) {
 	return symlinkRealPath, nil
 }
 
-func RunFIOWriteLinux(mode string) ([]byte, error) {
+func RunFIOWriteLinux(t *testing.T, mode string) ([]byte, error) {
 	var writeOptions string
 	if mode == sequentialMode {
 		writeOptions = commonFIOSeqWriteOptions
@@ -64,7 +64,7 @@ func RunFIOWriteLinux(mode string) ([]byte, error) {
 		return []byte{}, err
 	}
 	// ubuntu 16.04 has a different option name due to an old fio version
-	image, err := utils.GetMetadata("image")
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
 	if err != nil {
 		return []byte{}, fmt.Errorf("couldn't get image from metadata")
 	}
@@ -89,7 +89,7 @@ func TestRandomWriteIOPS(t *testing.T) {
 			t.Fatalf("windows fio rand write failed with error: %v", err)
 		}
 	} else {
-		if randWriteIOPSJson, err = RunFIOWriteLinux(randomMode); err != nil {
+		if randWriteIOPSJson, err = RunFIOWriteLinux(t, randomMode); err != nil {
 			t.Fatalf("linux fio rand write failed with error: %v", err)
 		}
 	}
@@ -100,7 +100,7 @@ func TestRandomWriteIOPS(t *testing.T) {
 	}
 
 	finalIOPSValue := fioOut.Jobs[0].WriteResult.IOPS
-	expectedRandWriteIOPSString, err := utils.GetMetadataAttribute(randWriteAttribute)
+	expectedRandWriteIOPSString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", randWriteAttribute)
 	if err != nil {
 		t.Fatalf("could not get metadata attribut %s: err %v", randWriteAttribute, err)
 	}
@@ -126,7 +126,7 @@ func TestSequentialWriteIOPS(t *testing.T) {
 			t.Fatalf("windows fio seq write failed with error: %v", err)
 		}
 	} else {
-		if seqWriteIOPSJson, err = RunFIOWriteLinux(sequentialMode); err != nil {
+		if seqWriteIOPSJson, err = RunFIOWriteLinux(t, sequentialMode); err != nil {
 			t.Fatalf("linux fio seq write failed with error: %v", err)
 		}
 	}
@@ -142,7 +142,7 @@ func TestSequentialWriteIOPS(t *testing.T) {
 	}
 	var finalBandwidthMBps float64 = float64(finalBandwidthBytesPerSecond) / bytesInMB
 
-	expectedSeqWriteIOPSString, err := utils.GetMetadataAttribute(seqWriteAttribute)
+	expectedSeqWriteIOPSString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", seqWriteAttribute)
 	if err != nil {
 		t.Fatalf("could not get metadata attribute %s: err %v", seqWriteAttribute, err)
 	}

--- a/imagetest/utils/metadata.go
+++ b/imagetest/utils/metadata.go
@@ -1,0 +1,106 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+const (
+	metadataURLPrefix = "http://metadata.google.internal/computeMetadata/v1/"
+)
+
+// GetMetadata does a HTTP Get request to the metadata server, the metadata entry of
+// interest is provided by elem as the elements of the entry path, the following example
+// does a Get request to the entry "instance/guest-attributes":
+//
+// resp, err := GetAttribute(context.Background(), "instance", "guest-attributes")
+// ...
+func GetMetadata(ctx context.Context, elem ...string) (string, error) {
+	path, err := url.JoinPath(metadataURLPrefix, elem...)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse metadata url: %+s", err)
+	}
+
+	body, _, err := doHTTPGet(ctx, path)
+	return body, err
+}
+
+// GetMetadataWithHeaders is similar to GetMetadata it only differs on the return where GetMetadata
+// returns only the response's body as a string and an error GetMetadataWithHeaders returns the
+// response's body as a string, the headers and an error.
+func GetMetadataWithHeaders(ctx context.Context, elem ...string) (string, http.Header, error) {
+	path, err := url.JoinPath(metadataURLPrefix, elem...)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse metadata url: %+s", err)
+	}
+
+	return doHTTPGet(ctx, path)
+}
+
+// PutMetadata does a HTTP Put request to the metadata server, the metadata entry of
+// interest is provided by elem as the elements of the entry path, the following example
+// does a Put request to the entry "instance/guest-attributes":
+//
+// err := PutMetadata(context.Background(), "instance", "guest-attributes")
+// ...
+func PutMetadata(ctx context.Context, elem ...string) error {
+	path, err := url.JoinPath(metadataURLPrefix, elem...)
+	if err != nil {
+		return fmt.Errorf("failed to parse metadata url: %+v", err)
+	}
+
+	err = doHTTPPut(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func doHTTPRequest(req *http.Request) (*http.Response, error) {
+	req.Header.Add("Metadata-Flavor", "Google")
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do the http request: %+v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("http response code is %v", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+func doHTTPGet(ctx context.Context, path string) (string, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create a http request with context: %+v", err)
+	}
+
+	resp, err := doHTTPRequest(req)
+	if err != nil {
+		return "", nil, err
+	}
+
+	val, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to read http request body: %+v", err)
+	}
+
+	return string(val), resp.Header, nil
+}
+
+func doHTTPPut(ctx context.Context, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, path, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a http request with context: %+v", err)
+	}
+
+	_, err = doHTTPRequest(req)
+	return err
+}

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -18,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"golang.org/x/crypto/ssh"
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	metadataURLPrefix = "http://metadata.google.internal/computeMetadata/v1/instance/"
-	bytesInGB         = 1073741824
+	bytesInGB = 1073741824
 	// GuestAttributeTestNamespace is the namespace for the guest attribute in the daisy "wait for instance" step for CIT.
 	GuestAttributeTestNamespace = "citTest"
 	// GuestAttributeTestKey is the key for the guest attribute in the daisy "wait for instance" step for CIT in the common case.
@@ -69,80 +68,6 @@ func GetRealVMName(name string) (string, error) {
 		return "", errors.New("hostname doesn't match scheme")
 	}
 	return strings.Join([]string{name, parts[1], parts[2]}, "-"), nil
-}
-
-// GetMetadataAttribute returns an attribute from metadata if present, and error if not.
-func GetMetadataAttribute(attribute string) (string, error) {
-	return GetMetadata("attributes/" + attribute)
-}
-
-// GetMetadataGuestAttribute returns an guest attribute from metadata if present, and error if not.
-func GetMetadataGuestAttribute(attribute string) (string, error) {
-	return GetMetadata("guest-attributes/" + attribute)
-}
-
-// GetMetadata returns a metadata value for the specified key if it is present, and error if not.
-func GetMetadata(path string) (string, error) {
-	resp, err := GetMetadataHTTPResponse(path)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("http response code is %v", resp.StatusCode)
-	}
-	val, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(val), nil
-}
-
-// GetMetadataHTTPResponse returns http response for the specified key without checking status code.
-func GetMetadataHTTPResponse(path string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", metadataURLPrefix, path), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Metadata-Flavor", "Google")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// QueryMetadataGuestAttribute sets the guest attribute in the namespace
-// using the given method, and returns an error if this operation fails.
-func QueryMetadataGuestAttribute(ctx context.Context, namespace, attribute, httpMethod string) error {
-	path, err := url.JoinPath(metadataURLPrefix, "guest-attributes", namespace, attribute)
-	if err != nil {
-		return err
-	}
-	err = QueryMetadataHTTPResponse(ctx, path, httpMethod)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// QueryMetadataHTTPResponse returns http response for the specified key
-// using a http request with the given method without checking status code.
-func QueryMetadataHTTPResponse(ctx context.Context, path, httpMethod string) error {
-	req, err := http.NewRequestWithContext(ctx, httpMethod, path, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Metadata-Flavor", "Google")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("http response code is %v", resp.StatusCode)
-	}
-	return nil
 }
 
 // DownloadGCSObject downloads a GCS object.
@@ -195,13 +120,13 @@ func ExtractBaseImageName(image string) (string, error) {
 }
 
 // DownloadPrivateKey download private key from daisy source.
-func DownloadPrivateKey(user string) ([]byte, error) {
-	ctx := context.Background()
+func DownloadPrivateKey(ctx context.Context, user string) ([]byte, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	sourcesPath, err := GetMetadataAttribute("daisy-sources-path")
+
+	sourcesPath, err := GetMetadata(ctx, "instance", "attributes", "daisy-sources-path")
 	if err != nil {
 		return nil, err
 	}
@@ -302,8 +227,8 @@ func GetInterfaceByMAC(mac string) (net.Interface, error) {
 }
 
 // GetInterface returns the interface corresponding to the metadata interface array at the specified index.
-func GetInterface(index int) (net.Interface, error) {
-	mac, err := GetMetadata(fmt.Sprintf("network-interfaces/%d/mac", index))
+func GetInterface(ctx context.Context, index int) (net.Interface, error) {
+	mac, err := GetMetadata(ctx, "instance", "network-interfaces", fmt.Sprintf("%d", index), "mac")
 	if err != nil {
 		return net.Interface{}, err
 	}
@@ -347,7 +272,7 @@ func Is32BitWindows(image string) bool {
 
 // Skip32BitWindows skips tests on 32-bit client images.
 func Skip32BitWindows(t *testing.T, skipMsg string) {
-	image, err := GetMetadata("image")
+	image, err := GetMetadata(Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata: %v", err)
 	}
@@ -378,7 +303,7 @@ func IsWindowsClient(image string) bool {
 // WindowsContainersOnly skips tests not on Windows "for Containers" images.
 func WindowsContainersOnly(t *testing.T) {
 	WindowsOnly(t)
-	image, err := GetMetadata("image")
+	image, err := GetMetadata(Context(t), "instance", "image")
 	if err != nil {
 		t.Fatalf("Couldn't get image from metadata: %v", err)
 	}
@@ -523,4 +448,26 @@ func HasFeature(img *compute.Image, feature string) bool {
 		}
 	}
 	return false
+}
+
+// Context returns a context to be used by test implementations, it handles
+// the context cancellation based on the test's timeout(deadline), if no timeout
+// is defined (or the deadline can't be assessed) then a plain background context
+// is returned.
+func Context(t *testing.T) context.Context {
+	// If the test has a deadline defined use it as a last resort
+	// context cancelation.
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel := context.WithCancel(context.Background())
+		timer := time.NewTimer(time.Until(deadline))
+		go func() {
+			<-timer.C
+			cancel()
+		}()
+		return ctx
+	}
+
+	// If there's not deadline defined then we just use a
+	// plain background context as we won't need to cancel it.
+	return context.Background()
 }


### PR DESCRIPTION
Remove duplicate methods and stop assuming instance attributes for all calls, let the callers decide the metadata root level.