### PR TITLE
Revert "package_test: we haven't published a rocky 8 for arm with google-cloud-cli (#1006)"

### DIFF
--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -119,12 +119,6 @@ func TestGuestPackages(t *testing.T) {
 	requiredPkgs = append(requiredPkgs, "google-compute-engine", "gce-disk-expand", "google-cloud-cli")
 	requiredPkgs = append(requiredPkgs, "google-compute-engine-oslogin")
 
-	// We haven't published a rocky-linux-8-optimized for arm with google-cloud-cli, so check google-cloud-sdk instead.
-	if strings.Contains(image, "rocky-linux-8-optimized-gcp-arm64") {
-		requiredPkgs = removeFromArray(requiredPkgs, "google-cloud-cli")
-		requiredPkgs = append(requiredPkgs, "google-cloud-sdk")
-	}
-
 	if strings.Contains(image, "sles") || strings.Contains(image, "suse") {
 		requiredPkgs = removeFromArray(requiredPkgs, "google-cloud-cli")
 		requiredPkgs = removeFromArray(requiredPkgs, "google-compute-engine")


### PR DESCRIPTION
Agent is released now and it breaks staging
This reverts commit f146c18299b6744443ba93432476e2c361939b50.
/hold