### PR TITLE
Allow override compute client endpoint

### DIFF
--- a/imagetest/cmd/manager/main.go
+++ b/imagetest/cmd/manager/main.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"google.golang.org/api/option"
 	"github.com/GoogleCloudPlatform/compute-daisy/compute"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/cvm"
@@ -32,27 +31,28 @@ import (
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/ssh"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/storageperf"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/test_suites/windowscontainers"
+	"google.golang.org/api/option"
 )
 
 var (
-	project         = flag.String("project", "", "project to use for test runner")
-	testProjects    = flag.String("test_projects", "", "comma separated list of projects to be used for tests. defaults to the test runner project")
-	zone            = flag.String("zone", "us-central1-a", "zone to be used for tests")
-	printwf         = flag.Bool("print", false, "print out the parsed test workflows and exit")
-	validate        = flag.Bool("validate", false, "validate all the test workflows and exit")
-	outPath         = flag.String("out_path", "junit.xml", "junit xml path")
-	gcsPath         = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
-	localPath       = flag.String("local_path", "", "path where test output files are stored, can be modified for local testing")
-	images          = flag.String("images", "", "comma separated list of images to test")
-	timeout         = flag.String("timeout", "45m", "timeout for the test suite")
+	project                 = flag.String("project", "", "project to use for test runner")
+	testProjects            = flag.String("test_projects", "", "comma separated list of projects to be used for tests. defaults to the test runner project")
+	zone                    = flag.String("zone", "us-central1-a", "zone to be used for tests")
+	printwf                 = flag.Bool("print", false, "print out the parsed test workflows and exit")
+	validate                = flag.Bool("validate", false, "validate all the test workflows and exit")
+	outPath                 = flag.String("out_path", "junit.xml", "junit xml path")
+	gcsPath                 = flag.String("gcs_path", "", "GCS Path for Daisy working directory")
+	localPath               = flag.String("local_path", "", "path where test output files are stored, can be modified for local testing")
+	images                  = flag.String("images", "", "comma separated list of images to test")
+	timeout                 = flag.String("timeout", "45m", "timeout for the test suite")
 	computeEndpointOverride = flag.String("compute_endpoint_override", "", "compute client endpoint override")
-	parallelCount   = flag.Int("parallel_count", 5, "TestParallelCount")
-	parallelStagger = flag.String("parallel_stagger", "60s", "parseable time.Duration to stagger each parallel test")
-	filter          = flag.String("filter", "", "only run tests matching filter")
-	exclude         = flag.String("exclude", "", "skip tests matching filter")
-	machineType     = flag.String("machine_type", "", "deprecated, use -x86_shape and/or -arm64_shape instead")
-	x86Shape        = flag.String("x86_shape", "n1-standard-1", "default x86(-32 and -64) vm shape for tests not requiring a specific shape")
-	arm64Shape      = flag.String("arm64_shape", "t2a-standard-1", "default arm64 vm shape for tests not requiring a specific shape")
+	parallelCount           = flag.Int("parallel_count", 5, "TestParallelCount")
+	parallelStagger         = flag.String("parallel_stagger", "60s", "parseable time.Duration to stagger each parallel test")
+	filter                  = flag.String("filter", "", "only run tests matching filter")
+	exclude                 = flag.String("exclude", "", "skip tests matching filter")
+	machineType             = flag.String("machine_type", "", "deprecated, use -x86_shape and/or -arm64_shape instead")
+	x86Shape                = flag.String("x86_shape", "n1-standard-1", "default x86(-32 and -64) vm shape for tests not requiring a specific shape")
+	arm64Shape              = flag.String("arm64_shape", "t2a-standard-1", "default arm64 vm shape for tests not requiring a specific shape")
 )
 
 var (

--- a/imagetest/local_build.sh
+++ b/imagetest/local_build.sh
@@ -25,10 +25,10 @@ echo "imagetestroot is $imagetestroot"
 cd $imagetestroot
 go mod download
 go build -o $outpath/wrapper.amd64 ./cmd/wrapper/main.go
-GOARCH=arm64 go build -o $outpath/wrapper.arm64 ./cmd/wrapper/main.go
-GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe ./cmd/wrapper/main.go
-GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe ./cmd/wrapper/main.go
-go build -o $outpath/manager ./cmd/manager/main.go
+GOARCH=arm64 go build -o $outpath/wrapper.arm64 ./cmd/wrapper/main.go || exit 1
+GOOS=windows GOARCH=amd64 go build -o $outpath/wrapp64.exe ./cmd/wrapper/main.go || exit 1
+GOOS=windows GOARCH=386 go build -o $outpath/wrapp32.exe ./cmd/wrapper/main.go || exit 1
+go build -o $outpath/manager ./cmd/manager/main.go || exit 1
 
 
 cd test_suites

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -572,7 +572,7 @@ func getTestResults(ctx context.Context, ts *TestWorkflow) ([]string, error) {
 }
 
 // NewTestWorkflow returns a new TestWorkflow.
-func NewTestWorkflow(client daisycompute.Client, name, image, timeout, project, zone, x86Shape string, arm64Shape string) (*TestWorkflow, error) {
+func NewTestWorkflow(client daisycompute.Client, computeEndpointOverride, name, image, timeout, project, zone, x86Shape string, arm64Shape string) (*TestWorkflow, error) {
 	t := &TestWorkflow{}
 	t.counter = 0
 	t.Name = name
@@ -607,6 +607,9 @@ func NewTestWorkflow(client daisycompute.Client, name, image, timeout, project, 
 	}
 
 	t.wf = daisy.New()
+	if computeEndpointOverride != "" {
+		t.wf.ComputeEndpoint = computeEndpointOverride
+	}
 	t.wf.Name = strings.ReplaceAll(name, "_", "-")
 	t.wf.DefaultTimeout = timeout
 	t.wf.Zone = zone

--- a/imagetest/testworkflow_test.go
+++ b/imagetest/testworkflow_test.go
@@ -529,7 +529,7 @@ func TestNewTestWorkflow(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer srv.Close()
-			twf, err := NewTestWorkflow(client, tc.name, tc.image, tc.timeout, tc.project, tc.zone, tc.x86Shape, tc.arm64Shape)
+			twf, err := NewTestWorkflow(client, "", tc.name, tc.image, tc.timeout, tc.project, tc.zone, tc.x86Shape, tc.arm64Shape)
 			if err != nil {
 				t.Fatalf("failed to create test workflow: %v", err)
 			}


### PR DESCRIPTION
Necessary to run CIT in staging. I also noticed the `local_build.sh` doesn't exit with a non-zero code when I broke the wrapper or the manager, so I fixed that.

/cc @koln67 @jjerger 