### PR TITLE
Update packages in cloud-image-tests container and bump golang version to 1.20

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 WORKDIR /build
 COPY . .
@@ -26,6 +26,7 @@ RUN ./local_build.sh -o /out
 
 FROM alpine:latest
 RUN apk add --no-cache openssh-keygen
+RUN apk update && apk upgrade
 COPY --from=builder /out/* /
 
 ENTRYPOINT ["/manager"]

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/guest-test-infra/imagetest
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/compute v1.22.0


### PR DESCRIPTION
It builds and runs:
```
acrate@acrate-p1g4 ~/g/g/imagetest (citimage)> sudo docker run -v ~/.config/gcloud:/creds -e GOOGLE_APPLICATION_CREDENTIALS=/creds/application_default_credentials.json cit -project compute-image-test-pool-001 -zone us-central1-a -images projects/debian-cloud/global/images/family/debian-11-arm64 -filter "imageboot" -timeout 10m
2023/11/02 23:15:26 Running in project compute-image-test-pool-001 zone us-central1-a. Tests will run in projects: [compute-image-test-pool-001]
2023/11/02 23:15:26 using -filter imageboot
2023/11/02 23:15:26 Add test workflow for test imageboot on image projects/debian-cloud/global/images/family/debian-11-arm64
2023/11/02 23:15:27 Done with setup
2023/11/02 23:15:28 Storing artifacts and logs in gs://compute-image-test-pool-001-cloud-test-outputs/2023-11-02T23:15:28Z
2023/11/02 23:15:28 running test imageboot/debian-11-bullseye-arm64-v20231010 (ID tpqhl) in project compute-image-test-pool-001
2023/11/02 23:19:37 finished test imageboot/debian-11-bullseye-arm64-v20231010 (ID tpqhl) in project compute-image-test-pool-001, time spent: 04m 08s
<testsuites name="" errors="0" failures="0" disabled="0" skipped="0" tests="5" time="0">
	<testsuite name="imageboot-debian-11-arm64" tests="5" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="imageboot-debian-11-arm64" name="TestGuestBoot" time="0"></testcase>
		<testcase classname="imageboot-debian-11-arm64" name="TestGuestReboot" time="0"></testcase>
		<testcase classname="imageboot-debian-11-arm64" name="TestGuestRebootOnHost" time="0"></testcase>
		<testcase classname="imageboot-debian-11-arm64" name="TestStartTime" time="0"></testcase>
		<testcase classname="imageboot-debian-11-arm64" name="TestBootTime" time="0"></testcase>
	</testsuite>
</testsuites>
acrate@acrate-p1g4 ~/g/g/imagetest (citimage)>
```

/cc @zmarano @ChaitanyaKulkarni28 