### PR TITLE
Imagetest local build support

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -22,7 +22,7 @@ ENV CGO_ENABLED 0
 ENV GOOS linux
 ENV GO111MODULE on
 
-RUN ./local_build.sh -o /
+RUN ./local_build.sh -o /out
 
 FROM alpine:latest
 RUN apk add --no-cache openssh-keygen

--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -22,31 +22,7 @@ ENV CGO_ENABLED 0
 ENV GOOS linux
 ENV GO111MODULE on
 
-RUN go mod download
-RUN go build -o /out/wrapper.amd64 ./cmd/wrapper/main.go
-RUN GOARCH=arm64 go build -o /out/wrapper.arm64 ./cmd/wrapper/main.go
-# Setting the windows file names to respect 8.3 file naming.
-RUN GOOS=windows GOARCH=amd64 go build -o /out/wrapp64.exe ./cmd/wrapper/main.go
-RUN GOOS=windows GOARCH=386 go build -o /out/wrapp32.exe ./cmd/wrapper/main.go
-RUN go build -o /out/manager ./cmd/manager/main.go
-RUN cd test_suites; for suite in *; do \
-  [[ -d $suite ]] || continue; \
-  cd $suite; \
-  go test -c -tags cit || exit 1; \
-  ./"${suite}.test" -test.list '.*' > /out/"${suite}_tests.txt" || exit 1; \
-  mv "${suite}.test" "/out/${suite}.amd64.test" || exit 1; \
-  GOARCH=arm64 go test -c -tags cit || exit 1; \
-  mv "${suite}.test" "/out/${suite}.arm64.test" || exit 1; \
-  GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1; \
-  if [ -f "${suite}.test.exe" ]; then \
-    mv "${suite}.test.exe" "/out/${suite}64.exe" || exit 1; \
-  fi; \
-  GOOS=windows GOARCH=386 go test -c -tags cit || exit 1; \
-  if [ -f "${suite}.test.exe" ]; then \
-    mv "${suite}.test.exe" "/out/${suite}32.exe" || exit 1; \
-  fi; \
-  cd ..; \
-  done
+RUN ./local_build.sh -o /
 
 FROM alpine:latest
 RUN apk add --no-cache openssh-keygen

--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -40,6 +40,7 @@ var (
 	validate        = flag.Bool("validate", false, "validate all the test workflows and exit")
 	outPath         = flag.String("out_path", "junit.xml", "junit xml path")
 	gcsPath         = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
+	localPath       = flag.String("local_path", "/", "path where test output files are stored, can be modified for local testing")
 	images          = flag.String("images", "", "comma separated list of images to test")
 	timeout         = flag.String("timeout", "45m", "timeout for the test suite")
 	parallelCount   = flag.Int("parallel_count", 5, "TestParallelCount")
@@ -272,18 +273,18 @@ func main() {
 	}
 
 	if *printwf {
-		imagetest.PrintTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath)
+		imagetest.PrintTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath, *localPath)
 		return
 	}
 
 	if *validate {
-		if err := imagetest.ValidateTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath); err != nil {
+		if err := imagetest.ValidateTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath, *localPath); err != nil {
 			log.Printf("Validate failed: %v\n", err)
 		}
 		return
 	}
 
-	suites, err := imagetest.RunTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath, *parallelCount, *parallelStagger, testProjectsReal)
+	suites, err := imagetest.RunTests(ctx, storageclient, testWorkflows, *project, *zone, *gcsPath, *localPath, *parallelCount, *parallelStagger, testProjectsReal)
 	if err != nil {
 		log.Fatalf("Failed to run tests: %v", err)
 	}

--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -40,7 +40,7 @@ var (
 	validate        = flag.Bool("validate", false, "validate all the test workflows and exit")
 	outPath         = flag.String("out_path", "junit.xml", "junit xml path")
 	gcsPath         = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
-	localPath       = flag.String("local_path", "/", "path where test output files are stored, can be modified for local testing")
+	localPath       = flag.String("local_path", "", "path where test output files are stored, can be modified for local testing")
 	images          = flag.String("images", "", "comma separated list of images to test")
 	timeout         = flag.String("timeout", "45m", "timeout for the test suite")
 	parallelCount   = flag.Int("parallel_count", 5, "TestParallelCount")

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -28,14 +28,14 @@ for suite in $suites; do
   [[ -d $suite ]] || continue
   cd $suite
   echo "building suite $suite"
-  go test -c -tags cit
-  ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt"
-  mv "${suite}.test" $outpath/"${suite}.amd64.test"
-  GOARCH=arm64 go test -c -tags cit
-  mv "${suite}.test" "$outpath/${suite}.arm64.test"
-  GOOS=windows GOARCH=amd64 go test -c -tags cit
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe"; fi;
-  GOOS=windows GOARCH=386 go test -c -tags cit
-  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe"; fi;
+  go test -c -tags cit || exit 1
+  ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt" || exit 1
+  mv "${suite}.test" $outpath/"${suite}.amd64.test" || exit 1
+  GOARCH=arm64 go test -c -tags cit || exit 1
+  mv "${suite}.test" "$outpath/${suite}.arm64.test" || exit 1
+  GOOS=windows GOARCH=amd64 go test -c -tags cit || exit 1
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe" || exit 1; fi;
+  GOOS=windows GOARCH=386 go test -c -tags cit || exit 1
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe" || exit 1; fi;
   cd ..
 done

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -1,0 +1,9 @@
+rootpath=$1
+suite=$2
+go build -o $rootpath/wrapper.amd64 ./cmd/wrapper/main.go
+go build -o $rootpath/manager ./cmd/manager/main.go
+cd test_suites
+cd $suite
+go test -c -tags cit
+./"${suite}.test" -test.list '.*' > $rootpath/"${suite}_tests.txt"
+mv "${suite}.test" $rootpath/"${suite}.amd64.test"

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -1,11 +1,47 @@
-# rootpath should be an absolute path where you want test output files storedm, such as /home/username
-# suite is the name of the test suite
-rootpath=$1
-suite=$2
-go build -o $rootpath/wrapper.amd64 ./cmd/wrapper/main.go
-go build -o $rootpath/manager ./cmd/manager/main.go
+# usage: local_build.sh -o $outspath -c $cmdroot -s $suites_to_build
+# the output path of the test files
+outpath=.
+# the root of the cmd folder, default assumes this script is run from imagetest
+cmdroot=.
+# the suites to build, space separated. all suites are built by default
+suites=*
+
+while getopts "o:c:s:" arg; do
+  case $arg in 
+    o) outpath=$OPTARG;;
+    c) cmdroot=$OPTARG;;
+    s) suites=$OPTARG;;
+    *) echo "unknown arg"
+  esac
+done 
+echo "outspath is $outpath"
+echo "cmdroot is $cmdroot"
+echo "suites are $suites"
+go mod download
+echo "1"
+go build -o $outpath/wrapper.amd64 $cmdroot/cmd/wrapper/main.go
+GOARCH=arm64 go build -o $outpath/wrapper.arm64 $cmdroot/cmd/wrapper/main.go
+GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe $cmdroot/cmd/wrapper/main.go
+GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe $cmdroot/cmd/wrapper/main.go
+echo "2"
+go build -o $outpath/manager $cmdroot/cmd/manager/main.go
 cd test_suites
-cd $suite
-go test -c -tags cit
-./"${suite}.test" -test.list '.*' > $rootpath/"${suite}_tests.txt"
-mv "${suite}.test" $rootpath/"${suite}.amd64.test"
+echo "3"
+for suite in $suites; do
+  [[ -d $suite ]] || continue
+  cd $suite
+  echo "4"
+  go test -c -tags cit
+  ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt"
+  mv "${suite}.test" $outpath/"${suite}.amd64.test"
+  GOARCH=arm64 go test -c -tags cit
+  mv "${suite}.test" "$outpath/${suite}.arm64.test"
+  echo "5"
+  GOOS=windows GOARCH=amd64 go test -c -tags cit
+  echo "6"
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe"; fi;
+  echo "7"
+  GOOS=windows GOARCH=386 go test -c -tags cit
+  if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe"; fi;
+  cd ..
+done

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -1,4 +1,4 @@
-# usage: local_build.sh -o $outspath -c $cmdroot -s $suites_to_build
+# usage: local_build.sh -o $outspath -i $imagetestroot -s $suites_to_build
 # the output path of the test files
 outpath=.
 # the suites to build, space separated. all suites are built by default

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -16,31 +16,25 @@ while getopts "o:c:s:" arg; do
 done 
 echo "outspath is $outpath"
 echo "cmdroot is $cmdroot"
-echo "suites are $suites"
+echo "suites being built are $suites"
 go mod download
-echo "1"
 go build -o $outpath/wrapper.amd64 $cmdroot/cmd/wrapper/main.go
 GOARCH=arm64 go build -o $outpath/wrapper.arm64 $cmdroot/cmd/wrapper/main.go
 GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe $cmdroot/cmd/wrapper/main.go
 GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe $cmdroot/cmd/wrapper/main.go
-echo "2"
 go build -o $outpath/manager $cmdroot/cmd/manager/main.go
 cd test_suites
-echo "3"
 for suite in $suites; do
   [[ -d $suite ]] || continue
   cd $suite
-  echo "4"
+  echo "building suite $suite"
   go test -c -tags cit
   ./"${suite}.test" -test.list '.*' > $outpath/"${suite}_tests.txt"
   mv "${suite}.test" $outpath/"${suite}.amd64.test"
   GOARCH=arm64 go test -c -tags cit
   mv "${suite}.test" "$outpath/${suite}.arm64.test"
-  echo "5"
   GOOS=windows GOARCH=amd64 go test -c -tags cit
-  echo "6"
   if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}64.exe"; fi;
-  echo "7"
   GOOS=windows GOARCH=386 go test -c -tags cit
   if [ -f "${suite}.test.exe" ]; then mv "${suite}.test.exe" "$outpath/${suite}32.exe"; fi;
   cd ..

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -1,3 +1,5 @@
+# rootpath should be an absolute path where you want test output files storedm, such as /home/username
+# suite is the name of the test suite
 rootpath=$1
 suite=$2
 go build -o $rootpath/wrapper.amd64 ./cmd/wrapper/main.go

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -5,25 +5,35 @@ outpath=.
 cmdroot=.
 # the suites to build, space separated. all suites are built by default
 suites=*
+# the script will run cd $imagetestroot/test_suites. If this script is not run from the imagetest folder, imagetestroot should be set to the path to the parent directory of test_suites.
+imagetestroot=.
 
-while getopts "o:c:s:" arg; do
+
+while getopts "o:c:s:i:" arg; do
   case $arg in 
     o) outpath=$OPTARG;;
     c) cmdroot=$OPTARG;;
     s) suites=$OPTARG;;
+    i) imagetestroot=$OPTARG;;
     *) echo "unknown arg"
   esac
 done 
+
+
 echo "outspath is $outpath"
 echo "cmdroot is $cmdroot"
 echo "suites being built are $suites"
+echo "imagetestroot is $imagetestroot"
+
 go mod download
 go build -o $outpath/wrapper.amd64 $cmdroot/cmd/wrapper/main.go
 GOARCH=arm64 go build -o $outpath/wrapper.arm64 $cmdroot/cmd/wrapper/main.go
 GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe $cmdroot/cmd/wrapper/main.go
 GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe $cmdroot/cmd/wrapper/main.go
 go build -o $outpath/manager $cmdroot/cmd/manager/main.go
-cd test_suites
+
+
+cd $imagetestroot/test_suites
 for suite in $suites; do
   [[ -d $suite ]] || continue
   cd $suite

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -1,18 +1,15 @@
 # usage: local_build.sh -o $outspath -c $cmdroot -s $suites_to_build
 # the output path of the test files
 outpath=.
-# the root of the cmd folder, default assumes this script is run from imagetest
-cmdroot=.
 # the suites to build, space separated. all suites are built by default
 suites=*
-# the script will run cd $imagetestroot/test_suites. If this script is not run from the imagetest folder, imagetestroot should be set to the path to the parent directory of test_suites.
+# the path to the imagetest folder, default value assumes this script is run from the imagetest folder. If set, the commands cd $imagetestroot/cmd and cd $imagetestroot/test_suites should succeed.
 imagetestroot=.
 
 
-while getopts "o:c:s:i:" arg; do
+while getopts "o:s:i:" arg; do
   case $arg in 
     o) outpath=$OPTARG;;
-    c) cmdroot=$OPTARG;;
     s) suites=$OPTARG;;
     i) imagetestroot=$OPTARG;;
     *) echo "unknown arg"
@@ -21,19 +18,19 @@ done
 
 
 echo "outspath is $outpath"
-echo "cmdroot is $cmdroot"
 echo "suites being built are $suites"
 echo "imagetestroot is $imagetestroot"
 
+cd $imagetestroot
 go mod download
-go build -o $outpath/wrapper.amd64 $cmdroot/cmd/wrapper/main.go
-GOARCH=arm64 go build -o $outpath/wrapper.arm64 $cmdroot/cmd/wrapper/main.go
-GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe $cmdroot/cmd/wrapper/main.go
-GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe $cmdroot/cmd/wrapper/main.go
-go build -o $outpath/manager $cmdroot/cmd/manager/main.go
+go build -o $outpath/wrapper.amd64 ./cmd/wrapper/main.go
+GOARCH=arm64 go build -o $outpath/wrapper.arm64 ./cmd/wrapper/main.go
+GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe ./cmd/wrapper/main.go
+GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe ./cmd/wrapper/main.go
+go build -o $outpath/manager ./cmd/manager/main.go
 
 
-cd $imagetestroot/test_suites
+cd test_suites
 for suite in $suites; do
   [[ -d $suite ]] || continue
   cd $suite

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -457,7 +457,7 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s/%s%s.exe", localPath, testWrapperPathWindows, archBits)
 		} else {
 			twf.wf.Sources["testpackage"] = fmt.Sprintf("%s/%s.%s.test", localPath, twf.Name, arch)
-			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s/%s.%s", localPath, testWrapperPath, arch)
+			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s%s.%s", localPath, testWrapperPath, arch)
 		}
 
 		// add a final copy-objects step which copies the daisy-outs-path directory to twf.gcsPath + /outs

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -380,7 +380,7 @@ func getGCSPrefix(ctx context.Context, storageClient *storage.Client, project, g
 
 // finalizeWorkflows adds the final necessary data to each workflow for it to
 // be able to run, including the final copy-objects step.
-func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPrefix string) error {
+func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPrefix, localPath string) error {
 	log.Printf("Storing artifacts and logs in %s", gcsPrefix)
 	for _, twf := range tests {
 		if twf.wf == nil {
@@ -453,11 +453,11 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 			if strings.Contains(twf.ImageURL, "x86") {
 				archBits = "32"
 			}
-			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s%s.exe", twf.Name, archBits)
-			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s%s.exe", testWrapperPathWindows, archBits)
+			twf.wf.Sources["testpackage"] = fmt.Sprintf("%s/%s%s.exe", localPath, twf.Name, archBits)
+			twf.wf.Sources["wrapper.exe"] = fmt.Sprintf("%s/%s%s.exe", localPath, testWrapperPathWindows, archBits)
 		} else {
-			twf.wf.Sources["testpackage"] = fmt.Sprintf("/%s.%s.test", twf.Name, arch)
-			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s.%s", testWrapperPath, arch)
+			twf.wf.Sources["testpackage"] = fmt.Sprintf("%s/%s.%s.test", localPath, twf.Name, arch)
+			twf.wf.Sources["wrapper"] = fmt.Sprintf("%s/%s.%s", localPath, testWrapperPath, arch)
 		}
 
 		// add a final copy-objects step which copies the daisy-outs-path directory to twf.gcsPath + /outs
@@ -555,13 +555,13 @@ func NewTestWorkflow(client daisycompute.Client, name, image, timeout, project, 
 }
 
 // PrintTests prints all test workflows.
-func PrintTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath string) {
+func PrintTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath, localPath string) {
 	gcsPrefix, err := getGCSPrefix(ctx, storageClient, project, gcsPath)
 	if err != nil {
 		log.Printf("Error determining GCS prefix: %v", err)
 		gcsPrefix = ""
 	}
-	if err := finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix); err != nil {
+	if err := finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix, localPath); err != nil {
 		log.Printf("Error finalizing workflow: %v", err)
 	}
 	for _, test := range testWorkflows {
@@ -574,12 +574,12 @@ func PrintTests(ctx context.Context, storageClient *storage.Client, testWorkflow
 }
 
 // ValidateTests validates all test workflows.
-func ValidateTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath string) error {
+func ValidateTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath, localPath string) error {
 	gcsPrefix, err := getGCSPrefix(ctx, storageClient, project, gcsPath)
 	if err != nil {
 		return err
 	}
-	if err := finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix); err != nil {
+	if err := finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix, localPath); err != nil {
 		return err
 	}
 	for _, test := range testWorkflows {
@@ -614,7 +614,7 @@ func daisyBucket(ctx context.Context, client *storage.Client, project string) (s
 }
 
 // RunTests runs all test workflows.
-func RunTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath string, parallelCount int, parallelStagger string, testProjects []string) (*TestSuites, error) {
+func RunTests(ctx context.Context, storageClient *storage.Client, testWorkflows []*TestWorkflow, project, zone, gcsPath, localPath string, parallelCount int, parallelStagger string, testProjects []string) (*TestSuites, error) {
 	gcsPrefix, err := getGCSPrefix(ctx, storageClient, project, gcsPath)
 	if err != nil {
 		return nil, err
@@ -624,7 +624,7 @@ func RunTests(ctx context.Context, storageClient *storage.Client, testWorkflows 
 		return nil, err
 	}
 
-	finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix)
+	finalizeWorkflows(ctx, testWorkflows, zone, gcsPrefix, localPath)
 
 	testResults := make(chan testResult, len(testWorkflows))
 	testchan := make(chan *TestWorkflow, len(testWorkflows))
@@ -672,7 +672,7 @@ func RunTests(ctx context.Context, storageClient *storage.Client, testWorkflows 
 
 	var suites TestSuites
 	for i := 0; i < len(testWorkflows); i++ {
-		suites.TestSuite = append(suites.TestSuite, parseResult(<-testResults))
+		suites.TestSuite = append(suites.TestSuite, parseResult(<-testResults, localPath))
 	}
 	for _, suite := range suites.TestSuite {
 		suites.Errors += suite.Errors
@@ -721,7 +721,7 @@ func runTestWorkflow(ctx context.Context, test *TestWorkflow) testResult {
 }
 
 // gets result struct and converts to a jUnit TestSuite
-func parseResult(res testResult) *testSuite {
+func parseResult(res testResult, localPath string) *testSuite {
 	ret := &testSuite{}
 	// Use ImageURL instead of the name or family to display results the same way
 	// as the user entered them.
@@ -729,7 +729,7 @@ func parseResult(res testResult) *testSuite {
 
 	switch {
 	case res.skipped:
-		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
+		for _, test := range getTestsBySuiteName(res.testWorkflow.Name, localPath) {
 			tc := &testCase{}
 			tc.Classname = name
 			tc.Name = test
@@ -749,7 +749,7 @@ func parseResult(res testResult) *testSuite {
 		} else {
 			status = "Unknown status"
 		}
-		for _, test := range getTestsBySuiteName(res.testWorkflow.Name) {
+		for _, test := range getTestsBySuiteName(res.testWorkflow.Name, localPath) {
 			tc := &testCase{}
 			tc.Classname = name
 			tc.Name = test
@@ -765,8 +765,8 @@ func parseResult(res testResult) *testSuite {
 	return ret
 }
 
-func getTestsBySuiteName(name string) []string {
-	b, err := ioutil.ReadFile(fmt.Sprintf("/%s_tests.txt", name))
+func getTestsBySuiteName(name, localPath string) []string {
+	b, err := ioutil.ReadFile(fmt.Sprintf("%s/%s_tests.txt", localPath, name))
 	if err != nil {
 		log.Fatalf("unable to parse tests list: %v", err)
 		return []string{} // NOT nil


### PR DESCRIPTION
Allow local testing for builds so the dev process is faster, though currently only supported for one test suite at a time and AMD 64 linux

Example invocation (assuming zone, project, and images are set, and this is run from the imagetest folder):

outspath=/home/username/out
./local_build.sh -o $outspath -s disk
cd $outspath
./manager -zone $ZONE -project $PROJECT -images $images -filter disk -local_path $outspath

Alternatively, if invoking from another folder, the imagetest root can be passed in.

If invoking from guest-test-infra, 
./imagetest/local_build.sh -o $outspath -s disk -i imagetest