### PR TITLE
Add try catch to ps1 networkperf startup scripts

### DIFF
--- a/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
@@ -15,12 +15,16 @@ cd $exepath
 Start-Sleep -s 5 # Wait for the server to start up.
 
 # Perform the test, and upload results.
-./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile
-for (($i = 0); $i -lt 3; $i++)
-{
-  Start-Sleep -Seconds $i
-  (Get-Content -Path $outfile | Select-String -Pattern 'SUM') -replace "\s+"," " | Invoke-RestMethod -Method "Put" -Uri $metadata -Header @{"Metadata-Flavor" = "Google"} -ContentType "application/json; charset=utf-8" -UseBasicParsing
-  if ($?) {
-    break
+try {
+  ./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile
+  for (($i = 0); $i -lt 3; $i++)
+  {
+    Start-Sleep -Seconds $i
+    (Get-Content -Path $outfile | Select-String -Pattern 'SUM') -replace "\s+"," " | Invoke-RestMethod -Method "Put" -Uri $metadata -Header @{"Metadata-Flavor" = "Google"} -ContentType "application/json; charset=utf-8" -UseBasicParsing
+    if ($?) {
+      break
+    }
   }
+} catch {
+  throw $_
 }

--- a/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_clientstartup.ps1
@@ -15,16 +15,14 @@ cd $exepath
 Start-Sleep -s 5 # Wait for the server to start up.
 
 # Perform the test, and upload results.
-try {
-  ./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile
-  for (($i = 0); $i -lt 3; $i++)
-  {
-    Start-Sleep -Seconds $i
-    (Get-Content -Path $outfile | Select-String -Pattern 'SUM') -replace "\s+"," " | Invoke-RestMethod -Method "Put" -Uri $metadata -Header @{"Metadata-Flavor" = "Google"} -ContentType "application/json; charset=utf-8" -UseBasicParsing
-    if ($?) {
-      break
-    }
+./iperf -c $iperftarget -t 30 -P 16 2>&1 > $outfile
+# print iperf output to the logs
+Write-Host $_ 
+for (($i = 0); $i -lt 3; $i++)
+{
+  Start-Sleep -Seconds $i
+  (Get-Content -Path $outfile | Select-String -Pattern 'SUM') -replace "\s+"," " | Invoke-RestMethod -Method "Put" -Uri $metadata -Header @{"Metadata-Flavor" = "Google"} -ContentType "application/json; charset=utf-8" -UseBasicParsing
+  if ($?) {
+    break
   }
-} catch {
-  throw $_
 }

--- a/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
@@ -10,8 +10,6 @@ Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
 New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
 
 cd $exepath
-try {
-  ./iperf -s -P 16 -t $timeout
-} catch {
-  throw $_
-}
+./iperf -s -P 16 -t $timeout
+# print iperf output to logs
+Write-Host $_

--- a/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
+++ b/imagetest/test_suites/networkperf/startupscripts/windows_serverstartup.ps1
@@ -10,4 +10,8 @@ Expand-Archive -Path $iperfzippath -DestinationPath $zipdir
 New-NetFirewallRule -DisplayName "allow-iperf" -Direction Inbound -LocalPort 5001 -Protocol TCP -Action Allow
 
 cd $exepath
-./iperf -s -P 16 -t $timeout
+try {
+  ./iperf -s -P 16 -t $timeout
+} catch {
+  throw $_
+}


### PR DESCRIPTION
The daisy logs on windows for the networkperf test suite always logs that the windows startup script completes successfully. In a few of these runs, there is a 404 error when trying to get test results.

Adding a try catch will add an error message to the logs when the 404 error occurs, so we know which command did not run successfully.

In the future, @drewhli will add more detailed debugging for iperf failing to complete successfully.