### PR TITLE
Remove google-cloud-sdk as a substitute for google-cloud-cli

### DIFF
--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -137,8 +137,8 @@ func TestGuestPackages(t *testing.T) {
 			imagesSkip: []string{"sles", "suse", "ubuntu"},
 		},
 		{
-			name:         "google-cloud-cli",
-			imagesSkip:   []string{"sles", "suse"},
+			name:       "google-cloud-cli",
+			imagesSkip: []string{"sles", "suse"},
 		},
 		{
 			name:       "google-compute-engine-oslogin",

--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -138,7 +138,6 @@ func TestGuestPackages(t *testing.T) {
 		},
 		{
 			name:         "google-cloud-cli",
-			alternatives: []string{"google-cloud-sdk"},
 			imagesSkip:   []string{"sles", "suse"},
 		},
 		{


### PR DESCRIPTION
Everything in both staging and prod should have google-cloud-cli at this point
/cc @dorileo @drewhli 