### PR TITLE
Use us-east4-b for hyperdisk extreme case

### DIFF
--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -110,7 +110,7 @@ var storagePerfTestConfig = []storagePerfTest{
 	{
 		name:             "c4-hde",
 		bootDiskType:     imagetest.HyperdiskBalanced,
-		zone:             "us-east5-b",
+		zone:             "us-east4-b",
 		arch:             "X86_64",
 		machineType:      "c4-standard-192",
 		diskType:         imagetest.HyperdiskExtreme,


### PR DESCRIPTION
hyperdiskextreme is not available in us-east5-*, we will just need to filter this until we have some C4 capacity in us-east4