### PR TITLE
Add the ability for TestVM to run on an instance from the beta API.

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -23,8 +23,8 @@ import (
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	"github.com/google/uuid"
-	"google.golang.org/api/compute/v1"
 	computeBeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
 )
 
 const (
@@ -297,7 +297,7 @@ func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instance
 
 // CreateTestVMFromInstanceBeta creates a test vm struct to run CIT suites on from
 // the given daisy instancebeta and adds it to the test workflow.
-func (t *TestWorkflow)CreateTestVMFromInstanceBeta(i *daisy.InstanceBeta, disks []*compute.Disk) (*TestVM, error) {
+func (t *TestWorkflow) CreateTestVMFromInstanceBeta(i *daisy.InstanceBeta, disks []*compute.Disk) (*TestVM, error) {
 	if len(disks) == 0 || disks[0].Name == "" {
 		return nil, fmt.Errorf("failed to create multiple disk VM with empty boot disk")
 	}

--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -24,6 +24,7 @@ import (
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	"github.com/google/uuid"
 	"google.golang.org/api/compute/v1"
+	computeBeta "google.golang.org/api/compute/v0.beta"
 )
 
 const (
@@ -55,14 +56,22 @@ const (
 type TestVM struct {
 	name         string
 	testWorkflow *TestWorkflow
+	// The underlying instance running the test. Exactly one of these must be non-nil.
 	instance     *daisy.Instance
+	instancebeta *daisy.InstanceBeta
 }
 
 // AddUser add user public key to metadata ssh-keys.
 func (t *TestVM) AddUser(user, publicKey string) {
 	keyline := fmt.Sprintf("%s:%s", user, publicKey)
-	if keys, ok := t.instance.Metadata["ssh-keys"]; ok {
-		keyline = fmt.Sprintf("%s\n%s", keys, keyline)
+	if t.instance != nil {
+		if keys, ok := t.instance.Metadata["ssh-keys"]; ok {
+			keyline = fmt.Sprintf("%s\n%s", keys, keyline)
+		}
+	} else if t.instancebeta != nil {
+		if keys, ok := t.instancebeta.Metadata["ssh-keys"]; ok {
+			keyline = fmt.Sprintf("%s\n%s", keys, keyline)
+		}
 	}
 	t.AddMetadata("ssh-keys", keyline)
 }
@@ -163,6 +172,53 @@ func (t *TestWorkflow) CreateTestVM(name string) (*TestVM, error) {
 	return &TestVM{name: vmname, testWorkflow: t, instance: i}, nil
 }
 
+// CreateTestVMBeta adds the necessary steps to create a VM with the specified
+// name from the compute beta API to the workflow.
+func (t *TestWorkflow) CreateTestVMBeta(name string) (*TestVM, error) {
+	parts := strings.Split(name, ".")
+	vmname := strings.ReplaceAll(parts[0], "_", "-")
+
+	bootDisk := &compute.Disk{Name: vmname}
+	createDisksStep, err := t.appendCreateDisksStep(bootDisk)
+	if err != nil {
+		return nil, err
+	}
+
+	daisyInst := &daisy.InstanceBeta{}
+	// createDisksStep doesn't depend on any other steps.
+	createVMStep, i, err := t.appendCreateVMStepBeta([]*compute.Disk{bootDisk}, daisyInst)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
+		return nil, err
+	}
+
+	waitStep, err := t.addWaitStep(vmname, vmname)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := t.wf.AddDependency(waitStep, createVMStep); err != nil {
+		return nil, err
+	}
+
+	if createSubnetworkStep, ok := t.wf.Steps[createSubnetworkStepName]; ok {
+		if err := t.wf.AddDependency(createVMStep, createSubnetworkStep); err != nil {
+			return nil, err
+		}
+	}
+
+	if createNetworkStep, ok := t.wf.Steps[createNetworkStepName]; ok {
+		if err := t.wf.AddDependency(createVMStep, createNetworkStep); err != nil {
+			return nil, err
+		}
+	}
+
+	return &TestVM{name: vmname, testWorkflow: t, instancebeta: i}, nil
+}
+
 // CreateTestVMMultipleDisks adds the necessary steps to create a VM with the specified
 // name to the workflow.
 func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instanceParams *daisy.Instance) (*TestVM, error) {
@@ -239,12 +295,86 @@ func (t *TestWorkflow) CreateTestVMMultipleDisks(disks []*compute.Disk, instance
 	return &TestVM{name: vmname, testWorkflow: t, instance: i}, nil
 }
 
+// CreateTestVMFromInstanceBeta creates a test vm struct to run CIT suites on from
+// the given daisy instancebeta and adds it to the test workflow.
+func (t *TestWorkflow)CreateTestVMFromInstanceBeta(i *daisy.InstanceBeta, disks []*compute.Disk) (*TestVM, error) {
+	if len(disks) == 0 || disks[0].Name == "" {
+		return nil, fmt.Errorf("failed to create multiple disk VM with empty boot disk")
+	}
+
+	name := disks[0].Name
+	parts := strings.Split(name, ".")
+	vmname := strings.ReplaceAll(parts[0], "_", "-")
+
+	createDisksSteps := make([]*daisy.Step, len(disks))
+	for i, disk := range disks {
+		// the disk creation steps are slightly different for the boot disk and mount disks
+		var createDisksStep *daisy.Step
+		var err error
+		if i == 0 {
+			createDisksStep, err = t.appendCreateDisksStep(disk)
+		} else {
+			createDisksStep, err = t.appendCreateMountDisksStep(disk)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+		createDisksSteps[i] = createDisksStep
+	}
+	// createDisksStep doesn't depend on any other steps.
+	createVMStep, i, err := t.appendCreateVMStepBeta(disks, i)
+	if err != nil {
+		return nil, err
+	}
+	for _, createDisksStep := range createDisksSteps {
+		if err := t.wf.AddDependency(createVMStep, createDisksStep); err != nil {
+			return nil, err
+		}
+	}
+
+	var waitStep *daisy.Step
+	if _, foundKey := i.Metadata[ShouldRebootDuringTest]; foundKey {
+		waitStep, err = t.addWaitRebootGAStep(vmname, vmname)
+	} else {
+		waitStep, err = t.addWaitStep(vmname, vmname)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := t.wf.AddDependency(waitStep, createVMStep); err != nil {
+		return nil, err
+	}
+
+	if createSubnetworkStep, ok := t.wf.Steps[createSubnetworkStepName]; ok {
+		if err := t.wf.AddDependency(createVMStep, createSubnetworkStep); err != nil {
+			return nil, err
+		}
+	}
+
+	if createNetworkStep, ok := t.wf.Steps[createNetworkStepName]; ok {
+		if err := t.wf.AddDependency(createVMStep, createNetworkStep); err != nil {
+			return nil, err
+		}
+	}
+
+	return &TestVM{name: vmname, testWorkflow: t, instancebeta: i}, nil
+}
+
 // AddMetadata adds the specified key:value pair to metadata during VM creation.
 func (t *TestVM) AddMetadata(key, value string) {
-	if t.instance.Metadata == nil {
-		t.instance.Metadata = make(map[string]string)
+	if t.instance != nil {
+		if t.instance.Metadata == nil {
+			t.instance.Metadata = make(map[string]string)
+		}
+		t.instance.Metadata[key] = value
+	} else if t.instancebeta != nil {
+		if t.instancebeta.Metadata == nil {
+			t.instancebeta.Metadata = make(map[string]string)
+		}
+		t.instancebeta.Metadata[key] = value
 	}
-	t.instance.Metadata[key] = value
 }
 
 // RunTests runs only the named tests on the testVM.
@@ -314,10 +444,18 @@ func (t *TestVM) SetNetworkPerformanceTier(tier string) error {
 	if tier != "DEFAULT" && tier != "TIER_1" {
 		return fmt.Errorf("Error: %v not one of DEFAULT or TIER_1", tier)
 	}
-	if t.instance.NetworkPerformanceConfig == nil {
-		t.instance.NetworkPerformanceConfig = &compute.NetworkPerformanceConfig{TotalEgressBandwidthTier: tier}
-	} else {
-		t.instance.NetworkPerformanceConfig.TotalEgressBandwidthTier = tier
+	if t.instance != nil {
+		if t.instance.NetworkPerformanceConfig == nil {
+			t.instance.NetworkPerformanceConfig = &compute.NetworkPerformanceConfig{TotalEgressBandwidthTier: tier}
+		} else {
+			t.instance.NetworkPerformanceConfig.TotalEgressBandwidthTier = tier
+		}
+	} else if t.instancebeta != nil {
+		if t.instancebeta.NetworkPerformanceConfig == nil {
+			t.instancebeta.NetworkPerformanceConfig = &computeBeta.NetworkPerformanceConfig{TotalEgressBandwidthTier: tier}
+		} else {
+			t.instancebeta.NetworkPerformanceConfig.TotalEgressBandwidthTier = tier
+		}
 	}
 	return nil
 }
@@ -398,48 +536,93 @@ func (t *TestVM) ResizeDiskAndReboot(diskSize int) error {
 // the machine_type flag in the CIT wrapper, and should only be used when a
 // test absolutely requires a specific machine shape.
 func (t *TestVM) ForceMachineType(machinetype string) {
-	t.instance.MachineType = machinetype
+	if t.instance != nil {
+		t.instance.MachineType = machinetype
+	} else if t.instancebeta != nil {
+		t.instancebeta.MachineType = machinetype
+	}
 }
 
 // ForceZone sets the zone for the test vm. This will override the zone option
 // from the CIT wrapper and and should only be used when a test requires a specific
 // zone.
 func (t *TestVM) ForceZone(z string) {
-	t.instance.Zone = z
+	if t.instance != nil {
+		t.instance.Zone = z
+	} else if t.instancebeta != nil {
+		t.instancebeta.Zone = z
+	}
 }
 
 // EnableSecureBoot make the current test VMs in workflow with secure boot.
 func (t *TestVM) EnableSecureBoot() {
-	t.instance.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{
-		EnableSecureBoot: true,
+	if t.instance != nil {
+		if t.instance.ShieldedInstanceConfig == nil {
+			t.instance.ShieldedInstanceConfig = &compute.ShieldedInstanceConfig{}
+		}
+		t.instance.ShieldedInstanceConfig.EnableSecureBoot = true
+	} else if t.instancebeta != nil {
+		if t.instancebeta.ShieldedInstanceConfig == nil {
+			t.instancebeta.ShieldedInstanceConfig = &computeBeta.ShieldedInstanceConfig{}
+		}
+		t.instancebeta.ShieldedInstanceConfig.EnableSecureBoot = true
 	}
 }
 
 // EnableConfidentialInstance enabled CVM features for the instance.
 func (t *TestVM) EnableConfidentialInstance() {
-	t.instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
-		EnableConfidentialCompute: true,
-	}
-	t.instance.Scheduling = &compute.Scheduling{
-		OnHostMaintenance: "TERMINATE",
+	if t.instance != nil {
+		if t.instance.ConfidentialInstanceConfig == nil {
+			t.instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{}
+		}
+		t.instance.ConfidentialInstanceConfig.EnableConfidentialCompute = true
+		if t.instance.Scheduling == nil {
+			t.instance.Scheduling = &compute.Scheduling{}
+		}
+		t.instance.Scheduling.OnHostMaintenance = "TERMINATE"
+	} else if t.instancebeta != nil {
+		if t.instancebeta.ConfidentialInstanceConfig == nil {
+			t.instancebeta.ConfidentialInstanceConfig = &computeBeta.ConfidentialInstanceConfig{}
+		}
+		t.instancebeta.ConfidentialInstanceConfig.EnableConfidentialCompute = true
+		if t.instancebeta.Scheduling == nil {
+			t.instancebeta.Scheduling = &computeBeta.Scheduling{}
+		}
+		t.instancebeta.Scheduling.OnHostMaintenance = "TERMINATE"
 	}
 }
 
 // SetMinCPUPlatform sets the minimum CPU platform of the instance.
 func (t *TestVM) SetMinCPUPlatform(minCPUPlatform string) {
-	t.instance.MinCpuPlatform = minCPUPlatform
+	if t.instance != nil {
+		t.instance.MinCpuPlatform = minCPUPlatform
+	} else if t.instancebeta != nil {
+		t.instancebeta.MinCpuPlatform = minCPUPlatform
+	}
 }
 
 // UseGVNIC sets the type of vNIC to be used to GVNIC
 func (t *TestVM) UseGVNIC() {
-	if t.instance.NetworkInterfaces == nil {
-		t.instance.NetworkInterfaces = []*compute.NetworkInterface{
-			{
-				NicType: "GVNIC",
-			},
+	if t.instance != nil {
+		if t.instance.NetworkInterfaces == nil {
+			t.instance.NetworkInterfaces = []*compute.NetworkInterface{
+				{
+					NicType: "GVNIC",
+				},
+			}
+		} else {
+			t.instance.NetworkInterfaces[0].NicType = "GVNIC"
 		}
-	} else {
-		t.instance.NetworkInterfaces[0].NicType = "GVNIC"
+	} else if t.instancebeta != nil {
+		if t.instancebeta.NetworkInterfaces == nil {
+			t.instancebeta.NetworkInterfaces = []*computeBeta.NetworkInterface{
+				{
+					NicType: "GVNIC",
+				},
+			}
+		} else {
+			t.instancebeta.NetworkInterfaces[0].NicType = "GVNIC"
+		}
 	}
 }
 
@@ -457,20 +640,38 @@ func (t *TestVM) AddCustomNetwork(network *Network, subnetwork *Subnetwork) erro
 		subnetworkName = subnetwork.name
 	}
 
-	// Add network config.
-	networkInterface := compute.NetworkInterface{
-		Network:    network.name,
-		Subnetwork: subnetworkName,
-		AccessConfigs: []*compute.AccessConfig{
-			{
-				Type: "ONE_TO_ONE_NAT",
+	if t.instance != nil {
+		// Add network config.
+		networkInterface := compute.NetworkInterface{
+			Network:    network.name,
+			Subnetwork: subnetworkName,
+			AccessConfigs: []*compute.AccessConfig{
+				{
+					Type: "ONE_TO_ONE_NAT",
+				},
 			},
-		},
-	}
-	if t.instance.NetworkInterfaces == nil {
-		t.instance.NetworkInterfaces = []*compute.NetworkInterface{&networkInterface}
-	} else {
-		t.instance.NetworkInterfaces = append(t.instance.NetworkInterfaces, &networkInterface)
+		}
+		if t.instance.NetworkInterfaces == nil {
+			t.instance.NetworkInterfaces = []*compute.NetworkInterface{&networkInterface}
+		} else {
+			t.instance.NetworkInterfaces = append(t.instance.NetworkInterfaces, &networkInterface)
+		}
+	} else if t.instancebeta != nil {
+		// Add network config.
+		networkInterface := computeBeta.NetworkInterface{
+			Network:    network.name,
+			Subnetwork: subnetworkName,
+			AccessConfigs: []*computeBeta.AccessConfig{
+				{
+					Type: "ONE_TO_ONE_NAT",
+				},
+			},
+		}
+		if t.instancebeta.NetworkInterfaces == nil {
+			t.instancebeta.NetworkInterfaces = []*computeBeta.NetworkInterface{&networkInterface}
+		} else {
+			t.instancebeta.NetworkInterfaces = append(t.instancebeta.NetworkInterfaces, &networkInterface)
+		}
 	}
 
 	return nil
@@ -479,26 +680,47 @@ func (t *TestVM) AddCustomNetwork(network *Network, subnetwork *Subnetwork) erro
 // AddAliasIPRanges add alias ip range to current test VMs.
 func (t *TestVM) AddAliasIPRanges(aliasIPRange, rangeName string) error {
 	// TODO: If we haven't set any NetworkInterface struct, does it make sense to support adding alias IPs?
-	if t.instance.NetworkInterfaces == nil {
-		return fmt.Errorf("must call AddCustomNetwork prior to AddAliasIPRanges")
+	if t.instance != nil {
+		if t.instance.NetworkInterfaces == nil {
+			return fmt.Errorf("must call AddCustomNetwork prior to AddAliasIPRanges")
+		}
+		t.instance.NetworkInterfaces[0].AliasIpRanges = append(t.instance.NetworkInterfaces[0].AliasIpRanges, &compute.AliasIpRange{
+			IpCidrRange:         aliasIPRange,
+			SubnetworkRangeName: rangeName,
+		})
+	} else if t.instancebeta != nil {
+		if t.instancebeta.NetworkInterfaces == nil {
+			return fmt.Errorf("must call AddCustomNetwork prior to AddAliasIPRanges")
+		}
+		t.instancebeta.NetworkInterfaces[0].AliasIpRanges = append(t.instancebeta.NetworkInterfaces[0].AliasIpRanges, &computeBeta.AliasIpRange{
+			IpCidrRange:         aliasIPRange,
+			SubnetworkRangeName: rangeName,
+		})
 	}
-	t.instance.NetworkInterfaces[0].AliasIpRanges = append(t.instance.NetworkInterfaces[0].AliasIpRanges, &compute.AliasIpRange{
-		IpCidrRange:         aliasIPRange,
-		SubnetworkRangeName: rangeName,
-	})
-
 	return nil
 }
 
 // SetPrivateIP set IPv4 internal IP address for target network to the current test VMs.
 func (t *TestVM) SetPrivateIP(network *Network, networkIP string) error {
-	if t.instance.NetworkInterfaces == nil {
-		return fmt.Errorf("must call AddCustomNetwork prior to AddPrivateIP")
-	}
-	for _, nic := range t.instance.NetworkInterfaces {
-		if nic.Network == network.name {
-			nic.NetworkIP = networkIP
-			return nil
+	if t.instance != nil {
+		if t.instance.NetworkInterfaces == nil {
+			return fmt.Errorf("must call AddCustomNetwork prior to AddPrivateIP")
+		}
+		for _, nic := range t.instance.NetworkInterfaces {
+			if nic.Network == network.name {
+				nic.NetworkIP = networkIP
+				return nil
+			}
+		}
+	} else if t.instancebeta != nil {
+		if t.instancebeta.NetworkInterfaces == nil {
+			return fmt.Errorf("must call AddCustomNetwork prior to AddPrivateIP")
+		}
+		for _, nic := range t.instancebeta.NetworkInterfaces {
+			if nic.Network == network.name {
+				nic.NetworkIP = networkIP
+				return nil
+			}
 		}
 	}
 

--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -27,6 +27,21 @@ func TestAddMetadata(t *testing.T) {
 	if val, ok := tvm.instance.Metadata["key"]; !ok || val != "val2" {
 		t.Errorf("invalid metadata set")
 	}
+	tvmb, err := twf.CreateTestVMBeta("vmBeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	tvmb.AddMetadata("key", "val")
+	if tvmb.instancebeta.Metadata == nil {
+		t.Errorf("failed to set VM metadata")
+	}
+	if val, ok := tvmb.instancebeta.Metadata["key"]; !ok || val != "val" {
+		t.Errorf("invalid metadata set")
+	}
+	tvmb.AddMetadata("key", "val2")
+	if val, ok := tvmb.instancebeta.Metadata["key"]; !ok || val != "val2" {
+		t.Errorf("invalid metadata set")
+	}
 }
 
 // TestReboot tests that *TestVM.Reboot succeeds and that the appropriate stop
@@ -55,6 +70,87 @@ func TestReboot(t *testing.T) {
 	}
 	if lastStep.WaitForInstancesSignal == nil {
 		t.Error("not wait step")
+	}
+	if step, ok := twf.wf.Steps["wait-started-vm-1"]; !ok || step != lastStep {
+		t.Error("not wait-started-vm-1 step")
+	}
+}
+
+func TestCreateVMFromInstanceBeta(t *testing.T) {
+	twf := NewTestWorkflowForUnitTest("name", "image", "30m")
+	disks := []*compute.Disk{{Name: "vm"}, {Name: "mountdisk", Type: PdSsd, SizeGb: 100}}
+	inst := &daisy.InstanceBeta{}
+	inst.Name = "vm"
+	tvm, err := twf.CreateTestVMFromInstanceBeta(inst, disks)
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	// once found, expect createInstancesStep.CreateInstances != nil
+	// once found, expect createDisksStep.CreateDisks != nil
+	var createInstancesStep, createDisksStep *daisy.Step
+	for _, step := range twf.wf.Steps {
+		// there should only be one create instance step
+		if step.CreateInstances != nil {
+			if createInstancesStep == nil {
+				createInstancesStep = step
+			} else {
+				t.Errorf("workflow has multiple create instance steps when it should not")
+			}
+		}
+
+		if step.CreateDisks != nil {
+			if createDisksStep == nil {
+				createDisksStep = step
+			} else {
+				t.Errorf("workflow has multiple create disk steps when it should not")
+			}
+		}
+	}
+
+	if createInstancesStep == nil || createInstancesStep.CreateInstances == nil {
+		t.Errorf("failed to find create instances step when creating multiple disks")
+	}
+
+	if createDisksStep == nil || createDisksStep.CreateDisks == nil {
+		t.Errorf("failed to find create disks step when creating multiple disks")
+	}
+
+	daisyStepDisksSlice := *(createDisksStep.CreateDisks)
+	if len(disks) != len(daisyStepDisksSlice) {
+		t.Errorf("found incorrect number of disks in create disk step: expected %d, got %d",
+			len(disks), len(daisyStepDisksSlice))
+	}
+
+	if twf.counter != 0 {
+		t.Errorf("step counter not starting at 0")
+	}
+	if err := tvm.Reboot(); err != nil {
+		t.Errorf("failed to reboot: %v", err)
+	}
+	if twf.counter != 1 {
+		t.Errorf("step counter not incremented")
+	}
+	if _, ok := twf.wf.Steps["stop-vm-1"]; !ok {
+		t.Errorf("wait-vm-1 step missing")
+	}
+	lastStep, err := twf.getLastStepForVM("vm")
+	if err != nil {
+		t.Errorf("failed to get last step for vm: %v", err)
+	}
+	if lastStep.WaitForInstancesSignal == nil {
+		t.Error("not wait step")
+	}
+	waitForInstancesSignalSlice := (*lastStep.WaitForInstancesSignal)
+	if len(waitForInstancesSignalSlice) == 0 {
+		t.Error("waitForInstancesSignal has no elements in slice")
+	}
+	waitGuestAttribute := waitForInstancesSignalSlice[0].GuestAttribute
+	if waitGuestAttribute == nil {
+		t.Error("could not find guest attribute wait step")
+	}
+	gaNameSpace, gaKeyName := waitGuestAttribute.Namespace, waitGuestAttribute.KeyName
+	if gaNameSpace != utils.GuestAttributeTestNamespace || gaKeyName != utils.GuestAttributeTestKey {
+		t.Errorf("wrong guest attribute: got namespace, keyname as %s, %s but expected %s, %s", gaNameSpace, gaKeyName, utils.GuestAttributeTestNamespace, utils.GuestAttributeTestKey)
 	}
 	if step, ok := twf.wf.Steps["wait-started-vm-1"]; !ok || step != lastStep {
 		t.Error("not wait-started-vm-1 step")
@@ -310,6 +406,26 @@ func TestResizeDiskAndReboot(t *testing.T) {
 	if twf.wf.Steps["wait-started-vm-2"] != step {
 		t.Error("not wait-started-vm-2 step")
 	}
+	tvmb, err := twf.CreateTestVM("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if err := tvmb.ResizeDiskAndReboot(200); err != nil {
+		t.Errorf("failed to reboot: %v", err)
+	}
+	if _, ok := twf.wf.Steps["resize-disk-vm-1"]; !ok {
+		t.Errorf("wait-vm-1 step missing")
+	}
+	step, err = twf.getLastStepForVM("vmbeta")
+	if err != nil {
+		t.Errorf("failed to get last step for vm: %v", err)
+	}
+	if step.WaitForInstancesSignal == nil {
+		t.Error("not wait step")
+	}
+	if twf.wf.Steps["wait-started-vmbeta-4"] != step {
+		t.Error("not wait-started-vmbeta-4")
+	}
 }
 
 // TestEnableSecureBoot tests that *TestVM.EnableSecureBoot succeeds and
@@ -320,12 +436,17 @@ func TestEnableSecureBoot(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create test vm: %v", err)
 	}
-	if tvm.instance.ShieldedInstanceConfig != nil {
-		t.Errorf("VM didn't have nil SIC at creation")
-	}
 	tvm.EnableSecureBoot()
-	if tvm.instance.ShieldedInstanceConfig == nil {
-		t.Errorf("VM SIC is nil")
+	if !tvm.instance.ShieldedInstanceConfig.EnableSecureBoot {
+		t.Errorf("test vm does not have secure boot enabled")
+	}
+	tvmb, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	tvmb.EnableSecureBoot()
+	if !tvmb.instancebeta.ShieldedInstanceConfig.EnableSecureBoot {
+		t.Errorf("test vmbeta does not have secure boot enabled")
 	}
 }
 
@@ -404,6 +525,17 @@ func TestUseGVNIC(t *testing.T) {
 	if tvm.instance.NetworkInterfaces[0].NicType != "GVNIC" {
 		t.Errorf("VM Network Interface type not set to GVNIC")
 	}
+	tvmb, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	tvmb.UseGVNIC()
+	if tvmb.instancebeta.NetworkInterfaces == nil {
+		t.Errorf("VM Network Interfaces is nil")
+	}
+	if tvmb.instancebeta.NetworkInterfaces[0].NicType != "GVNIC" {
+		t.Errorf("VM Network Interface type not set to GVNIC")
+	}
 }
 
 // TestAddAliasIPRanges tests that *TestVM.AddAliasIPRanges succeeds and that
@@ -430,6 +562,22 @@ func TestAddAliasIPRanges(t *testing.T) {
 	if tvm.instance.NetworkInterfaces[0].AliasIpRanges == nil {
 		t.Errorf("VM alias IP is nil")
 	}
+	tvmb, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if err := tvmb.AddAliasIPRanges("aliasIPRange", "rangeName"); err == nil {
+		t.Fatalf("shouldn't be able to set alias IP without calling setcustomnetwork")
+	}
+	if err := tvmb.AddCustomNetwork(network, nil); err != nil {
+		t.Errorf("failed to set custom network: %v", err)
+	}
+	if err := tvmb.AddAliasIPRanges("aliasIPRange", "rangeName"); err != nil {
+		t.Fatalf("error adding alias IP range: %v", err)
+	}
+	if tvmb.instancebeta.NetworkInterfaces[0].AliasIpRanges == nil {
+		t.Errorf("VM alias IP is nil")
+	}
 }
 
 // TestSetCustomNetwork tests that *TestVM.AddCustomNetwork succeeds and that
@@ -445,6 +593,17 @@ func TestSetCustomNetwork(t *testing.T) {
 		t.Errorf("failed to create network: %v", err)
 	}
 	if err := tvm.AddCustomNetwork(network, nil); err != nil {
+		t.Errorf("failed to set custom network: %v", err)
+	}
+	tvmb, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	network, err = twf.CreateNetwork("network", true)
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	if err := tvmb.AddCustomNetwork(network, nil); err != nil {
 		t.Errorf("failed to set custom network: %v", err)
 	}
 }
@@ -574,6 +733,25 @@ func TestAddUser(t *testing.T) {
 	if keys, ok := tvm.instance.Metadata["ssh-keys"]; !ok || keys != "username:PUBKEY1\nusername2:PUBKEY2" {
 		t.Errorf("\"ssh-keys\" key malformed after repeated entry")
 	}
+	tvmb, err := twf.CreateTestVMBeta("vmBeta")
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	tvmb.AddUser("username", "PUBKEY1")
+	if tvmb.instancebeta.Metadata == nil {
+		t.Fatalf("instance metadata is nil")
+	}
+	keys, ok = tvmb.instancebeta.Metadata["ssh-keys"]
+	if !ok {
+		t.Fatalf("\"ssh-keys\" key not added to instance")
+	}
+	if keys != "username:PUBKEY1" {
+		t.Fatalf("\"ssh-keys\" key malformed")
+	}
+	tvmb.AddUser("username2", "PUBKEY2")
+	if keys, ok := tvmb.instancebeta.Metadata["ssh-keys"]; !ok || keys != "username:PUBKEY1\nusername2:PUBKEY2" {
+		t.Errorf("\"ssh-keys\" key malformed after repeated entry")
+	}
 }
 
 func TestForceMachineType(t *testing.T) {
@@ -602,6 +780,17 @@ func TestForceZone(t *testing.T) {
 	}
 	tvm.ForceZone("us-east1-a")
 	if tvm.instance.Zone != "us-east1-a" {
+		t.Errorf("could not set test zone, got %q, want us-east1-a", tvm.instance.Zone)
+	}
+	tvmb, err := twf.CreateTestVMBeta("vmbeta")
+	if err != nil {
+		t.Errorf("failed to create test vm: %v", err)
+	}
+	if tvmb.instancebeta.Zone != "" {
+		t.Errorf("machine zone already set: %v", tvmb.instancebeta.Zone)
+	}
+	tvmb.ForceZone("us-east1-a")
+	if tvmb.instancebeta.Zone != "us-east1-a" {
 		t.Errorf("could not set test zone, got %q, want us-east1-a", tvm.instance.Zone)
 	}
 }

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -28,8 +28,8 @@ import (
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	daisycompute "github.com/GoogleCloudPlatform/compute-daisy/compute"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
-	"google.golang.org/api/compute/v1"
 	computeBeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 )
 


### PR DESCRIPTION
The abstraction of setting one of instance or instancebeta is not super elegant but it matches the abstractions present in daisy. There is no unified way to represent a compute instance which is either GA or beta. Generics are not an option because we can't directly reference arbitrary properties on instiated generic types, something we need to do frequently.

Added support for beta instances in existing TestVM methods. Expanded unit tests for TestVM methods to cover instancebeta cases. I modified the behavior in a couple TestVM methods which were clobbering ShieldedInstanceConfig, it's now possible to enable both secure boot and shielded vm in the same instance without them clobbering each other.

Added a function to create a TestVM from a daisy.InstanceBeta and a slice of compute (GA) disks. Added unit tests for this.

No failures from test execution of `docker run cit -images projects/debian-cloud/global/images/family/debian-11,projects/windows-cloud/global/images/family/windows-2019 -filter "(imageboot|cvm|metadata)" [etc...]`

/cc @zmarano @drewhli @koln67 