### PR TITLE
Call cleanerupper after running a CIT suite to clean up any resources left behind by Daisy.

### DIFF
--- a/container_images/cleanerupper/go-cleanerupper/cleanerupper.go
+++ b/container_images/cleanerupper/go-cleanerupper/cleanerupper.go
@@ -189,7 +189,7 @@ func WorkflowPolicy(id string) PolicyFunc {
 		if _, keep := labels[keepLabel]; keep {
 			return false
 		}
-		return strings.HasSuffix(name, id) && strings.Contains(desc, "created by Daisy in workflow") && !strings.Contains(desc, keepLabel)
+		return strings.HasSuffix(name, id) && strings.Contains(desc, `created by Daisy in workflow "`+id+`"`) && !strings.Contains(desc, keepLabel)
 	}
 }
 

--- a/container_images/cleanerupper/go-cleanerupper/cleanerupper_test.go
+++ b/container_images/cleanerupper/go-cleanerupper/cleanerupper_test.go
@@ -230,6 +230,12 @@ func TestWorkflowPolicy(t *testing.T) {
 			resource: &compute.Instance{Name: "network-asdf", Description: "created by Daisy in workflow \"asdf\" on behalf of root. do-not-delete"},
 			output:   false,
 		},
+		{
+			name:     "Different workflow in description",
+			wfID:     "asdf",
+			resource: &compute.Instance{Name: "network-asdf", Description: "created by Daisy in workflow \"1234\" on behalf of root."},
+			output:   false,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -21,6 +21,8 @@ require (
 	cloud.google.com/go/iam v1.1.5 // indirect
 	cloud.google.com/go/logging v1.8.1 // indirect
 	cloud.google.com/go/longrunning v0.5.4 // indirect
+	cloud.google.com/go/osconfig v1.12.4 // indirect
+	github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper v0.0.0-20231129203917-db71af465791 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -36,10 +38,12 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
+
+replace github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper => ../container_images/cleanerupper/go-cleanerupper

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -24,6 +24,8 @@ cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA5
 cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
 cloud.google.com/go/longrunning v0.5.4 h1:w8xEcbZodnA2BbW6sVirkkoC+1gP8wS57EUUgGS0GVg=
 cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+xFSzOL++V0dI=
+cloud.google.com/go/osconfig v1.12.4 h1:OrRCIYEAbrbXdhm13/JINn9pQchvTTIzgmOCA7uJw8I=
+cloud.google.com/go/osconfig v1.12.4/go.mod h1:B1qEwJ/jzqSRslvdOCI8Kdnp0gSng0xW4LOnIebQomA=
 cloud.google.com/go/oslogin v1.10.1 h1:LdSuG3xBYu2Sgr3jTUULL1XCl5QBx6xwzGqzoDUw1j0=
 cloud.google.com/go/oslogin v1.10.1/go.mod h1:x692z7yAue5nE7CsSnoG0aaMbNoRJRXO4sn73R+ZqAs=
 cloud.google.com/go/oslogin v1.12.2 h1:NP/KgsD9+0r9hmHC5wKye0vJXVwdciv219DtYKYjgqE=
@@ -227,6 +229,8 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
+google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -28,9 +28,9 @@ import (
 	"cloud.google.com/go/storage"
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	daisycompute "github.com/GoogleCloudPlatform/compute-daisy/compute"
+	"github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 	computeBeta "google.golang.org/api/compute/v0.beta"
-	"github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 )

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -30,6 +30,7 @@ import (
 	daisycompute "github.com/GoogleCloudPlatform/compute-daisy/compute"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 	computeBeta "google.golang.org/api/compute/v0.beta"
+	"github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/iterator"
 )
@@ -788,9 +789,21 @@ func runTestWorkflow(ctx context.Context, test *TestWorkflow) testResult {
 		res.err = err
 		return res
 	}
-
 	delta := formatTimeDelta("04m 05s", time.Now().Sub(start))
 	log.Printf("finished test %s/%s (ID %s) in project %s, time spent: %s\n", test.Name, test.Image.Name, test.wf.ID(), test.wf.Project, delta)
+
+	log.Printf("cleaning up after test %s/%s (ID %s) in project %s\n", test.Name, test.Image.Name, test.wf.ID(), test.wf.Project)
+	cleaned, errs := cleanTestWorkflow(test)
+	for _, err := range errs {
+		log.Printf("error cleaning test %s/%s: %v\n", test.Name, test.Image.Name, err)
+	}
+	if len(cleaned) > 0 {
+		log.Printf("test %s/%s had %d leftover resources\n", test.Name, test.Image.Name, len(cleaned))
+	}
+	for _, c := range cleaned {
+		log.Printf("deleted resource %s from test %s/%s", c, test.Name, test.Image.Name)
+	}
+
 	results, err := getTestResults(ctx, test)
 	if err != nil {
 		res.err = err
@@ -800,6 +813,23 @@ func runTestWorkflow(ctx context.Context, test *TestWorkflow) testResult {
 	res.workflowSuccess = true
 
 	return res
+}
+
+func cleanTestWorkflow(test *TestWorkflow) (totalCleaned []string, totalErrs []error) {
+	c := cleanerupper.Clients{Daisy: test.Client}
+	policy := cleanerupper.WorkflowPolicy(test.wf.ID())
+
+	cleaned, errs := cleanerupper.CleanInstances(c, test.wf.Project, policy, false)
+	totalCleaned = append(totalCleaned, cleaned...)
+	totalErrs = append(totalErrs, errs...)
+	cleaned, errs = cleanerupper.CleanDisks(c, test.wf.Project, policy, false)
+	totalCleaned = append(totalCleaned, cleaned...)
+	totalErrs = append(totalErrs, errs...)
+	cleaned, errs = cleanerupper.CleanNetworks(c, test.wf.Project, policy, false)
+	totalCleaned = append(totalCleaned, cleaned...)
+	totalErrs = append(totalErrs, errs...)
+
+	return
 }
 
 // gets result struct and converts to a jUnit TestSuite

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -17,8 +17,8 @@ package imagetest
 import (
 	"fmt"
 	"net/http"
-	"testing"
 	"sort"
+	"testing"
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	daisycompute "github.com/GoogleCloudPlatform/compute-daisy/compute"
@@ -131,7 +131,7 @@ func TestCleanTestWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	twf.Client = daisyFake
-	expect := []string{"projects/test-project/global/firewalls/test-firewall", "projects/test-project/global/networks/test-network-"+twf.wf.ID(), "projects/test-project/regions/test-region/subnetworks/test-subnetwork", "projects/test-project/zones/test-zone/disks/test-disk-"+twf.wf.ID(), "projects/test-project/zones/test-zone/instances/test-instance-"+twf.wf.ID()}
+	expect := []string{"projects/test-project/global/firewalls/test-firewall", "projects/test-project/global/networks/test-network-" + twf.wf.ID(), "projects/test-project/regions/test-region/subnetworks/test-subnetwork", "projects/test-project/zones/test-zone/disks/test-disk-" + twf.wf.ID(), "projects/test-project/zones/test-zone/instances/test-instance-" + twf.wf.ID()}
 	cleaned, errs := cleanTestWorkflow(twf)
 	for _, err := range errs {
 		t.Errorf("got error from cleanTestWorkflow: %v", err)


### PR DESCRIPTION
Change WorkflowPolicy to match the workflow ID in both name and description.

The two resources we are having problems with are instances and networks so this is limited to that (plus disks to clean up disks left behind by the instances)

/cc @zmarano @jjerger @koln67 @drewhli 