### PR TITLE
Wait for fio to finish installing on linux

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -71,8 +71,11 @@ func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 		readOptions = strings.Replace(readOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
 
-	// in rare cases, fio might not yet be done installing.
-	waitFIOInstalledLinux()
+	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
+		if err = installFioLinux(); err != nil {
+			return []byte{}, fmt.Errorf("linux fio installation failed: err %v", err)
+		}
+	}
 	fioReadOptionsLinuxSlice := strings.Fields(readOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
 	readIOPSJson, err := exec.Command(fioCmdNameLinux, fioReadOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -71,8 +71,10 @@ func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 		readOptions = strings.Replace(readOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
 
+	// in rare cases, fio not yet be done installing.
+	waitFIOInstalledLinux()
 	fioReadOptionsLinuxSlice := strings.Fields(readOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
-	readIOPSJson, err := exec.Command("fio", fioReadOptionsLinuxSlice...).CombinedOutput()
+	readIOPSJson, err := exec.Command(fioCmdNameLinux, fioReadOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {
 		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", readIOPSJson, err)
 	}

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -71,7 +71,7 @@ func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 		readOptions = strings.Replace(readOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
 
-	// in rare cases, fio not yet be done installing.
+	// in rare cases, fio might not yet be done installing.
 	waitFIOInstalledLinux()
 	fioReadOptionsLinuxSlice := strings.Fields(readOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
 	readIOPSJson, err := exec.Command(fioCmdNameLinux, fioReadOptionsLinuxSlice...).CombinedOutput()

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -72,8 +72,11 @@ func RunFIOWriteLinux(t *testing.T, mode string) ([]byte, error) {
 		writeOptions = strings.Replace(writeOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
 
-	// in rare cases, fio might not yet be done installing.
-	waitFIOInstalledLinux()
+	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
+		if err = installFioLinux(); err != nil {
+			return []byte{}, fmt.Errorf("fio installation on linux failed: err %v", err)
+		}
+	}
 	fioWriteOptionsLinuxSlice := strings.Fields(writeOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
 	writeIOPSJson, err := exec.Command(fioCmdNameLinux, fioWriteOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -72,8 +72,10 @@ func RunFIOWriteLinux(t *testing.T, mode string) ([]byte, error) {
 		writeOptions = strings.Replace(writeOptions, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
 
+	// in rare cases, fio might not yet be done installing.
+	waitFIOInstalledLinux()
 	fioWriteOptionsLinuxSlice := strings.Fields(writeOptions + " --filename=" + symlinkRealPath + " --ioengine=libaio")
-	writeIOPSJson, err := exec.Command("fio", fioWriteOptionsLinuxSlice...).CombinedOutput()
+	writeIOPSJson, err := exec.Command(fioCmdNameLinux, fioWriteOptionsLinuxSlice...).CombinedOutput()
 	if err != nil {
 		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", writeIOPSJson, err)
 	}

--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -161,18 +161,13 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		vm.AddMetadata(randWriteAttribute, fmt.Sprintf("%f", vmPerformanceTargets.randWriteIOPS))
 		vm.AddMetadata(seqReadAttribute, fmt.Sprintf("%f", vmPerformanceTargets.seqReadBW))
 		vm.AddMetadata(seqWriteAttribute, fmt.Sprintf("%f", vmPerformanceTargets.seqWriteBW))
+		// for now, only use the startup script on windows because the linux startup script to install fio can take a while, leading to race conditions.
 		if utils.HasFeature(t.Image, "WINDOWS") {
 			windowsStartup, err := scripts.ReadFile(windowsInstallFioScriptURL)
 			if err != nil {
 				return err
 			}
 			vm.AddMetadata("windows-startup-script-ps1", string(windowsStartup))
-		} else {
-			linuxStartup, err := scripts.ReadFile(linuxInstallFioScriptURL)
-			if err != nil {
-				return err
-			}
-			vm.SetStartupScript(string(linuxStartup))
 		}
 		testVMs = append(testVMs, vm)
 	}

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -3,7 +3,6 @@ package storageperf
 import (
 	"fmt"
 	"os/exec"
-	"time"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
@@ -119,16 +118,6 @@ type FIOStatistics struct {
 	IOPS           float64                `json:iops,omitempty"`
 	BandwidthBytes int                    `json:bw_bytes,omitempty"`
 	X              map[string]interface{} `json:"-"`
-}
-
-// In some cases, fio might take longer to install on linux than expected.
-// To ensure tests do not fail from not finding fio, wait for the install.
-func waitFIOInstalledLinux() {
-	fioCompletedInstalling := utils.CheckLinuxCmdExists(fioCmdNameLinux)
-	for !fioCompletedInstalling {
-		time.Sleep(10 * time.Second)
-		fioCompletedInstalling = utils.CheckLinuxCmdExists(fioCmdNameLinux)
-	}
 }
 
 // installFioWindows copies the fio.exe file onto the VM instance.

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -127,6 +127,7 @@ func waitFIOInstalledLinux() {
 	fioCompletedInstalling := utils.CheckLinuxCmdExists(fioCmdNameLinux)
 	for !fioCompletedInstalling {
 		time.Sleep(10 * time.Second)
+		fioCompletedInstalling = utils.CheckLinuxCmdExists(fioCmdNameLinux)
 	}
 }
 


### PR DESCRIPTION
Sometimes, there is a race condition where the linux startup script to install fio does not complete before the test runs.

This causes the fio command to fail because it was not found. To fix this, wait until fio is installed. 