### PR TITLE
Fix various issues with dockerfile builds

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -133,7 +133,7 @@ local BuildContainerImage(image) = buildcontainerimgjob {
     // These build from the root of the repo.
     BuildContainerImage('cloud-image-tests') {
       context: 'guest-test-infra',
-      dockerfile: 'imagtest/Dockerfile',
+      dockerfile: 'imagetest/Dockerfile',
       // Public image.
       repo: 'gcr.io/compute-image-tools',
     },

--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -132,7 +132,8 @@ local BuildContainerImage(image) = buildcontainerimgjob {
 
     // These build from the root of the repo.
     BuildContainerImage('cloud-image-tests') {
-      context: 'guest-test-infra/imagetest',
+      context: 'guest-test-infra',
+      dockerfile: 'imagtest/Dockerfile',
       // Public image.
       repo: 'gcr.io/compute-image-tools',
     },

--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /out
 ENV GOOS linux
 ENV GO111MODULE on
 
-RUN ./local_build.sh -o /out
+RUN ./imagetest/local_build.sh -o /out -i imagetest
 
 FROM alpine:latest
 RUN apk add --no-cache openssh-keygen

--- a/imagetest/README.md
+++ b/imagetest/README.md
@@ -135,9 +135,9 @@ Tests that need to run against features in the beta API can do so by creating Te
 
 ## Building the container image ##
 
-From the `imagetest` directory of this repository:
+From the root directory of this repository:
 
-    $ docker build -t cloud-image-tests -f Dockerfile .
+    $ docker build -t cloud-image-tests -f imagetest/Dockerfile .
 
 ## Testing on a local machine ##
 

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -17,7 +17,7 @@ while getopts "o:s:i:" arg; do
 done 
 
 
-CGO_ENABLED=0
+export CGO_ENABLED=0
 echo "outspath is $outpath"
 echo "suites being built are $suites"
 echo "imagetestroot is $imagetestroot"


### PR DESCRIPTION
1) CGO_ENABLED should be exported to be picked up by child processes
2) The dockerfile should be built relative to the root directory to allowed the imagetest go.mod to find cleanerupper nested in the directory above it
3) Correct the concourse pipeline [failing](http://localhost:8080/teams/guestos/pipelines/container-build/jobs/build-cloud-image-tests/builds/472) because of issue 2 to build with the new method.

`local_build.sh` is unaffected by these changes.

/cc @zmarano @jjerger @koln67 @drewhli 