### PR TITLE
Switch disk types to hyperdisk extreme for machine types that don't support PD

### DIFF
--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -506,7 +506,7 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 				if createDisksOk && (strings.HasPrefix(vm.MachineType, "c4-") || strings.HasPrefix(vm.MachineType, "n4-")) {
 					for _, attachedDisk := range vm.Disks {
 						for _, disk := range *createDisksStep.CreateDisks {
-							if attachedDisk.Source == disk.Name && (disk.Type == "" || strings.HasPrefix(disk.Type, "pd-")) {
+							if attachedDisk.Source == disk.Name && disk.Type == "" {
 								disk.Type = HyperdiskBalanced
 							}
 						}

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -491,6 +491,7 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 			arch = "arm64"
 		}
 
+		createDisksStep, createDisksOk := twf.wf.Steps[createDisksStepName]
 		createVMsStep, ok := twf.wf.Steps[createVMsStepName]
 		if ok {
 			for _, vm := range createVMsStep.CreateInstances.Instances {
@@ -501,6 +502,15 @@ func finalizeWorkflows(ctx context.Context, tests []*TestWorkflow, zone, gcsPref
 				}
 				if vm.Zone != "" && vm.Zone != twf.wf.Zone {
 					log.Printf("VM %s zone is set to %s, differing from workflow zone %s for test %s, not overriding\n", vm.Name, vm.Zone, twf.wf.Zone, twf.Name)
+				}
+				if createDisksOk && (strings.HasPrefix(vm.MachineType, "c4-") || strings.HasPrefix(vm.MachineType, "n4-")) {
+					for _, attachedDisk := range vm.Disks {
+						for _, disk := range *createDisksStep.CreateDisks {
+							if attachedDisk.Source == disk.Name && (disk.Type == "" || strings.HasPrefix(disk.Type, "pd-")) {
+								disk.Type = HyperdiskBalanced
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
/cc @drewhli @zmarano 

This is extremely ugly (O(N^3) for the triply nested loop) but there is no direct link between a VM and a disk and finding the link between disk and attachedDisk is O(N^2) because of the way daisy stores this data. To make this prettier and more efficient we could either break the daisy API by switching CreateDisks to a map (will cause problems for anyone using the latest version of the CLI tool to import a pre-written json workflow) or we could modify CIT or daisy to better parse and handle failures from the compute API.

Either way these are long(er) term solutions and we should (imo) do this in the interim to make things work for these machine types right now.