### PR TITLE
Reduce Parallel Thread Count for Network Performance Tests for SUSE Images.

### DIFF
--- a/imagetest/test_suites/networkperf/gvnic_test.go
+++ b/imagetest/test_suites/networkperf/gvnic_test.go
@@ -26,7 +26,7 @@ func CheckGVNICPresent(interfaceName string) error {
 	}
 	s := strings.Split(data, "/")
 	driver := s[len(s)-1]
-	if driver != "gvnic" && driver != "gve" {
+	if driver != "gvnic" || driver != "gve" {
 		errMsg := fmt.Sprintf("Driver set as %v want gvnic or gve", driver)
 		return errors.New(errMsg)
 	}

--- a/imagetest/test_suites/networkperf/gvnic_test.go
+++ b/imagetest/test_suites/networkperf/gvnic_test.go
@@ -26,7 +26,7 @@ func CheckGVNICPresent(interfaceName string) error {
 	}
 	s := strings.Split(data, "/")
 	driver := s[len(s)-1]
-	if driver != "gvnic" || driver != "gve" {
+	if driver != "gvnic" && driver != "gve" {
 		errMsg := fmt.Sprintf("Driver set as %v want gvnic or gve", driver)
 		return errors.New(errMsg)
 	}

--- a/imagetest/test_suites/networkperf/startupscripts/netclient_startup.sh
+++ b/imagetest/test_suites/networkperf/startupscripts/netclient_startup.sh
@@ -47,6 +47,9 @@ elif [[ -f /usr/bin/zypper ]]; then
   echo "$(date +"%Y-%m-%d %T"): zypper found Installing iperf."
   sudo zypper --no-gpg-checks refresh
   sudo zypper --no-gpg-checks --non-interactive install https://iperf.fr/download/opensuse/iperf-2.0.5-14.1.2.x86_64.rpm netcat
+
+  # TODO: Figure out what's causing parallel connections to fail when a high
+  # parallel connection count is set.
   parallelthreads=4
 fi
 

--- a/imagetest/test_suites/networkperf/startupscripts/netclient_startup.sh
+++ b/imagetest/test_suites/networkperf/startupscripts/netclient_startup.sh
@@ -8,6 +8,7 @@ iperftarget=$(curl http://metadata.google.internal/computeMetadata/v1/instance/a
 sleepduration=5
 maxtimeout=60
 timeout=0
+parallelthreads=12
 
 echo "MTU: "
 /sbin/ifconfig | grep mtu
@@ -46,6 +47,7 @@ elif [[ -f /usr/bin/zypper ]]; then
   echo "$(date +"%Y-%m-%d %T"): zypper found Installing iperf."
   sudo zypper --no-gpg-checks refresh
   sudo zypper --no-gpg-checks --non-interactive install https://iperf.fr/download/opensuse/iperf-2.0.5-14.1.2.x86_64.rpm netcat
+  parallelthreads=4
 fi
 
 # Ensure the server is up and running.
@@ -63,12 +65,12 @@ sleep "$sleepduration"
 
 # Run iperf
 echo "$(date +"%Y-%m-%d %T"): Running iperf client with target $iperftarget"
-iperf -t 30 -c "$iperftarget" -P 12 | grep SUM | tr -s ' ' | tee -a "$outfile"
+iperf -t 30 -c "$iperftarget" -P $parallelthreads | grep SUM | tr -s ' ' | tee -a "$outfile"
 
 echo "$(date +"%Y-%m-%d %T"): Test Results $results"
 echo "$(date +"%Y-%m-%d %T"): Sending results to metadata."
 results=$(cat "./$outfile")
 for i in $(seq 0 2); do
-	sleep $i
-	curl -X PUT --data "$results" http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/testing/results -H "Metadata-Flavor: Google" && break
+sleep $i
+curl -X PUT --data "$results" http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/testing/results -H "Metadata-Flavor: Google" && break
 done

--- a/imagetest/test_suites/networkperf/startupscripts/netserver_startup.sh
+++ b/imagetest/test_suites/networkperf/startupscripts/netserver_startup.sh
@@ -3,6 +3,7 @@
 # This script installs iperf on a VM and starts an iperf server for the client
 # to test the network bandwidth between the two VMs.
 timeout=60
+parallelcount=12
 
 if [[ -f /usr/bin/apt ]]; then
   echo "apt found Installing iperf."
@@ -42,8 +43,9 @@ elif [[ -f /usr/bin/zypper ]]; then
   echo "zypper found Installing iperf."
   sudo zypper --no-gpg-checks refresh
   sudo zypper --no-gpg-checks --non-interactive install https://iperf.fr/download/opensuse/iperf-2.0.5-14.1.2.x86_64.rpm
+  parallelcount=4
 fi
 
 echo "Starting iperf server"
 iperf -s -P 1
-iperf -s -t $timeout -P 12
+iperf -s -t $timeout -P $parallelcount

--- a/imagetest/test_suites/networkperf/startupscripts/netserver_startup.sh
+++ b/imagetest/test_suites/networkperf/startupscripts/netserver_startup.sh
@@ -43,6 +43,9 @@ elif [[ -f /usr/bin/zypper ]]; then
   echo "zypper found Installing iperf."
   sudo zypper --no-gpg-checks refresh
   sudo zypper --no-gpg-checks --non-interactive install https://iperf.fr/download/opensuse/iperf-2.0.5-14.1.2.x86_64.rpm
+
+  # TODO: Figure out what's causing parallel connections to fail when a high
+  # parallel connection count is set.
   parallelcount=4
 fi
 


### PR DESCRIPTION
When the number of parallel threads is high, the images seem to reject them for some reason. This is a patchwork fix so the tests don't constantly time out.