### PR TITLE
pipeline-set: use registry-image-private

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+- name: guest-image-private
+  type: registry-image
+  source:
+    repository: gcr.io/compute-image-tools/registry-image-forked
+
 resources:
 - name: guest-test-infra
   type: git

--- a/concourse/tasks/render-templates.yaml
+++ b/concourse/tasks/render-templates.yaml
@@ -1,7 +1,7 @@
 platform: linux
 
 image_resource:
-  type: registry-image
+  type: registry-image-private
   source:
     repository: gcr.io/gcp-guest/jsonnet-go
     tag: latest


### PR DESCRIPTION
Add the registry-image-private resource type as a resource and use it instead of registry-image.