### PR TITLE
Move derivative image build back to gcp-guest

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -317,7 +317,7 @@ local buildpackageimagetask = {
     run: {
       path: '/daisy',
       args: [
-        '-project=compute-image-test-pool-001',
+        '-project=gcp-guest',
         '-zone=us-central1-a',
         '-var:source_image=' + tl.source_image,
         '-var:gcs_package_path=' + tl.gcs_package_path,


### PR DESCRIPTION
We are trying to use images from one project while we are pushing it to the other, this change brings it back to consistency.