### PR TITLE
Skip running alias ip tests on windows, skip creating the multinic vm at all when there's nothing to test

### DIFF
--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -59,38 +59,48 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err := vm1.SetPrivateIP(network2, vm1Config.ip); err != nil {
 		return err
 	}
-
-	// VM2 for multiNIC
-	networkRebootInst := &daisy.Instance{}
-	networkRebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name}}, networkRebootInst)
-	if err != nil {
-		return err
-	}
-	vm2.AddMetadata("enable-guest-attributes", "TRUE")
-	if err := vm2.AddCustomNetwork(network1, subnetwork1); err != nil {
-		return err
-	}
-	if err := vm2.AddCustomNetwork(network2, subnetwork2); err != nil {
-		return err
-	}
-	if err := vm2.SetPrivateIP(network2, vm2Config.ip); err != nil {
-		return err
-	}
-	if err := vm2.AddAliasIPRanges("10.14.8.0/24", "secondary-range"); err != nil {
-		return err
-	}
-	if err := vm2.Reboot(); err != nil {
-		return err
-	}
-
 	vm1.RunTests("TestPingVMToVM|TestDHCP|TestDefaultMTU")
 
-	multinictests := "TestAlias"
-	if utils.HasFeature(t.Image, "GVNIC") {
-		vm2.UseGVNIC()
-		multinictests += "|TestGVNIC"
+	var multinictests string
+	if !utils.HasFeature(t.Image, "WINDOWS") {
+		multinictests += "TestAlias"
 	}
-	vm2.RunTests(multinictests)
+	if utils.HasFeature(t.Image, "GVNIC") {
+		if multinictests != "" {
+			multinictests += "|"
+		}
+		multinictests += "TestGVNIC"
+	}
+
+	if multinictests != "" {
+		// VM2 for multiNIC
+		networkRebootInst := &daisy.Instance{}
+		networkRebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
+		vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vm2Config.name}}, networkRebootInst)
+		if err != nil {
+			return err
+		}
+		vm2.AddMetadata("enable-guest-attributes", "TRUE")
+		if err := vm2.AddCustomNetwork(network1, subnetwork1); err != nil {
+			return err
+		}
+		if err := vm2.AddCustomNetwork(network2, subnetwork2); err != nil {
+			return err
+		}
+		if err := vm2.SetPrivateIP(network2, vm2Config.ip); err != nil {
+			return err
+		}
+		if err := vm2.AddAliasIPRanges("10.14.8.0/24", "secondary-range"); err != nil {
+			return err
+		}
+		if err := vm2.Reboot(); err != nil {
+			return err
+		}
+		if utils.HasFeature(t.Image, "GVNIC") {
+			vm2.UseGVNIC()
+		}
+
+		vm2.RunTests(multinictests)
+	}
 	return nil
 }


### PR DESCRIPTION
Guest agent doesn't support alias IP ranges on windows.
/cc @elicriffield @drewhli 