### PR TITLE
guest-agent-dev: don't add tags to github

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -554,6 +554,7 @@ local build_and_upload_guest_agent = build_guest_agent {
     build_guest_agent{
 	package: 'guest-agent-dev',
 	repo_name: 'guest-agent',
+	extended_tasks: [],
     },
     buildpackagejob {
       package: 'guest-oslogin',


### PR DESCRIPTION
In the guest-agent-dev pipeline we don't want to have tags added to github in a successful build.