### PR TITLE
Use bw json field for ubuntu

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -151,13 +151,13 @@ func TestSequentialReadIOPS(t *testing.T) {
 	// bytes is listed in bytes per second in the fio output
 	var finalBandwidthBytesPerSecond int64 = 0
 	for _, job := range fioOut.Jobs {
-		// this is the bandwidth bytes/sec as a json.Number object
-		bandwidthBytesNumber := job.ReadResult.BandwidthBytes
-		var bandwidthBytesInt int64
-		if bandwidthBytesInt, err = bandwidthBytesNumber.Int64(); err != nil {
-			t.Fatalf("bandwidth bytes per second %s was not a float: err  %v", bandwidthBytesNumber.String(), err)
+		// this is the bandwidth units/sec as a json.Number object
+		bandwidthNumber := job.ReadResult.Bandwidth
+		var bandwidthInt int64
+		if bandwidthInt, err = bandwidthNumber.Int64(); err != nil {
+			t.Fatalf("bandwidth units per second %s was not a float: err  %v", bandwidthNumber.String(), err)
 		}
-		finalBandwidthBytesPerSecond += bandwidthBytesInt
+		finalBandwidthBytesPerSecond += bandwidthInt * fioBWToBytes
 	}
 
 	var finalBandwidthMBps float64 = float64(finalBandwidthBytesPerSecond) / bytesInMB

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -152,12 +152,12 @@ func TestSequentialWriteIOPS(t *testing.T) {
 	var finalBandwidthBytesPerSecond int64 = 0
 	for _, job := range fioOut.Jobs {
 		// this is a json.Number object
-		bandwidthBytesNumber := job.WriteResult.BandwidthBytes
-		var bandwidthBytesInt int64
-		if bandwidthBytesInt, err = bandwidthBytesNumber.Int64(); err != nil {
-			t.Fatalf("bandwidth bytes %s was not an int: err %v", bandwidthBytesNumber.String(), err)
+		bandwidthNumber := job.WriteResult.Bandwidth
+		var bandwidthInt int64
+		if bandwidthInt, err = bandwidthNumber.Int64(); err != nil {
+			t.Fatalf("bandwidth units per sec %s was not an int: err %v", bandwidthNumber.String(), err)
 		}
-		finalBandwidthBytesPerSecond += bandwidthBytesInt
+		finalBandwidthBytesPerSecond += bandwidthInt * fioBWToBytes
 	}
 	var finalBandwidthMBps float64 = float64(finalBandwidthBytesPerSecond) / bytesInMB
 	finalBandwidthMBpsString := fmt.Sprintf("%f", finalBandwidthMBps)

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -26,6 +26,9 @@ const (
 	bytesInMB       = 1048576
 	mountDiskName   = "hyperdisk"
 	fioCmdNameLinux = "fio"
+	// constant from the fio docs to convert bandwidth to bw_bytes:
+	// https://fio.readthedocs.io/en/latest/fio_doc.html#json-output
+	fioBWToBytes = 1024
 	// The fixed gcs location where fio.exe is stored.
 	fioWindowsGCS = "gs://gce-image-build-resources/windows/fio.exe"
 	// The local path on the test VM where fio is stored.
@@ -117,8 +120,8 @@ type FIOJob struct {
 
 // FIOStatistics give information about FIO performance.
 type FIOStatistics struct {
-	// BandwidthBytes should be able to convert to an int64
-	BandwidthBytes json.Number `json:"bw_bytes,omitempty"`
+	// Bandwidth should be able to convert to an int64
+	Bandwidth json.Number `json:"bw,omitempty"`
 	// IOPS should be able to convert to a float64
 	IOPS json.Number            `json:iops,omitempty"`
 	X    map[string]interface{} `json:"-"`


### PR DESCRIPTION
On ubuntu 18, the fio output has a json field for bw, but not bw_bytes. Use bw instead of bw_bytes, with the conversion factor of 1024 as listed in the fio docs, https://fio.readthedocs.io/en/latest/fio_doc.html#json-output