### PR TITLE
Disable centos-7-predictable-nic-builds

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -411,7 +411,7 @@ local imggroup = {
 {
   local almalinux_images = ['almalinux-8', 'almalinux-9'],
   local debian_images = ['debian-10', 'debian-11', 'debian-11-arm64', 'debian-12', 'debian-12-arm64'],
-  local centos_images = ['centos-7', 'centos-7-predictable-nic', 'centos-stream-8', 'centos-stream-9'],
+  local centos_images = ['centos-7', 'centos-stream-8', 'centos-stream-9'],
   local rhel_sap_images = [
     'rhel-7-9-sap',
     'rhel-8-2-sap',


### PR DESCRIPTION
We don't need new images to continue testing the existing ones. The evidence looks pretty conclusive in favor of this being the culprit already.

/hold