### PR TITLE
Skip tests on zypper install issue

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -72,7 +72,7 @@ func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 	}
 
 	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
-		if err = installFioLinux(); err != nil {
+		if err = installFioLinux(t); err != nil {
 			return []byte{}, fmt.Errorf("linux fio installation failed: err %v", err)
 		}
 	}

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	commonFIORandReadOptions = "--name=read_iops_test --filesize=2500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randread --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
-	commonFIOSeqReadOptions  = "--name=read_bandwidth_test --filesize=2500G --numjobs=1 --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --offset_increment=500G --bs=1M --iodepth=64 --rw=read --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
+	commonFIORandReadOptions = "--name=read_iops_test --filesize=3500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randread --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
+	commonFIOSeqReadOptions  = "--name=read_bandwidth_test --filesize=3500G --numjobs=1 --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --offset_increment=500G --bs=1M --iodepth=64 --rw=read --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 )
 
 func RunFIOReadWindows(mode string) ([]byte, error) {

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -72,7 +72,7 @@ func RunFIOReadLinux(t *testing.T, mode string) ([]byte, error) {
 	}
 
 	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
-		if err = installFioLinux(t); err != nil {
+		if err = installFioLinux(); err != nil {
 			return []byte{}, fmt.Errorf("linux fio installation failed: err %v", err)
 		}
 	}

--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	commonFIORandReadOptions = "--name=read_iops_test --filesize=3500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randread --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
-	commonFIOSeqReadOptions  = "--name=read_bandwidth_test --filesize=3500G --numjobs=1 --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --offset_increment=500G --bs=1M --iodepth=64 --rw=read --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
+	commonFIORandReadOptions = "--name=read_iops_test --filesize=" + mountdiskSizeGBString + "G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randread --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
+	commonFIOSeqReadOptions  = "--name=read_bandwidth_test --filesize=" + mountdiskSizeGBString + "G --numjobs=1 --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --offset_increment=500G --bs=1M --iodepth=64 --rw=read --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 )
 
 func RunFIOReadWindows(mode string) ([]byte, error) {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	commonFIORandWriteOptions = "--name=write_iops_test --filesize=3500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randwrite --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
-	commonFIOSeqWriteOptions  = "--name=write_bandwidth_test --filesize=3500G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --rw=write --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
+	commonFIORandWriteOptions = "--name=write_iops_test --filesize=" + mountdiskSizeGBString + "G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randwrite --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
+	commonFIOSeqWriteOptions  = "--name=write_bandwidth_test --filesize=" + mountdiskSizeGBString + "G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --rw=write --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 )
 
 func RunFIOWriteWindows(mode string) ([]byte, error) {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -73,7 +73,7 @@ func RunFIOWriteLinux(t *testing.T, mode string) ([]byte, error) {
 	}
 
 	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
-		if err = installFioLinux(t); err != nil {
+		if err = installFioLinux(); err != nil {
 			return []byte{}, fmt.Errorf("fio installation on linux failed: err %v", err)
 		}
 	}

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	commonFIORandWriteOptions = "--name=write_iops_test --filesize=2500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randwrite --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
-	commonFIOSeqWriteOptions  = "--name=write_bandwidth_test --filesize=2500G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --rw=write --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
+	commonFIORandWriteOptions = "--name=write_iops_test --filesize=3500G --numjobs=1 --time_based --runtime=1m --ramp_time=2s --direct=1 --verify=0 --bs=4K --iodepth=256 --randrepeat=0 --rw=randwrite --iodepth_batch_submit=256  --iodepth_batch_complete_max=256 --output-format=json"
+	commonFIOSeqWriteOptions  = "--name=write_bandwidth_test --filesize=3500G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --rw=write --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 )
 
 func RunFIOWriteWindows(mode string) ([]byte, error) {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -73,7 +73,7 @@ func RunFIOWriteLinux(t *testing.T, mode string) ([]byte, error) {
 	}
 
 	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
-		if err = installFioLinux(); err != nil {
+		if err = installFioLinux(t); err != nil {
 			return []byte{}, fmt.Errorf("fio installation on linux failed: err %v", err)
 		}
 	}

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -161,7 +161,7 @@ func installFioLinux() error {
 	}
 
 	if err := installFioCmd.Wait(); err != nil {
-		// Transient backend issues with zypper can cause exit errors 7, 104, 106, etc. Skip the test on the current execution shell.
+		// Transient backend issues with zypper can cause exit errors 7, 104, 106, etc. Return a more detailed error message in these cases.
 		if usingZypper {
 			return checkZypperTransientError(err)
 		}

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -21,11 +21,13 @@ const (
 	vmName = "vm"
 	// iopsErrorMargin allows for a small difference between iops found in the test and the iops value listed in public documentation.
 	iopsErrorMargin = 0.85
-	mountdiskSizeGB = 3500
-	bootdiskSizeGB  = 50
-	bytesInMB       = 1048576
-	mountDiskName   = "hyperdisk"
-	fioCmdNameLinux = "fio"
+	// fio should use the full disk size as the filesize when benchmarking
+	mountdiskSizeGBString = "3500"
+	mountdiskSizeGB       = 3500
+	bootdiskSizeGB        = 50
+	bytesInMB             = 1048576
+	mountDiskName         = "hyperdisk"
+	fioCmdNameLinux       = "fio"
 	// constant from the fio docs to convert bandwidth to bw_bytes:
 	// https://fio.readthedocs.io/en/latest/fio_doc.html#json-output
 	fioBWToBytes = 1024


### PR DESCRIPTION
Most commonly, sometimes on startup the sles instances might have a zypper process running, leading to an exit code 7 when running "zypper install." Other errors such as 104 (repository not available) or 106 (zypper refreshing repositories failed) sometimes happen as well, indicating a temporary backend error.

This is not actionable by PD or teams working on disk performance and should not fail the test, so skipping the specific test case run is the proposed solution. I'm open to other suggestions for zypper backend errors. 

Also, use the full size of the mounted disk for benchmarking
https://cloud.google.com/compute/docs/disks/benchmarking-pd-performance#raw-disk