### PR TITLE
Bump CIT go version from 1.20 to 1.21

### DIFF
--- a/imagetest/Dockerfile
+++ b/imagetest/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20-alpine as builder
+FROM golang:1.21-alpine as builder
 
 WORKDIR /build
 COPY . .

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/guest-test-infra/imagetest
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/compute v1.23.3


### PR DESCRIPTION
`slices` is go 1.21 only, but we should keep up to date anyway
/cc @zmarano @jjerger @koln67 @drewhli 

http://localhost:8080/teams/guestos/pipelines/container-build/jobs/build-cloud-image-tests/builds/483