### PR TITLE
Fix and enable linux license validation, exclude from guest package integration test pipelines

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -454,6 +454,7 @@ local build_guest_agent = buildpackagejob {
                 args: [
                   '-project=gcp-guest',
                   '-zone=us-central1-a',
+                  '-exclude=licensevalidtion', #At time of writing, licensevalidation only validates image metadata not image behavior so not relevant for package testing
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-10-((.:build-id)),projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/centos-7-((.:build-id)),projects/gcp-guest/global/images/rhel-7-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id))',
                   '-exclude=(image)|(disk)|(security)|(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(hotattach)',
@@ -475,6 +476,7 @@ local build_guest_agent = buildpackagejob {
                 args: [
                   '-project=gcp-guest',
                   '-zone=us-central1-a',
+                  '-exclude=licensevalidtion', #At time of writing, licensevalidation only validates image metadata not image behavior so not relevant for package testing
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-11-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
                   '-exclude=(image)|(disk)|(security)|(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(hotattach)',

--- a/imagetest/test_suites/licensevalidation/setup.go
+++ b/imagetest/test_suites/licensevalidation/setup.go
@@ -76,7 +76,7 @@ func requiredLicenseList(image *compute.Image) ([]string, error) {
 			// Rightmost dash separated segment with only [a-z] chars should be the codename
 			var codename string
 			segments := strings.Split(image.Name, "-")
-			for i := len(segments)-1; i>=0; i-- {
+			for i := len(segments) - 1; i >= 0; i-- {
 				if len(regexp.MustCompile("[a-z]+").FindString(segments[i])) == len(segments[i]) {
 					codename = segments[i]
 					break


### PR DESCRIPTION
Licensevalidation is validating the image metadata, not the behavior, so this is completely unaffected by guest packages. Building the guest package derivative images in a way that looks more like how we build them for prod would make this work as well, but doesn't bring any benefit to guest package testing and this is simpler.

/cc @drewhli @dorileo 
/hold