### PR TITLE
render-templates: use registry-image-forked

### DIFF
--- a/concourse/tasks/render-templates.yaml
+++ b/concourse/tasks/render-templates.yaml
@@ -1,7 +1,7 @@
 platform: linux
 
 image_resource:
-  type: registry-image-private
+  type: registry-image-forked
   source:
     repository: gcr.io/gcp-guest/jsonnet-go
     tag: latest


### PR DESCRIPTION
Instead of using registry-images-private alias use the original name.