### PR TITLE
oslogin: 2fa MDS entry will not always be present

### DIFF
--- a/imagetest/test_suites/oslogin/oslogin_test.go
+++ b/imagetest/test_suites/oslogin/oslogin_test.go
@@ -5,6 +5,7 @@ package oslogin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
@@ -35,15 +36,21 @@ func getTwoFactorAuth(ctx context.Context, root string, elem ...string) (bool, e
 }
 
 func isTwoFactorAuthEnabled(t *testing.T) (bool, error) {
+	var (
+		instanceFlag, projectFlag bool
+		err                       error
+	)
+
 	elem := []string{"attributes", "enable-oslogin-2fa"}
 	ctx := utils.Context(t)
-	instanceFlag, err := getTwoFactorAuth(ctx, "instance", elem...)
-	if err != nil {
+
+	instanceFlag, err = getTwoFactorAuth(ctx, "instance", elem...)
+	if err != nil && !errors.Is(err, utils.ErrMDSEntryNotFound) {
 		return false, err
 	}
 
-	projectFlag, err := getTwoFactorAuth(ctx, "project", elem...)
-	if err != nil {
+	projectFlag, err = getTwoFactorAuth(ctx, "project", elem...)
+	if err != nil && !errors.Is(err, utils.ErrMDSEntryNotFound) {
 		return false, err
 	}
 

--- a/imagetest/utils/metadata.go
+++ b/imagetest/utils/metadata.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -10,6 +11,11 @@ import (
 
 const (
 	metadataURLPrefix = "http://metadata.google.internal/computeMetadata/v1/"
+)
+
+var (
+	// ErrMDSEntryNotFound is an error used to report 404 status code.
+	ErrMDSEntryNotFound = errors.New("No metadata entry found: 404 error")
 )
 
 // GetMetadata does a HTTP Get request to the metadata server, the metadata entry of
@@ -67,6 +73,10 @@ func doHTTPRequest(req *http.Request) (*http.Response, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to do the http request: %+v", err)
+	}
+
+	if resp.StatusCode == 404 {
+		return nil, ErrMDSEntryNotFound
 	}
 
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
Considering that non existing 2fa MDS entry is assumed as "non enabled" this patch changes the metadata utils to report a known error for 404 errors, if the entry is not found we assume the flag to be disabled.