### PR TITLE
Search dmesg output in go for CVM tests and deduplicate test code

### DIFF
--- a/imagetest/test_suites/cvm/cvm_test.go
+++ b/imagetest/test_suites/cvm/cvm_test.go
@@ -10,41 +10,27 @@ var sevMsgList = []string{"AMD Secure Encrypted Virtualization (SEV) active", "A
 var sevSnpMsgList = []string{"SEV: SNP guest platform device intitialized", "Memory Encryption Features active: AMD SEV SEV-ES SEV-SNP"}
 var tdxMsgList = []string{"Memory Encryption Features active: TDX", "Memory Encryption Features active: Intel TDX"}
 
-func TestSEVEnabled(t *testing.T) {
-	output, err := exec.Command("/bin/sh", "-c", "sudo dmesg | grep SEV").Output()
+func searchDmesg(t *testing.T, matches []string) {
+	output, err := exec.Command("dmesg").CombinedOutput()
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	for _, msg := range sevMsgList {
-		if strings.Contains(string(output), msg) {
+	for _, m := range sevMsgList {
+		if strings.Contains(string(output), m) {
 			return
 		}
 	}
-	t.Fatal("Error: SEV not active or found")
+	t.Fatal("Module not active or found")
+}
+
+func TestSEVEnabled(t *testing.T) {
+	searchDmesg(t, sevMsgList)
 }
 
 func TestSEVSNPEnabled(t *testing.T) {
-	output, err := exec.Command("/bin/sh", "-c", "sudo dmesg | grep SNP").Output()
-	if err != nil {
-		t.Fatalf("Error: %v", err)
-	}
-	for _, msg := range sevSnpMsgList {
-		if strings.Contains(string(output), msg) {
-			return
-		}
-	}
-	t.Fatal("Error: SEV not active or found")
+	searchDmesg(t, sevSnpMsgList)
 }
 
 func TestTDXEnabled(t *testing.T) {
-	output, err := exec.Command("/bin/sh", "-c", "sudo dmesg | grep TDX").Output()
-	if err != nil {
-		t.Fatalf("Error: %v", err)
-	}
-	for _, msg := range tdxMsgList {
-		if strings.Contains(string(output), msg) {
-			return
-		}
-	}
-	t.Fatal("Error: TDX not active or found")
+	searchDmesg(t, tdxMsgList)
 }

--- a/imagetest/test_suites/cvm/cvm_test.go
+++ b/imagetest/test_suites/cvm/cvm_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var sevMsgList = []string{"AMD Secure Encrypted Virtualization (SEV) active", "AMD Memory Encryption Features active: SEV", "Memory Encryption Features active: AMD SEV"}
-var sevSnpMsgList = []string{"SEV: SNP guest platform device intitialized", "Memory Encryption Features active: AMD SEV SEV-ES SEV-SNP"}
+var sevSnpMsgList = []string{"SEV: SNP guest platform device initialized", "Memory Encryption Features active: SEV SEV-ES SEV-SNP", "Memory Encryption Features active: AMD SEV SEV-ES SEV-SNP"}
 var tdxMsgList = []string{"Memory Encryption Features active: TDX", "Memory Encryption Features active: Intel TDX"}
 
 func searchDmesg(t *testing.T, matches []string) {
@@ -15,7 +15,7 @@ func searchDmesg(t *testing.T, matches []string) {
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	for _, m := range sevMsgList {
+	for _, m := range matches {
 		if strings.Contains(string(output), m) {
 			return
 		}


### PR DESCRIPTION
Spawning a shell to grep through output before parsing strings again in go is causing some false negatives when there is an error from grep unrelated to presence of the module's message (this happens on ubunutu-2004-lts).
/cc @zmarano @koln67 @drewhli @jjerger 