### PR TITLE
Define registry-image-private in a template and import it across pipelines that need it

### DIFF
--- a/concourse/pipelines/artifact-releaser-test.jsonnet
+++ b/concourse/pipelines/artifact-releaser-test.jsonnet
@@ -512,6 +512,7 @@ local pkggroup = {
       type: 'docker-image',
       source: { repository: 'cftoolsmiths/cron-resource' },
     },
+    common.RegistryImagePrivate,
   ],
   resources: [
                common.GitResource('guest-test-infra'),

--- a/concourse/pipelines/partner-image-validations.jsonnet
+++ b/concourse/pipelines/partner-image-validations.jsonnet
@@ -1,3 +1,4 @@
+local common = import '../templates/common.libsonnet';
 local imagetesttask = {
   local task = self,
 
@@ -312,11 +313,7 @@ local slesarm64images = [
 // Start of output.
 {
   resource_types: [
-    {
-      name: 'registry-image-private',
-      type: 'registry-image',
-      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
-    },
+    common.RegistryImagePrivate,
     {
       name: 'gce-image',
       type: 'registry-image-private',

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -121,4 +121,9 @@
         ],
     },
   },
+  RegistryImagePrivate:: {
+    name: 'registry-image-private',
+    type: 'registry-image',
+    source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
+  },
 }


### PR DESCRIPTION
Notably, the ARLE test pipeline is currently failing because it's not defined there.