### PR TITLE
Require the UEFI_COMPATIBLE flag for secure boot tests

### DIFF
--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -51,6 +51,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			return nil
 		}
 	}
+	if !utils.HasFeature(t.Image, "UEFI_COMPATIBLE") {
+		return nil
+	}
 	vm4, err := t.CreateTestVM("vm4")
 	if err != nil {
 		return err

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
 
 // Name is the name of the test package. It must match the directory name.


### PR DESCRIPTION
http://localhost:8080/teams/guestos/pipelines/windows-image-build-mbr/jobs/publish-to-testing-windows-server-2012-r2-dc-bios/builds/3