### PR TITLE
package build: downgrade golang to 1.21.3

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -37,7 +37,7 @@ function install_go() {
     arch="arm64"
   fi
 
-  local GOLANG="go1.21.4.linux-${arch}.tar.gz"
+  local GOLANG="go1.21.3.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
We found an issue[1] in golang's path/filepath stdlib impacting the build of at least osconfig (potentially others). The bug was fixed and will potentially be available in 1.31.5, we'll get it update whenever it's released.

[1] - https://github.com/golang/go/issues/64028