### PR TITLE
package build: use private image for concourse metrics

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -12,8 +12,11 @@ local publishresulttask = {
   config: {
     platform: 'linux',
     image_resource: {
-      type: 'registry-image',
-      source: { repository: 'gcr.io/gcp-guest/concourse-metrics' },
+      type: 'registry-image-private',
+      source: {
+        repository: 'gcr.io/gcp-guest/concourse-metrics',
+        google_auth: true,
+      },
     },
     run: {
       path: '/publish-job-result',


### PR DESCRIPTION
The images are not public any more, we should use the private resource type and use google auth.