### PR TITLE
Add a prep command for guest agent reinstallation

### DIFF
--- a/imagetest/test_suites/metadata/metadata_utils.go
+++ b/imagetest/test_suites/metadata/metadata_utils.go
@@ -1,0 +1,60 @@
+package metadata
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
+)
+
+func reinstallPackage(pkg string) error {
+	if utils.IsWindows() {
+		cmd := exec.Command("googet", "install", "-reinstall", pkg)
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		time.Sleep(time.Second)
+		// Respond to "Reinstall pkg? (y/N):" prompt
+		io.WriteString(stdin, "y\r\n")
+		return cmd.Wait()
+	}
+	var cmd, fallback, prep *exec.Cmd
+	switch {
+	case utils.CheckLinuxCmdExists("apt"):
+		prep = exec.Command("apt", "update", "-y")
+		cmd = exec.Command("apt", "reinstall", "-y", pkg)
+		fallback = exec.Command("apt", "install", "-y", "--reinstall", pkg)
+	case utils.CheckLinuxCmdExists("dnf"):
+		cmd = exec.Command("dnf", "-y", "reinstall", pkg)
+		fallback = exec.Command("dnf", "-y", "upgrade", pkg)
+	case utils.CheckLinuxCmdExists("yum"):
+		cmd = exec.Command("yum", "-y", "reinstall", pkg)
+		fallback = exec.Command("yum", "-y", "upgrade", pkg)
+	case utils.CheckLinuxCmdExists("zypper"):
+		cmd = exec.Command("zypper", "--non-interactive", "install", "--force", pkg)
+		fallback = exec.Command("zypper", "--non-interactive", "install", "--force", pkg)
+	default:
+		return fmt.Errorf("could not find a package manager to reinstall %s with", pkg)
+	}
+	if prep != nil {
+		if err := prep.Run(); err != nil {
+			return fmt.Errorf("could not prep to reinstall %s: %v", pkg, err)
+		}
+	}
+	if err := cmd.Run(); err != nil {
+		if fallback != nil {
+			if err := fallback.Run(); err != nil {
+				return fmt.Errorf("could not reinstall %s with fallback: %s", pkg, err)
+			}
+		} else {
+			return fmt.Errorf("could not reinstall %s: %s", pkg, err)
+		}
+	}
+	return nil
+}

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -5,13 +5,10 @@ package metadata
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
-	"os/exec"
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
@@ -89,48 +86,8 @@ func TestShutdownScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to clear shutdown script result: %s", err)
 	}
-	if utils.IsWindows() {
-		cmd := exec.Command("googet", "install", "-reinstall", "google-compute-engine-windows")
-		stdin, err := cmd.StdinPipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-		time.Sleep(time.Second)
-		// Respond to "Reinstall google-compute-engine-windows? (y/N):" prompt
-		io.WriteString(stdin, "y\r\n")
-		if err := cmd.Wait(); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		var cmd, fallback *exec.Cmd
-		switch {
-		case utils.CheckLinuxCmdExists("apt"):
-			cmd = exec.Command("apt", "reinstall", "-y", "google-guest-agent")
-			fallback = exec.Command("apt", "install", "-y", "--reinstall", "google-guest-agent")
-		case utils.CheckLinuxCmdExists("dnf"):
-			cmd = exec.Command("dnf", "-y", "reinstall", "google-guest-agent")
-			fallback = exec.Command("dnf", "-y", "upgrade", "google-guest-agent")
-		case utils.CheckLinuxCmdExists("yum"):
-			cmd = exec.Command("yum", "-y", "reinstall", "google-guest-agent")
-			fallback = exec.Command("yum", "-y", "upgrade", "google-guest-agent")
-		case utils.CheckLinuxCmdExists("zypper"):
-			cmd = exec.Command("zypper", "--non-interactive", "install", "--force", "google-guest-agent")
-			fallback = exec.Command("zypper", "--non-interactive", "install", "--force", "google-guest-agent")
-		default:
-			t.Fatal("could not find a package manager to reinstall guest-agent with")
-		}
-		if err := cmd.Run(); err != nil {
-			if fallback != nil {
-				if err := fallback.Run(); err != nil {
-					t.Fatalf("could not reinstall guest agent with fallback: %s", err)
-				}
-			} else {
-				t.Fatalf("could not reinstall guest agent: %s", err)
-			}
-		}
+	if err := reinstallPackage("google-guest-agent"); err != nil {
+		t.Fatal(err)
 	}
 	result, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
 	if err != nil {


### PR DESCRIPTION
Necessary to avoid attempting to reinstall a pkg removed from repos on distros with apt.

This was getting to be a lot of duplicated logic so I abstracted the logic into a general case. I considered putting this until test_utils but no other test suite needs this AFAIK so I left it in metadata.