### PR TITLE
Test setting subnetwork region and take base name of region url

### DIFF
--- a/imagetest/fixtures_test.go
+++ b/imagetest/fixtures_test.go
@@ -654,6 +654,22 @@ func TestAddSecondaryRange(t *testing.T) {
 	}
 }
 
+func TestSetRegion(t *testing.T) {
+	twf := NewTestWorkflowForUnitTest("name", "image", "30m")
+	network, err := twf.CreateNetwork("network", false)
+	if err != nil {
+		t.Errorf("failed to create network: %v", err)
+	}
+	subnet, err := network.CreateSubnetwork("subnet", "ipRange")
+	if err != nil {
+		t.Errorf("failed to create subnetwork: %v", err)
+	}
+	subnet.SetRegion("testregion")
+	if subnet.subnetwork.Region != "testregion" {
+		t.Errorf("Subnet has unexpected region, got %s want testregion", subnet.subnetwork.Region)
+	}
+}
+
 // TestCreateNetworkDependenciesReverse tests that the create-vms step depends
 // on the create-networks step if they are created in order.
 func TestCreateNetworkDependencies(t *testing.T) {

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/oslogin v1.12.2
 	cloud.google.com/go/secretmanager v1.11.4
 	cloud.google.com/go/storage v1.31.0
-	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f
+	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12
 	github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper v0.0.0-20231129203917-db71af465791
 	github.com/go-ping/ping v1.1.0
 	github.com/google/uuid v1.4.0

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/storage v1.31.0/go.mod h1:81ams1PrhW16L4kF7qg+4mTq7SRs5HsbDT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f h1:fHLga6U5ibwILQYGom/Fta6xJpn8DJ/XbIRmVaySLjA=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12 h1:p/aoXPazJo0ehO3yjg3O4VNbJTO5TAshYIga5fpL1Gw=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"path"
 	"regexp"
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
@@ -204,7 +205,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				return err
 			}
 			zone = z.Name
-			region = z.Region
+			region = path.Base(z.Region)
 		}
 		machine, err := t.Client.GetMachineType(t.Project.Name, zone, tc.machineType)
 		if err != nil {


### PR DESCRIPTION
Partial fix for test grid failures [here](https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics-performance), other component of the fix is [here](https://github.com/GoogleCloudPlatform/compute-daisy/pull/39)