### PR TITLE
Print vm name for failing tests

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -120,11 +120,13 @@ func TestRandomReadIOPS(t *testing.T) {
 	if expectedRandReadIOPS, err = strconv.ParseFloat(expectedRandReadIOPSString, 64); err != nil {
 		t.Fatalf("benchmark iops string %s was not a float: err %v", expectedRandReadIOPSString, err)
 	}
+
+	machineName := getVMName(utils.Context(t))
 	if finalIOPSValue < iopsErrorMargin*expectedRandReadIOPS {
-		t.Fatalf("iops average was too low: expected at least %f of target %s, got %s", iopsErrorMargin, expectedRandReadIOPSString, finalIOPSValueString)
+		t.Fatalf("iops average for vm %s was too low: expected at least %f of target %s, got %s", machineName, iopsErrorMargin, expectedRandReadIOPSString, finalIOPSValueString)
 	}
 
-	t.Logf("iops test pass with %s iops, expected at least %f of target %s", finalIOPSValueString, iopsErrorMargin, expectedRandReadIOPSString)
+	t.Logf("iops test pass for vm %s with %s iops, expected at least %f of target %s", machineName, finalIOPSValueString, iopsErrorMargin, expectedRandReadIOPSString)
 }
 
 // TestSequentialReadIOPS checks that sequential read IOPS are around the value listed in public docs.
@@ -171,9 +173,11 @@ func TestSequentialReadIOPS(t *testing.T) {
 	if expectedSeqReadIOPS, err = strconv.ParseFloat(expectedSeqReadIOPSString, 64); err != nil {
 		t.Fatalf("benchmark iops string %s  was not a float: err %v", expectedSeqReadIOPSString, err)
 	}
+
+	machineName := getVMName(utils.Context(t))
 	if finalBandwidthMBps < iopsErrorMargin*expectedSeqReadIOPS {
-		t.Fatalf("iops average was too low: expected at least %f of target %s, got %s", iopsErrorMargin, expectedSeqReadIOPSString, finalBandwidthMBpsString)
+		t.Fatalf("iops average was too low for vm %s: expected at least %f of target %s, got %s", machineName, iopsErrorMargin, expectedSeqReadIOPSString, finalBandwidthMBpsString)
 	}
 
-	t.Logf("iops test pass with %s iops, expected at least %f of target %s", finalBandwidthMBpsString, iopsErrorMargin, expectedSeqReadIOPSString)
+	t.Logf("iops test pass for vm %s with %s iops, expected at least %f of target %s", machineName, finalBandwidthMBpsString, iopsErrorMargin, expectedSeqReadIOPSString)
 }

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -121,11 +121,13 @@ func TestRandomWriteIOPS(t *testing.T) {
 	if expectedRandWriteIOPS, err = strconv.ParseFloat(expectedRandWriteIOPSString, 64); err != nil {
 		t.Fatalf("benchmark iops string %s was not a float: err %v", expectedRandWriteIOPSString, err)
 	}
+
+	machineName := getVMName(utils.Context(t))
 	if finalIOPSValue < iopsErrorMargin*expectedRandWriteIOPS {
-		t.Fatalf("iops average was too low: expected at least %f of target %s, got %s", iopsErrorMargin, expectedRandWriteIOPSString, finalIOPSValueString)
+		t.Fatalf("iops average for vm %s was too low: expected at least %f of target %s, got %s", machineName, iopsErrorMargin, expectedRandWriteIOPSString, finalIOPSValueString)
 	}
 
-	t.Logf("iops test pass with %s iops, expected at least %f of target %s", finalIOPSValueString, iopsErrorMargin, expectedRandWriteIOPSString)
+	t.Logf("iops test pass for vm %s with %s iops, expected at least %f of target %s", machineName, finalIOPSValueString, iopsErrorMargin, expectedRandWriteIOPSString)
 }
 
 // TestSequentialWriteIOPS checks that sequential write IOPS are around the value listed in public docs.
@@ -170,9 +172,11 @@ func TestSequentialWriteIOPS(t *testing.T) {
 	if expectedSeqWriteIOPS, err = strconv.ParseFloat(expectedSeqWriteIOPSString, 64); err != nil {
 		t.Fatalf("benchmark iops string %s was not a float: err %v", expectedSeqWriteIOPSString, err)
 	}
+
+	machineName := getVMName(utils.Context(t))
 	if finalBandwidthMBps < iopsErrorMargin*expectedSeqWriteIOPS {
-		t.Fatalf("iops average was too low: expected at least %f of target %s, got %s", iopsErrorMargin, expectedSeqWriteIOPSString, finalBandwidthMBpsString)
+		t.Fatalf("iops average for vm %s was too low: expected at least %f of target %s, got %s", machineName, iopsErrorMargin, expectedSeqWriteIOPSString, finalBandwidthMBpsString)
 	}
 
-	t.Logf("iops test pass with %s iops, expected at least %f of target %s", finalBandwidthMBpsString, iopsErrorMargin, expectedSeqWriteIOPSString)
+	t.Logf("iops test pass for vm %s with %s iops, expected at least %f of target %s", machineName, finalBandwidthMBpsString, iopsErrorMargin, expectedSeqWriteIOPSString)
 }

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -1,6 +1,7 @@
 package storageperf
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -154,4 +155,14 @@ func installFioLinux() error {
 		return fmt.Errorf("install fio command failed with errors: %v", err)
 	}
 	return nil
+}
+
+// this function is only for convenience: if a performance test fails,
+// the test vm name can print out the vm machine type for faster analysis.
+func getVMName(ctx context.Context) string {
+	machineName, err := utils.GetMetadata(ctx, "instance", "name")
+	if err != nil {
+		return "unknown"
+	}
+	return machineName
 }


### PR DESCRIPTION
In the error log for test failures, print the machine type. For example, we would know if the failure was pd balanced for n1-standard-64 based on the error message vm name.