### PR TITLE
Sleep for a longer interval when getting results

### DIFF
--- a/imagetest/test_suites/networkperf/performance_test.go
+++ b/imagetest/test_suites/networkperf/performance_test.go
@@ -17,7 +17,7 @@ func TestNetworkPerformance(t *testing.T) {
 	var results string
 	var err error
 	for i := 0; i < 3; i++ {
-		time.Sleep(time.Duration(i) * time.Second)
+		time.Sleep(30 * time.Duration(i) * time.Second)
 		results, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "results")
 		if err == nil {
 			break


### PR DESCRIPTION
Occasionally, the 404 error where networkperf doesn't get the result still happens on windows. 

If the first attempt resulted in a 404, sleep for a longer duration so that future GET requests are more likely to happen after results are already placed.