### PR TITLE
Switch order of read and write tests

### DIFF
--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -172,7 +172,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		testVMs = append(testVMs, vm)
 	}
 	for _, vm := range testVMs {
-		vm.RunTests("TestRandomReadIOPS|TestSequentialReadIOPS|TestRandomWriteIOPS|TestSequentialWriteIOPS")
+		vm.RunTests("TestRandomWriteIOPS|TestSequentialWriteIOPS|TestRandomReadIOPS|TestSequentialReadIOPS")
 	}
 	return nil
 }


### PR DESCRIPTION
On the test grid, sometimes the c3-standard-88 hyperdisk extreme test has unusual behavior. Sometimes (but not all the time), the IOPS are high enough for random read to pass, but the IOPS are a little bit lower for random write, just enough to fail the test.

This change is testing the hypothesis that the Random Read test is changing the state in a way which slows down the future Random Write test, by running random write first instead of random read. If this is confirmed, a follow up change would be made to split the Read and Write tests into two VMs. 