### PR TITLE
Add LSSD support and cases to storageperf

### DIFF
--- a/imagetest/test_suites/storageperf/iops_read_test.go
+++ b/imagetest/test_suites/storageperf/iops_read_test.go
@@ -19,7 +19,7 @@ func TestRandomReadIOPS(t *testing.T) {
 	var randReadIOPSJson []byte
 	var err error
 	if runtime.GOOS == "windows" {
-		if randReadIOPSJson, err = runFIOWindows(randRead); err != nil {
+		if randReadIOPSJson, err = runFIOWindows(t, randRead); err != nil {
 			t.Fatalf("windows fio rand read failed with error: %v. If testing locally, check the guidance at storageperf/startupscripts/install_fio.ps1", err)
 		}
 	} else {
@@ -64,7 +64,7 @@ func TestSequentialReadIOPS(t *testing.T) {
 	var seqReadIOPSJson []byte
 	var err error
 	if runtime.GOOS == "windows" {
-		if seqReadIOPSJson, err = runFIOWindows(seqRead); err != nil {
+		if seqReadIOPSJson, err = runFIOWindows(t, seqRead); err != nil {
 			t.Fatalf("windows fio seq read failed with error: %v", err)
 		}
 	} else {

--- a/imagetest/test_suites/storageperf/iops_write_test.go
+++ b/imagetest/test_suites/storageperf/iops_write_test.go
@@ -19,7 +19,7 @@ func TestRandomWriteIOPS(t *testing.T) {
 	var randWriteIOPSJson []byte
 	var err error
 	if runtime.GOOS == "windows" {
-		if randWriteIOPSJson, err = runFIOWindows(randWrite); err != nil {
+		if randWriteIOPSJson, err = runFIOWindows(t, randWrite); err != nil {
 			t.Fatalf("windows fio rand write failed with error: %v. If testing locally, check the guidance at storageperf/startupscripts/install_fio.ps1", err)
 		}
 	} else {
@@ -65,7 +65,7 @@ func TestSequentialWriteIOPS(t *testing.T) {
 	var seqWriteIOPSJson []byte
 	var err error
 	if runtime.GOOS == "windows" {
-		if seqWriteIOPSJson, err = runFIOWindows(seqWrite); err != nil {
+		if seqWriteIOPSJson, err = runFIOWindows(t, seqWrite); err != nil {
 			t.Fatalf("windows fio seq write failed with error: %v", err)
 		}
 	} else {

--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -61,10 +61,10 @@ var storagePerfTestConfig = []storagePerfTest{
 		requiredFeatures: []string{"GVNIC"},
 	},
 	{
-		arch: "X86_64",
-		machineType: "c3-standard-88-lssd",
-		diskType: "lssd",
-		cpuMetric: "C3_CPUS",
+		arch:             "X86_64",
+		machineType:      "c3-standard-88-lssd",
+		diskType:         "lssd",
+		cpuMetric:        "C3_CPUS",
 		requiredFeatures: []string{"GVNIC"},
 	},
 	{
@@ -121,7 +121,6 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		if len(region) > 2 {
 			region = region[:len(region)-2]
 		}
-
 
 		mountdiskSizeGB := getRequiredDiskSize(tc.machineType, tc.diskType)
 		// disk sizes must be different for disk identification

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -57,9 +58,26 @@ const (
 	commonFIOSeqOptions     = "--name=write_bandwidth_test --filesize=500G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 	hyperdiskFIORandOptions = "--numjobs=8 --size=500G --time_based --runtime=5m --ramp_time=10s --direct=1 --verify=0 --bs=4K --iodepth=256 --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 --group_reporting --output-format=json"
 	hyperdiskFIOSeqOptions  = "--numjobs=8 --size=500G --time_based --runtime=5m --ramp_time=10s --direct=1 --verify=0 --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --offset_increment=20G --group_reporting --output-format=json"
+	lssdFIORandOptions = "--name=write_iops_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=4K --iodepth=256 --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 --group_reporting --output-format=json"
+	lssdFIOSeqOptions  = "--name=write_bandwidth_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --offset_increment=20G --group_reporting --output-format=json"
 )
 
 // map the machine type to performance targets
+var lssdIOPSMap = map[string]PerformanceTargets{
+	"c3-standard-88-lssd": {
+		randReadIOPS:  1600000.0,
+		randWriteIOPS: 800000.0,
+		seqReadBW:     6240.0,
+		seqWriteBW:    3120.0,
+	},
+	"c3d-standard-180": {
+		randReadIOPS:  1600000.0,
+		randWriteIOPS: 800000.0,
+		seqReadBW:     6240.0,
+		seqWriteBW:    3120.0,
+	},
+}
+
 var hyperdiskExtremeIOPSMap = map[string]PerformanceTargets{
 	"c3-standard-88": {
 		randReadIOPS:  350000.0,
@@ -127,6 +145,7 @@ var pdbalanceIOPSMap = map[string]PerformanceTargets{
 var iopsPerGBMap = map[string]int{
 	imagetest.HyperdiskExtreme: 1000,
 	imagetest.PdBalanced:       6,
+	"lssd":	0, // This value shouldn't be needed, but LSSD performance should be unaffected by core count.
 }
 
 // FIOOutput defines the output from the fio command
@@ -159,8 +178,8 @@ func installFioWindows() error {
 	return nil
 }
 
-// installFioLinux tries to install fio on linux with any of multiple package managers, and returns an error if all the package managers were not found or failed.
-func installFioLinux() error {
+// installPkgLinux tries to install a package on linux with any of multiple package managers, and returns an error if all the package managers were not found or failed.
+func installPkgLinux(pkg string) error {
 	usingZypper := false
 	var installFioCmd *exec.Cmd
 	if utils.CheckLinuxCmdExists("apt") {
@@ -168,16 +187,16 @@ func installFioLinux() error {
 		if _, err := exec.Command("apt", "-y", "update").CombinedOutput(); err != nil {
 			return fmt.Errorf("apt update failed with error: %v", err)
 		}
-		installFioCmd = exec.Command("apt", "install", "-y", fioCmdNameLinux)
+		installFioCmd = exec.Command("apt", "install", "-y", pkg)
 	} else if utils.CheckLinuxCmdExists("dnf") {
-		installFioCmd = exec.Command("dnf", "-y", "install", fioCmdNameLinux)
+		installFioCmd = exec.Command("dnf", "-y", "install", pkg)
 	} else if utils.CheckLinuxCmdExists("yum") {
-		installFioCmd = exec.Command("yum", "-y", "install", fioCmdNameLinux)
+		installFioCmd = exec.Command("yum", "-y", "install", pkg)
 	} else if utils.CheckLinuxCmdExists("zypper") {
 		usingZypper = true
-		installFioCmd = exec.Command("zypper", "--non-interactive", "install", fioCmdNameLinux)
+		installFioCmd = exec.Command("zypper", "--non-interactive", "install", pkg)
 	} else {
-		return fmt.Errorf("no package managers to install fio found")
+		return fmt.Errorf("no package managers to install %s found", pkg)
 	}
 
 	// print more detailed error message than "exit code 1"
@@ -186,7 +205,7 @@ func installFioLinux() error {
 	installFioCmd.Stdout = &out
 	installFioCmd.Stderr = &stderr
 	if err := installFioCmd.Start(); err != nil {
-		return fmt.Errorf("install fio command failed to start: err %v, %s, %s", err, out.String(), stderr.String())
+		return fmt.Errorf("install %s command failed to start: err %v, %s, %s", pkg, err, out.String(), stderr.String())
 	}
 
 	if err := installFioCmd.Wait(); err != nil {
@@ -196,7 +215,7 @@ func installFioLinux() error {
 		if usingZypper {
 			return checkZypperTransientError(err, stdoutStr, stderrStr)
 		}
-		return fmt.Errorf("install fio command failed with errors: %v, %s, %s", err, stdoutStr, stderrStr)
+		return fmt.Errorf("install %s command failed with errors: %v, %s, %s", pkg, err, stdoutStr, stderrStr)
 	}
 	return nil
 }
@@ -217,18 +236,81 @@ func getLinuxSymlink(mountdiskSizeGBString string) (string, error) {
 	return symlinkRealPath, nil
 }
 
-func getFIOOptions(mode string, usingHyperdisk bool) string {
-	if usingHyperdisk {
+// Assemble all LSSDs in RAID, and return a platform specific identifier for the array
+// On linux, returns a /dev/mdX disk path
+// On windows, returns a \\.\PhysicalDriveX disk path
+// See https://cloud.google.com/compute/docs/disks/benchmarking-local-ssd-performance#max_partitions
+func collectLSSDs(ctx context.Context) (string, error) {
+	var diskPath string
+	if utils.IsWindows() {
+		num, err := utils.RunPowershellCmd(`(Get-Disk -FriendlyName LssdVdisk).Number`)
+		if err == nil && num.Stdout != "" {
+			return `\\.\PhysicalDrive`+strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
+		}
+		out, err := utils.RunPowershellCmd(`New-StoragePool -FriendlyName LssdPool -ResiliencySettingNameDefault Simple -StorageSubsystemFriendlyName "Windows Storage*" -PhysicalDisks $(Get-PhysicalDisk -CanPool $True | Where-Object Model -Match "nvme_card[0-9]+") | New-VirtualDisk -FriendlyName "LssdVdisk" -UseMaximumSize`)
+		if err != nil {
+			return "", fmt.Errorf("failed to create lssd raid array: %s %v", out.Stdout, err)
+		}
+		num, err = utils.RunPowershellCmd(`(Get-Disk -FriendlyName LssdVdisk).Number`)
+		if err != nil {
+			return "", fmt.Errorf("could not find vdisk number: %s %v", num.Stdout, err)
+		}
+		return `\\.\PhysicalDrive`+strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
+	} else {
+		if !utils.CheckLinuxCmdExists("mdadm") {
+			err := installPkgLinux("mdadm")
+			if err != nil {
+				return "", err
+			}
+		}
+		if _, err := os.Stat("/dev/md0"); os.IsNotExist(err) {
+			var mdadmargs []string
+			disks, err := os.ReadDir("/dev/disk/by-id/")
+			if err != nil {
+				return "", err
+			}
+			for _, disk := range disks {
+				if strings.HasPrefix(disk.Name(), "google-local-nvme-ssd") {
+					mdadmargs = append(mdadmargs, "/dev/disk/by-id/"+disk.Name())
+				}
+			}
+			mdadmargs = append([]string{"--create", "/dev/md0", "--level=0", fmt.Sprintf("--raid-devices=%d", len(mdadmargs))}, mdadmargs...)
+			cmd := exec.CommandContext(ctx, "mdadm", mdadmargs...)
+			o, err := cmd.CombinedOutput()
+			if err != nil {
+				return "", fmt.Errorf("failed to run \"mdadm %s\": %s %v", mdadmargs, o, err)
+			}
+			diskPath = "/dev/md0"
+		} else if err == nil {
+			diskPath = "/dev/md0"
+		} else {
+			return "", fmt.Errorf("could not determine if raid array exists: %v", err)
+		}
+	}
+	return diskPath, nil
+}
+
+// diskClass should be one of "pd", "hyperdisk", "lssd"
+func getFIOOptions(mode, diskClass string) string {
+	switch diskClass {
+	case "hyperdisk":
 		if mode == randRead || mode == randWrite {
 			return hyperdiskFIORandOptions + " --rw=" + mode
 		}
 		return hyperdiskFIOSeqOptions + " --rw=" + mode
+	case "lssd":
+		if mode == randRead || mode == randWrite {
+			return lssdFIORandOptions + " --rw=" + mode
+		}
+		return lssdFIOSeqOptions + " --rw=" + mode
+	case "pd":
+		fallthrough
+	default:
+		if mode == randRead || mode == randWrite {
+			return commonFIORandOptions + " --rw=" + mode
+		}
+		return commonFIOSeqOptions + " --rw=" + mode
 	}
-
-	if mode == randRead || mode == randWrite {
-		return commonFIORandOptions + " --rw=" + mode
-	}
-	return commonFIOSeqOptions + " --rw=" + mode
 }
 
 // check if a known zypper backend error is found
@@ -249,17 +331,17 @@ func checkZypperTransientError(err error, stdout, stderr string) error {
 	return err
 }
 
-// use the guest attribute to check if hyperdisk is being used. If the guest attribute was not set, assume by default that hyperdisk fio options are not being used.
-func isUsingHyperdisk(ctx context.Context) bool {
+// use the guest attribute to check what kind of disk is being tested. If the guest attribute was not set, assume by default that PD is used.
+func getDiskClass(ctx context.Context) string {
 	diskType, err := utils.GetMetadata(ctx, "instance", "attributes", diskTypeAttribute)
 	if err != nil {
-		return false
+		return "pd"
+	} else if diskType == "lssd" {
+		return "lssd"
+	} else if diskType == imagetest.HyperdiskExtreme || diskType == imagetest.HyperdiskThroughput || diskType == imagetest.HyperdiskBalanced {
+		return "hyperdisk"
 	}
-	if diskType == imagetest.HyperdiskExtreme || diskType == imagetest.HyperdiskThroughput || diskType == imagetest.HyperdiskBalanced {
-		return true
-	}
-
-	return false
+	return "pd"
 }
 
 // function to get num numa nodes
@@ -353,8 +435,8 @@ func getHyperdiskAdditionalOptions(symlinkRealPath string) (string, error) {
 	return readOptionsSuffix, nil
 }
 
-func installFioAndFillDisk(symlinkRealPath string, usingHyperdisk bool, t *testing.T) error {
-	if err := installFioLinux(); err != nil {
+func installFioAndFillDisk(symlinkRealPath, diskClass string, t *testing.T) error {
+	if err := installPkgLinux(fioCmdNameLinux); err != nil {
 		return fmt.Errorf("fio installation on linux failed: err %v", err)
 	}
 	if err := fillDisk(symlinkRealPath, t); err != nil {
@@ -365,16 +447,25 @@ func installFioAndFillDisk(symlinkRealPath string, usingHyperdisk bool, t *testi
 
 func runFIOLinux(t *testing.T, mode string) ([]byte, error) {
 	ctx := utils.Context(t)
-	usingHyperdisk := isUsingHyperdisk(ctx)
-	options := getFIOOptions(mode, usingHyperdisk)
+	diskClass := getDiskClass(ctx)
+	options := getFIOOptions(mode, diskClass)
 
-	mountdiskSizeGBString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", diskSizeGBAttribute)
-	if err != nil {
-		return []byte{}, fmt.Errorf("couldn't get image from metadata")
-	}
-	symlinkRealPath, err := getLinuxSymlink(mountdiskSizeGBString)
-	if err != nil {
-		return []byte{}, err
+	var diskPath string
+	if diskClass == "lssd" {
+		var err error
+		diskPath, err = collectLSSDs(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		mountdiskSizeGBString, err := utils.GetMetadata(utils.Context(t), "instance", "attributes", diskSizeGBAttribute)
+		if err != nil {
+			return []byte{}, fmt.Errorf("couldn't get image from metadata")
+		}
+		diskPath, err = getLinuxSymlink(mountdiskSizeGBString)
+		if err != nil {
+			return []byte{}, err
+		}
 	}
 	// ubuntu 16.04 has a different option name due to an old fio version
 	image, err := utils.GetMetadata(ctx, "instance", "image")
@@ -384,17 +475,23 @@ func runFIOLinux(t *testing.T, mode string) ([]byte, error) {
 	if strings.Contains(image, "ubuntu-pro-1604") {
 		options = strings.Replace(options, "iodepth_batch_complete_max", "iodepth_batch_complete", 1)
 	}
+	if strings.Contains(image, "ubuntu") && (strings.Contains(image, "1804") || strings.Contains(image, "1604")) {
+		err := installPkgLinux("libnuma-dev")
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if !utils.CheckLinuxCmdExists(fioCmdNameLinux) {
-		if err = installFioAndFillDisk(symlinkRealPath, usingHyperdisk, t); err != nil {
+		if err = installFioAndFillDisk(diskPath, diskClass, t); err != nil {
 			return []byte{}, err
 		}
 	}
-	options += " --filename=" + symlinkRealPath + " --ioengine=libaio"
+	options += " --filename=" + diskPath + " --ioengine=libaio"
 	// use the recommended options from the hyperdisk docs at https://cloud.google.com/compute/docs/disks/benchmark-hyperdisk-performance
 	// the options --name and --numa_cpu_node must be at the very end of the command to run the jobs correctly on hyperdisk and avoid confusing fio
-	if usingHyperdisk {
-		hyperdiskAdditionalOptions, err := getHyperdiskAdditionalOptions(symlinkRealPath)
+	if diskClass == "hyperdisk" {
+		hyperdiskAdditionalOptions, err := getHyperdiskAdditionalOptions(diskPath)
 		if err != nil {
 			t.Fatalf("failed to get hyperdisk additional options: error %v", err)
 		}
@@ -403,17 +500,29 @@ func runFIOLinux(t *testing.T, mode string) ([]byte, error) {
 	randCmd := exec.Command(fioCmdNameLinux, strings.Fields(options)...)
 	IOPSJson, err := randCmd.CombinedOutput()
 	if err != nil {
-		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", IOPSJson, err)
+		return []byte{}, fmt.Errorf("fio command failed with error: %v %v", string(IOPSJson), err)
 	}
 	return IOPSJson, nil
 }
 
-func runFIOWindows(mode string) ([]byte, error) {
+func runFIOWindows(t *testing.T, mode string) ([]byte, error) {
 	IOPSFile := "C:\\fio-iops.txt"
+	ctx := utils.Context(t)
 	// TODO: hyperdisk testing is not yet implemented for windows
-	usingHyperdisk := false
-	fiopOptions := getFIOOptions(mode, usingHyperdisk)
-	fioOptionsWindows := " -ArgumentList \"" + fiopOptions + " --output=" + IOPSFile + " --filename=\\\\.\\PhysicalDrive1" + " --ioengine=windowsaio" + " --thread\"" + " -wait"
+	diskClass := getDiskClass(ctx)
+	if diskClass == "hyperdisk" {
+		diskClass = "pd"
+	}
+	fiopOptions := getFIOOptions(mode, diskClass)
+	diskPath := `\\.\PhysicalDrive1`
+	if diskClass == "lssd" {
+		var err error
+		diskPath, err = collectLSSDs(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	fioOptionsWindows := " -ArgumentList \"" + fiopOptions + " --output=" + IOPSFile + " --filename=" + diskPath + " --ioengine=windowsaio" + " --thread\"" + " -wait"
 	// fioWindowsLocalPath is defined within storage_perf_utils.go
 	if procStatus, err := utils.RunPowershellCmd("Start-Process " + fioWindowsLocalPath + fioOptionsWindows); err != nil {
 		return []byte{}, fmt.Errorf("fio.exe returned with error: %v %s %s", err, procStatus.Stdout, procStatus.Stderr)
@@ -429,6 +538,9 @@ func runFIOWindows(mode string) ([]byte, error) {
 // get the minimum mount disk size required to reach the iops target.
 // default to 3500GB if this calculation fails.
 func getRequiredDiskSize(machineType, diskType string) int64 {
+	if diskType == "lssd" {
+		return 0
+	}
 	// mount disks should always be at least 3500GB, as a testing convention.
 	var minimumDiskSizeGB int64 = 3500
 	var iopsTargetStruct PerformanceTargets

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"os"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -58,8 +58,8 @@ const (
 	commonFIOSeqOptions     = "--name=write_bandwidth_test --filesize=500G --time_based --ramp_time=2s --runtime=1m --direct=1 --verify=0 --randrepeat=0 --numjobs=1 --offset_increment=500G --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --output-format=json"
 	hyperdiskFIORandOptions = "--numjobs=8 --size=500G --time_based --runtime=5m --ramp_time=10s --direct=1 --verify=0 --bs=4K --iodepth=256 --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 --group_reporting --output-format=json"
 	hyperdiskFIOSeqOptions  = "--numjobs=8 --size=500G --time_based --runtime=5m --ramp_time=10s --direct=1 --verify=0 --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --offset_increment=20G --group_reporting --output-format=json"
-	lssdFIORandOptions = "--name=write_iops_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=4K --iodepth=256 --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 --group_reporting --output-format=json"
-	lssdFIOSeqOptions  = "--name=write_bandwidth_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --offset_increment=20G --group_reporting --output-format=json"
+	lssdFIORandOptions      = "--name=write_iops_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=4K --iodepth=256 --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 --group_reporting --output-format=json"
+	lssdFIOSeqOptions       = "--name=write_bandwidth_test --numjobs=8 --size=500G --time_based --runtime=5m --randrepeat=0 --invalidate=1 --ramp_time=10s --direct=1 --verify=0 --verify_fatal=0 --bs=1M --iodepth=64 --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 --offset_increment=20G --group_reporting --output-format=json"
 )
 
 // map the machine type to performance targets
@@ -145,7 +145,7 @@ var pdbalanceIOPSMap = map[string]PerformanceTargets{
 var iopsPerGBMap = map[string]int{
 	imagetest.HyperdiskExtreme: 1000,
 	imagetest.PdBalanced:       6,
-	"lssd":	0, // This value shouldn't be needed, but LSSD performance should be unaffected by core count.
+	"lssd":                     0, // This value shouldn't be needed, but LSSD performance should be unaffected by core count.
 }
 
 // FIOOutput defines the output from the fio command
@@ -245,7 +245,7 @@ func collectLSSDs(ctx context.Context) (string, error) {
 	if utils.IsWindows() {
 		num, err := utils.RunPowershellCmd(`(Get-Disk -FriendlyName LssdVdisk).Number`)
 		if err == nil && num.Stdout != "" {
-			return `\\.\PhysicalDrive`+strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
+			return `\\.\PhysicalDrive` + strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
 		}
 		out, err := utils.RunPowershellCmd(`New-StoragePool -FriendlyName LssdPool -ResiliencySettingNameDefault Simple -StorageSubsystemFriendlyName "Windows Storage*" -PhysicalDisks $(Get-PhysicalDisk -CanPool $True | Where-Object Model -Match "nvme_card[0-9]+") | New-VirtualDisk -FriendlyName "LssdVdisk" -UseMaximumSize`)
 		if err != nil {
@@ -255,7 +255,7 @@ func collectLSSDs(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not find vdisk number: %s %v", num.Stdout, err)
 		}
-		return `\\.\PhysicalDrive`+strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
+		return `\\.\PhysicalDrive` + strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(num.Stdout), "\n"), "\r"), nil
 	} else {
 		if !utils.CheckLinuxCmdExists("mdadm") {
 			err := installPkgLinux("mdadm")


### PR DESCRIPTION
LSSDs present on the machine are collected into a raid array as directed in our public documentation

I abstracted installFioLinux to install any package and used that to install mdadm for the array setup, then added some logic to install libnuma-dev on ubuntu 1604 and 1804 since this came up just now and I already wrote that abstraction

Added performance targets for LSSDs

Added some logic to determine "disk class" eg. PD, hyperdisk, or LSSD and reworked logic to return fio options based off that

getMountDiskSize returns 0 for LSSD so that it doesn't wait for quota it doesn't need

Test setup logic just checks of diskType is lssd and skips adding a secondary disk if so.

/cc @koln67 @zmarano 