### PR TITLE
Auto delete mounted disks

### DIFF
--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -105,7 +105,9 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
 
 	for _, disk := range disks {
-		instance.Disks = append(instance.Disks, &compute.AttachedDisk{Source: disk.Name})
+		currentDisk := &compute.AttachedDisk{Source: disk.Name}
+		currentDisk.AutoDelete = true
+		instance.Disks = append(instance.Disks, currentDisk)
 	}
 
 	if instance.Metadata == nil {


### PR DESCRIPTION
When doing local testing, if the instance is deleted after ctrl + z and has a mount disk, the mount disk is not deleted by default.

This helps clean up resources when doing manual runs.