### PR TITLE
Increase machine size for network test

### DIFF
--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -63,7 +63,9 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	// VM2 for multiNIC
 	networkRebootInst := &daisy.Instance{}
 	networkRebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name}}, networkRebootInst)
+	// this vm could run out of memory and lead to race conditions on n1-standard-1, the default shape. Instead, allocate more cpus and memory.
+	networkRebootInst.MachineType = "n1-standard-8"
+	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name, SizeGb: 30}}, networkRebootInst)
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -64,8 +64,8 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	networkRebootInst := &daisy.Instance{}
 	networkRebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
 	// this vm could run out of memory and lead to race conditions on n1-standard-1, the default shape. Instead, allocate more cpus and memory.
-	networkRebootInst.MachineType = "n1-standard-16"
-	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name, SizeGb: 60}}, networkRebootInst)
+	networkRebootInst.MachineType = "n1-standard-32"
+	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name, SizeGb: 120}}, networkRebootInst)
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -64,8 +64,8 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	networkRebootInst := &daisy.Instance{}
 	networkRebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
 	// this vm could run out of memory and lead to race conditions on n1-standard-1, the default shape. Instead, allocate more cpus and memory.
-	networkRebootInst.MachineType = "n1-standard-8"
-	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name, SizeGb: 30}}, networkRebootInst)
+	networkRebootInst.MachineType = "n1-standard-16"
+	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name, SizeGb: 60}}, networkRebootInst)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For EL7 network tests, some race conditions relating to networkmanager on el7 can lead to the machine exhausting cpus or memory on a n1-standard-1. 

Use n1-standard-32 instead for the instance which needs to reboot.