### PR TITLE
Autodelete all disks created for testvms

### DIFF
--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -105,7 +105,7 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
 
 	for _, disk := range disks {
-		currentDisk := &compute.AttachedDisk{Source: disk.Name}
+		currentDisk := &compute.AttachedDisk{Source: disk.Name, AutoDelete: true}
 		currentDisk.AutoDelete = true
 		instance.Disks = append(instance.Disks, currentDisk)
 	}
@@ -159,7 +159,7 @@ func (t *TestWorkflow) appendCreateVMStepBeta(disks []*compute.Disk, instance *d
 	instance.Scopes = append(instance.Scopes, "https://www.googleapis.com/auth/devstorage.read_write")
 
 	for _, disk := range disks {
-		instance.Disks = append(instance.Disks, &computeBeta.AttachedDisk{Source: disk.Name})
+		instance.Disks = append(instance.Disks, &computeBeta.AttachedDisk{Source: disk.Name, AutoDelete: true})
 	}
 
 	if instance.Metadata == nil {


### PR DESCRIPTION
Should be enabled be default for boot disks but I think some of the secondary disks are getting left behind.
/cc @drewhli @zmarano 