### PR TITLE
package build: don't use google_auth for resource type

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1013,7 +1013,7 @@ local build_and_upload_guest_agent = build_guest_agent {
     {
       name: 'registry-image-private',
       type: 'registry-image',
-      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked', google_auth: true },
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
     },
   ],
   resources: [


### PR DESCRIPTION
The resource type registry-image-forked doesn't need google_auth.