### PR TITLE
Exclude 4th gen machine type testing from release pipelines

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -46,7 +46,6 @@ local prepublishtesttask = {
 
   // Start of task
   platform: 'linux',
-  serial_groups: ['shapevalidation'],
   image_resource: {
     type: 'registry-image',
     source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
@@ -60,6 +59,7 @@ local prepublishtesttask = {
       // Run tests not ran in publish-to-testing
       // TODO enable oslogin
       '-filter=(shapevalidation)',
+      '-shapevalidation_test_filter=^[A-Z][0-3]',
       '-images=' + task.images,
     ] + task.extra_args,
   },

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -18,7 +18,6 @@ local prepublishtesttask = {
 
   // Start of task
   platform: 'linux',
-  serial_groups: ['shapevalidation'],
   image_resource: {
     type: 'registry-image',
     source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
@@ -31,6 +30,7 @@ local prepublishtesttask = {
       '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
       // Run tests not ran in publish-to-testing
       '-filter=(shapevalidation)',
+      '-shapevalidation_test_filter=^[A-Z][0-3]',
       '-images=' + task.images,
     ] + task.extra_args,
   },


### PR DESCRIPTION
I also dropped the serial_groups tags (this is a no-op, these don't work cross-pipeline anyway)

/cc @zmarano @elicriffield 