### PR TITLE
Revamp guest-test-infra presubmit checks

### DIFF
--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -21,16 +21,20 @@ BUILD_DIR=$1
 cd imagetest/
 RET=0
 
-# Test the testworkflow package and generate code coverage
-go test -v -coverprofile=/tmp/coverage.out . >${ARTIFACTS}/go-test.txt || RET=$?
-go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
-cat ${ARTIFACTS}/go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
+if [[ $@ == "test" ]]; then
+	# Test the testworkflow package and generate code coverage
+	go test -v -coverprofile=/tmp/coverage.out . >${ARTIFACTS}/go-test.txt || RET=$?
+	go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
+	cat ${ARTIFACTS}/go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
+fi
 
-# Build all test suites and manager
-mkdir /tmp/cit
-./local_build.sh -o /tmp/cit -s $(ls test_suites | xargs) || RET=$?
+if [[ $@ == "build" ]]; then
+	# Build all test suites and manager
+	mkdir /tmp/cit
+	./local_build.sh -o /tmp/cit -s $(ls test_suites | xargs) || RET=$?
 
-# Test that the manager can generate a workflow for all built suites on a Linux x86 and arm64 image and a windows image.
-/tmp/cit/manager -print -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/windows-cloud/global/images/family/windows-2022 -project gcp-guest > /dev/null || RET=$?
+	# Test that the manager can generate a workflow for all built suites on a Linux x86 and arm64 image and a windows image.
+	/tmp/cit/manager -print -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/windows-cloud/global/images/family/windows-2022 -project gcp-guest > /dev/null || RET=$?
+fi
 
 exit $RET

--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -21,35 +21,16 @@ BUILD_DIR=$1
 cd imagetest/
 RET=0
 
-GOARCH=amd64
-GOOS=linux
-CGO_ENABLED=0
-GO111MODULE=on
-go mod download || RET=$?
-
-go vet --structtag=false ./... || RET=$?
-
-
 # Test the testworkflow package and generate code coverage
 go test -v -coverprofile=/tmp/coverage.out . >${ARTIFACTS}/go-test.txt || RET=$?
 go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
 cat ${ARTIFACTS}/go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
 
-# Build wrapper for all necessary architectures
-go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
-GOARCH=arm64 go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
-GOOS=windows go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
-GOOS=windows GOARCH=386 go build -o /dev/null ./cmd/wrapper/main.go || RET=$?
+# Build all test suites and manager
+mkdir /tmp/cit
+./local_build.sh -o /tmp/cit -s $(ls test_suites | xargs) || RET=$?
 
-# Manager is only built for amd64 linux
-go build -o /dev/null ./cmd/manager/main.go
-
-for suite in test_suites/*; do
-  [[ -d $suite ]] || continue
-  go test -C $suite -c -o /dev/null -tags cit || RET=$?
-  GOARCH=arm64 go test -C $suite -c -o /dev/null -tags cit || RET=$?
-  GOOS=windows go test -C $suite -c -o /dev/null -tags cit || RET=$?
-  GOOS=windows GOARCH=386 go test -C $suite -c -o /dev/null -tags cit || RET=$?
-done
+# Test that the manager can generate a workflow for all built suites on a Linux x86 and arm64 image and a windows image.
+/tmp/cit/manager -print -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/windows-cloud/global/images/family/windows-2022 -project gcp-guest > /dev/null || RET=$?
 
 exit $RET

--- a/container_images/gotest/main.sh
+++ b/container_images/gotest/main.sh
@@ -28,16 +28,16 @@ go get -d -t ./... || exit 1
 echo "Pulling Windows imports..."
 GOOS=windows go get -d -t ./... || exit 1
 
-go test -v -coverprofile=/coverage.out "$@" ./... >/go-test.txt
+go test -v -coverprofile=/tmp/coverage.out "$@" ./... >/tmp/go-test.txt
 RET=$?
 if [[ $RET -ne 0 ]]; then
-  echo "go test -coverprofile=/coverage.out $@ ./... returned ${RET}"
+  echo "go test -coverprofile=/tmp/coverage.out $@ ./... returned ${RET}"
 fi
-cp /go-test.txt ${ARTIFACTS}/
+cp /tmp/go-test.txt ${ARTIFACTS}/
 
 # $ARTIFACTS is provided by prow decoration containers
-go tool cover -func=/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
-cat /go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
+go tool cover -func=/tmp/coverage.out | grep ^total | awk '{print $NF}' | cut -d'.' -f1 > ${ARTIFACTS}/coverage.txt
+cat /tmp/go-test.txt | go-junit-report > ${ARTIFACTS}/junit.xml
 
 # Upload coverage results to Codecov.
 #CODEV_COV_ARGS="-v -t $(cat ${CODECOV_TOKEN}) -B master -C $(git rev-parse HEAD)"

--- a/container_images/registry-image-forked/in_test.go
+++ b/container_images/registry-image-forked/in_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package resource_test
 
 import (


### PR DESCRIPTION
We are missing a lot of gobuild/gocheck/gotest coverage because these containers are scoped to only subdirectories which belong to the same module as the main directory. This change will modify the citpresubmit container to either build CIT or test it based on the argument given to the container. This should be accompanied by the change in guest-test-infra presubmit configuration to check/test/build each module in guest-test-infra separately.

This also includes a fix for registry-image-forked's `gocheck` presubmit, which would otherwise fail because it's accessing linux only APIs in a file that's not scoped for linux builds only.