### PR TITLE
Add a fallback command to retry reinstalling guest agent during startup/shutdown script testing

### DIFF
--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -105,21 +105,29 @@ func TestShutdownScripts(t *testing.T) {
 			t.Fatal(err)
 		}
 	} else {
-		var cmd *exec.Cmd
+		var cmd,fallback *exec.Cmd
 		switch {
 		case utils.CheckLinuxCmdExists("apt"):
 			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("dnf"):
 			cmd = exec.Command("dnf", "-y", "reinstall", "google-guest-agent")
+			fallback = exec.Command("dnf", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("yum"):
 			cmd = exec.Command("yum", "-y", "reinstall", "google-guest-agent")
+			fallback = exec.Command("yum", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("zypper"):
-			cmd = exec.Command("zypper", "--non-interactive", "--force", "install", "google-guest-agent")
+			cmd = exec.Command("zypper", "--non-interactive", "install", "--force", "google-guest-agent")
 		default:
 			t.Fatal("could not find a package manager to reinstall guest-agent with")
 		}
 		if err := cmd.Run(); err != nil {
-			t.Fatalf("could not reinstall guest agent: %s", err)
+			if fallback != nil {
+				if err := fallback.Run(); err != nil {
+					t.Fatalf("could not reinstall guest agent with fallback: %s", err)
+				}
+			} else {
+				t.Fatalf("could not reinstall guest agent: %s", err)
+			}
 		}
 	}
 	result, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -105,7 +105,7 @@ func TestShutdownScripts(t *testing.T) {
 			t.Fatal(err)
 		}
 	} else {
-		var cmd,fallback *exec.Cmd
+		var cmd, fallback *exec.Cmd
 		switch {
 		case utils.CheckLinuxCmdExists("apt"):
 			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -103,7 +103,7 @@ func TestStartupScripts(t *testing.T) {
 			t.Fatalf("could not reinstall guest-agent: %s", err)
 		}
 	} else {
-		var cmd,fallback *exec.Cmd
+		var cmd, fallback *exec.Cmd
 		switch {
 		case utils.CheckLinuxCmdExists("apt"):
 			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -109,10 +109,10 @@ func TestStartupScripts(t *testing.T) {
 			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("dnf"):
 			cmd = exec.Command("dnf", "-y", "reinstall", "google-guest-agent")
-			cmd = exec.Command("dnf", "-y", "upgrade", "google-guest-agent")
+			fallback = exec.Command("dnf", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("yum"):
 			cmd = exec.Command("yum", "-y", "reinstall", "google-guest-agent")
-			cmd = exec.Command("yum", "-y", "upgrade", "google-guest-agent")
+			fallback = exec.Command("yum", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("zypper"):
 			cmd = exec.Command("zypper", "--non-interactive", "install", "--force", "google-guest-agent")
 		default:

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -103,21 +103,29 @@ func TestStartupScripts(t *testing.T) {
 			t.Fatalf("could not reinstall guest-agent: %s", err)
 		}
 	} else {
-		var cmd *exec.Cmd
+		var cmd,fallback *exec.Cmd
 		switch {
 		case utils.CheckLinuxCmdExists("apt"):
 			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("dnf"):
 			cmd = exec.Command("dnf", "-y", "reinstall", "google-guest-agent")
+			cmd = exec.Command("dnf", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("yum"):
 			cmd = exec.Command("yum", "-y", "reinstall", "google-guest-agent")
+			cmd = exec.Command("yum", "-y", "upgrade", "google-guest-agent")
 		case utils.CheckLinuxCmdExists("zypper"):
-			cmd = exec.Command("zypper", "--non-interactive", "--force", "install", "google-guest-agent")
+			cmd = exec.Command("zypper", "--non-interactive", "install", "--force", "google-guest-agent")
 		default:
 			t.Fatal("could not find a package manager to reinstall guest-agent with")
 		}
 		if err := cmd.Run(); err != nil {
-			t.Fatalf("could not reinstall guest agent: %s", err)
+			if fallback != nil {
+				if err := fallback.Run(); err != nil {
+					t.Fatalf("could not reinstall guest agent with fallback: %s", err)
+				}
+			} else {
+				t.Fatalf("could not reinstall guest agent: %s", err)
+			}
 		}
 	}
 	result, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")


### PR DESCRIPTION
dnf and yum don't have a command that forces a reinstall or an upgrade
Also swapped the argument order for zypper, newer version require the --force flag after the install command
/cc @koln67 @drewhli 