### PR TITLE
Permanently disable DHCP tests for debian-10 and debian-11

### DIFF
--- a/imagetest/test_suites/network/dhcp_test.go
+++ b/imagetest/test_suites/network/dhcp_test.go
@@ -25,6 +25,15 @@ func TestDHCP(t *testing.T) {
 	var cmd *exec.Cmd
 	var err error
 
+	image, err := utils.GetMetadata(utils.Context(t), "instance", "image")
+	if err != nil {
+		t.Fatalf("could not get image name: %s", err)
+	}
+
+	if strings.Contains(image, "debian-10") || strings.Contains(image, "debian-11") {
+		t.Skipf("DHCP test not supported on: %s", image)
+	}
+
 	// Run every case: if one command or check succeeds, the test passes.
 	if utils.IsWindows() {
 		checkDhcpWindows(t)


### PR DESCRIPTION
The tests need to be adjusted to the new guest-agent network manager interface implementation, all the exceptions must be addressed (i.e. not all systems will have dhclient processes for both primary and secondary nics).