### PR TITLE
Artifact Registry task template

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -260,8 +260,8 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s], "reponame": "%s",}}' %
-        [tl.request_type, tl.os_type, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files, "gs://gce-packages-prod/" + tl.pkg_name + "/" + tl.pkg_version + "/" + tl.os_type],
+        '{"type": "%s", "request": {"ostype": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
+        [tl.request_type, tl.os_type, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
       ],
     },
   },

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -234,7 +234,7 @@ local promotepackagejob = {
 local uploadpackageversiontask = {
   local tl = self,
 
-  environment:: 'staging',
+  environment:: 'stable',
   os_type:: error 'must set os_type in uploadpackageversiontask',
   // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -235,10 +235,10 @@ local uploadpackageversiontask = {
   local tl = self,
 
   environment:: 'stable',
-  os_type:: error 'must set os_type in uploadpackageversiontask',
   // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.
   gcs_files:: error 'must set gcs_files in uploadpackageversiontask',
+  os_type:: error 'must set os_type in uploadpackageversiontask',
   pkg_name:: error 'must set pkgname in uploadpackageversiontask',
   pkg_version:: error 'must set pkgversion in uploadpackageversiontask',
   sbom_file:: error 'must set sbom_file in uploadpackageversiontask',
@@ -888,14 +888,6 @@ local build_and_upload_guest_agent = build_guest_agent {
             '{"bucket":"gcp-guest-package-uploads","object":"gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json"}',
           universe: 'cloud-yum',
           repo: 'gce-disk-expand-el8',
-        },
-        uploadpackagetask {
-          package_paths:
-            '{"bucket":"gcp-guest-package-uploads","object":"gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el9.noarch.rpm"}',
-          sbom_file:
-            '{"bucket":"gcp-guest-package-uploads","object":"gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json"}',
-          universe: 'cloud-yum',
-          repo: 'gce-disk-expand-el9',
         },
 
       ],

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -234,14 +234,15 @@ local promotepackagejob = {
 local uploadpackageversiontask = {
   local tl = self,
 
-  environment:: 'prod',
   // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.
   gcs_files:: error 'must set gcs_files in uploadpackageversiontask',
   os_type:: error 'must set os_type in uploadpackageversiontask',
+  pkg_inside_name:: error 'must set pkg_inside_name in uploadpackageversiontask',
   pkg_name:: error 'must set pkgname in uploadpackageversiontask',
   pkg_version:: error 'must set pkgversion in uploadpackageversiontask',
   request_type:: 'uploadToArtifactReleaser',
+  reponame:: error 'must set reponame in uploadpackageversiontask',
   sbom_file:: error 'must set sbom_file in uploadpackageversiontask',
   topic:: 'projects/artifact-releaser-prod/topics/artifact-registry-package-upload-prod',
 
@@ -261,8 +262,8 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
-        [tl.request_type, tl.os_type, tl.environment, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
+        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkginsidename": "%s", "pkgname": "%s", "pkgversion": "%s", "reponame": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
+        [tl.request_type, tl.os_type, tl.environment, tl.pkg_inside_name, tl.pkg_name, tl.pkg_version, tl.reponame, tl.sbom_file, tl.gcs_files],
       ],
     },
   },
@@ -901,8 +902,10 @@ local build_and_upload_guest_agent = build_guest_agent {
         uploadpackageversiontask {
           gcs_files: '"gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el9.noarch.rpm"',
           os_type: 'EL9_YUM',
+          pkg_inside_name: 'gce-disk-expand',
           pkg_name: 'guest-diskexpand',
           pkg_version: '((.:package-version))',
+          reponame: 'gce-disk-expand-el9',
           sbom_file: 'gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json',
         },
 

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -245,7 +245,7 @@ local uploadpackageversiontask = {
   topic:: 'projects/artifact-releaser-prod/topics/artifact-registry-package-upload-prod',
   request_type:: 'uploadToArtifactReleaser',
 
-  task: 'upload-' + tl.repo + '-version',
+  task: 'upload-' + tl.pkg_name + '-' + tl.os_type,
   config: {
     platform: 'linux',
     image_resource: {
@@ -260,7 +260,7 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}' %
+        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
         [tl.request_type, tl.os_type, tl.environment, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
       ],
     },
@@ -889,7 +889,13 @@ local build_and_upload_guest_agent = build_guest_agent {
           universe: 'cloud-yum',
           repo: 'gce-disk-expand-el8',
         },
-
+        uploadpackageversiontask {
+          gcs_files: '"gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el9.noarch.rpm"',
+          os_type: 'EL9_YUM',
+          pkg_name: 'guest-diskexpand',
+          pkg_version: '((.:package-version))',
+          sbom_file: 'gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json',
+        },
       ],
     },
     buildpackagejob {

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -889,6 +889,14 @@ local build_and_upload_guest_agent = build_guest_agent {
           universe: 'cloud-yum',
           repo: 'gce-disk-expand-el8',
         },
+        uploadpackagetask {
+          package_paths:
+            '{"bucket":"gcp-guest-package-uploads","object":"gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el9.noarch.rpm"}',
+          sbom_file:
+            '{"bucket":"gcp-guest-package-uploads","object":"gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json"}',
+          universe: 'cloud-yum',
+          repo: 'gce-disk-expand-el9',
+        },
         uploadpackageversiontask {
           gcs_files: '"gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el9.noarch.rpm"',
           os_type: 'EL9_YUM',
@@ -896,6 +904,7 @@ local build_and_upload_guest_agent = build_guest_agent {
           pkg_version: '((.:package-version))',
           sbom_file: 'gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json',
         },
+
       ],
     },
     buildpackagejob {

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -236,14 +236,14 @@ local uploadpackageversiontask = {
 
   environment:: 'staging',
   os_type:: error 'must set os_type in uploadpackageversiontask',
-  // This parameter must be enclosed in double quotes when passed in, for json parsing.
+  // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.
   gcs_files:: error 'must set gcs_files in uploadpackageversiontask',
   pkg_name:: error 'must set pkgname in uploadpackageversiontask',
   pkg_version:: error 'must set pkgversion in uploadpackageversiontask',
   sbom_file:: error 'must set sbom_file in uploadpackageversiontask',
   topic:: 'projects/artifact-releaser-prod/topics/artifact-registry-package-upload-prod',
-  request_type:: '"uploadToArtifactReleaser"',
+  request_type:: 'uploadToArtifactReleaser',
 
   task: 'upload-' + tl.repo + '-version',
   config: {

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -234,16 +234,16 @@ local promotepackagejob = {
 local uploadpackageversiontask = {
   local tl = self,
 
-  environment:: 'stable',
   // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.
   gcs_files:: error 'must set gcs_files in uploadpackageversiontask',
   os_type:: error 'must set os_type in uploadpackageversiontask',
   pkg_name:: error 'must set pkgname in uploadpackageversiontask',
   pkg_version:: error 'must set pkgversion in uploadpackageversiontask',
+  request_type:: 'uploadToArtifactReleaser',
   sbom_file:: error 'must set sbom_file in uploadpackageversiontask',
   topic:: 'projects/artifact-releaser-prod/topics/artifact-registry-package-upload-prod',
-  request_type:: 'uploadToArtifactReleaser',
+
 
   task: 'upload-' + tl.pkg_name + '-' + tl.os_type,
   config: {
@@ -260,8 +260,8 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
-        [tl.request_type, tl.os_type, tl.environment, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
+        '{"type": "%s", "request": {"ostype": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s], "reponame": "%s",}}' %
+        [tl.request_type, tl.os_type, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files, "gs://gce-packages-prod/" + tl.pkg_name + "/" + tl.pkg_version + "/" + tl.os_type],
       ],
     },
   },

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -234,6 +234,7 @@ local promotepackagejob = {
 local uploadpackageversiontask = {
   local tl = self,
 
+  environment:: 'prod',
   // Unlike other parameters, gcs_files must be enclosed in double quotes when passed in for json parsing.
   // For example, gcs_files: '"path1","path2"', or gcs_files: '"path"' if there is only one file.
   gcs_files:: error 'must set gcs_files in uploadpackageversiontask',
@@ -260,8 +261,8 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
-        [tl.request_type, tl.os_type, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
+        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkgname": "%s", "pkgversion": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
+        [tl.request_type, tl.os_type, tl.environment, tl.pkg_name, tl.pkg_version, tl.sbom_file, tl.gcs_files],
       ],
     },
   },

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -262,8 +262,8 @@ local uploadpackageversiontask = {
         'publish',
         tl.topic,
         '--message',
-        '{"type": "%s", "request": {"ostype": "%s", "environment": "%s", "pkginsidename": "%s", "pkgname": "%s", "pkgversion": "%s", "reponame": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
-        [tl.request_type, tl.os_type, tl.environment, tl.pkg_inside_name, tl.pkg_name, tl.pkg_version, tl.reponame, tl.sbom_file, tl.gcs_files],
+        '{"type": "%s", "request": {"ostype": "%s", "pkginsidename": "%s", "pkgname": "%s", "pkgversion": "%s", "reponame": "%s", "sbomfile": "%s", "gcsfiles": [%s]}}' %
+        [tl.request_type, tl.os_type, tl.pkg_inside_name, tl.pkg_name, tl.pkg_version, tl.reponame, tl.sbom_file, tl.gcs_files],
       ],
     },
   },


### PR DESCRIPTION
Template for artifact registry package upload tasks, which will eventually replace the current cloud rapture package upload tasks.

No instances of this task are being called yet, until a follow up PR.