### PR TITLE
Switch compute-image-test-pool-001 back to gcp-guest in concourse pipelines

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -452,7 +452,7 @@ local build_guest_agent = buildpackagejob {
               run: {
                 path: '/manager',
                 args: [
-                  '-project=compute-image-test-pool-001',
+                  '-project=gcp-guest',
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id))',
@@ -473,7 +473,7 @@ local build_guest_agent = buildpackagejob {
               run: {
                 path: '/manager',
                 args: [
-                  '-project=compute-image-test-pool-001',
+                  '-project=gcp-guest',
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',

--- a/concourse/tasks/image-test-args.yaml
+++ b/concourse/tasks/image-test-args.yaml
@@ -11,7 +11,7 @@ inputs:
 run:
   path: /manager
   args:
-  - -project=compute-image-test-pool-001
+  - -project=gcp-guest
   - -zone=us-central1-a
   - -test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005
   - -images=((images))


### PR DESCRIPTION
Need to sort out GCS permission issues first, and the service accounts here are kind of a maze