### PR TITLE
Handle CIT in regular presubmit containers

### DIFF
--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -21,14 +21,6 @@ BUILD_DIR=$1
 cd imagetest/
 RET=0
 
-GOARCH=amd64
-GOOS=linux
-CGO_ENABLED=0
-GO111MODULE=on
-go mod download || RET=$?
-
-go vet --structtag=false ./... || RET=$?
-
 # Test the testworkflow package and generate code coverage
 go test -v -coverprofile=/tmp/coverage.out . >${ARTIFACTS}/go-test.txt || RET=$?
 go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt

--- a/container_images/gobuild/main.sh
+++ b/container_images/gobuild/main.sh
@@ -42,6 +42,14 @@ if [[ $RET -ne 0 ]]; then
   echo "'GOOS=windows go build' exited with ${GOBUILD_OUT}"
 fi
 
+echo "Building CIT"
+./imagetest/local_build.sh -o /tmp/cit -i imagetest -s $(ls imagetest/test_suites/ | xargs)
+RET=$?
+if [[ $RET -ne 0 ]]; then
+	GOBUILD_OUT=$RET
+	echo "'./imagetest/local_build.sh -i imagetest -s $(ls imagetest/test_suites/ | xargs)' exited with ${GOBUILD_OUT}"
+fi
+
 sync
 echo Done
 exit $GOBUILD_OUT

--- a/container_images/registry-image-forked/in_test.go
+++ b/container_images/registry-image-forked/in_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package resource_test
 
 import (


### PR DESCRIPTION
This should break up the presubmit work a bit. Now the `gobuild` presubmit builds CIT using `local_build.sh`, and I've also expanded it to build all modules in the repo (currently, breaking `registry-image-forked` builds for example, won't fail presubmit).

`gocheck` similarly cycles through all modules now with go vet. golint ignores module information so no changes necessary to this.
This script was failing repo as is, because `container_images/registry-image-forked/in_test.go` uses unix-specific syscalls but doesn't have the linux build tag. I've included the fix.

`gotest` now cycles through all modules, generating coverage and suite information at for all of them. After testing all modules it averages code coverage across the whole repository and generates the junit report from all test suites.

`citpresubmit` is now an integration presubmit for CIT execution, currently it checks that it's possible to generate a workflow for a windows, linux, and linux arm image. In the future I hope to expand this to catch new test failures.