### PR TITLE
Block CIT submission on successful workflow generation

### DIFF
--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -32,7 +32,7 @@ if [[ $1 == "build" ]]; then
 
 	# Test that the manager can generate a workflow for all built suites on a Linux x86 and arm64 image and a windows image.
 	# Currently non-blocking and informational only
-	/tmp/cit/manager -print -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/windows-cloud/global/images/family/windows-2022 -project gcp-guest > /dev/null || echo "Workflow generation failed"
+	/tmp/cit/manager -print -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64,projects/windows-cloud/global/images/family/windows-2022 -project gcp-guest > /dev/null || RET=$?
 fi
 
 exit $RET

--- a/container_images/citpresubmit/main.sh
+++ b/container_images/citpresubmit/main.sh
@@ -28,7 +28,7 @@ fi
 if [[ $1 == "build" ]]; then
 	# Build all test suites and manager
 	mkdir -p /tmp/cit
-	./local_build.sh -o /tmp/cit -s "$(ls test_suites | xargs)" || RET=$?
+	./local_build.sh -o /tmp/cit || RET=$?
 
 	# Test that the manager can generate a workflow for all built suites on a Linux x86 and arm64 image and a windows image.
 	# Currently non-blocking and informational only


### PR DESCRIPTION
Seems to be working fine: https://storage.googleapis.com/oss-prow/pr-logs/pull/GoogleCloudPlatform_guest-test-infra/912/infra-presubmit-gobuild-cit/1723067726181699584/build-log.txt