### PR TITLE
Move CGO_ENABLED declaration from Dockerfile to local_build.sh

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -18,7 +18,6 @@ WORKDIR /build
 COPY . .
 RUN mkdir /out
 
-ENV CGO_ENABLED 0
 ENV GOOS linux
 ENV GO111MODULE on
 

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -17,6 +17,7 @@ while getopts "o:s:i:" arg; do
 done 
 
 
+CGO_ENABLED=0
 echo "outspath is $outpath"
 echo "suites being built are $suites"
 echo "imagetestroot is $imagetestroot"


### PR DESCRIPTION
This is required to avoid some issues with glibc versioning on certain OS. This won't affect building via the dockerfile, but it will fix some edge case failures when building without the dockerfile.
/cc @zmarano @jjerger @koln67 @drewhli 