### PR TITLE
Take base name of region in all cases for networkperf

### DIFF
--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -198,7 +198,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		var zone string
 		if tc.zone == "" {
 			zone = t.Zone.Name
-			region = t.Zone.Region
+			region = path.Base(t.Zone.Region)
 		} else {
 			z, err := t.Client.GetZone(t.Project.Name, tc.zone)
 			if err != nil {


### PR DESCRIPTION
Fixes failures here: https://oss.gprow.dev/view/gs/oss-prow/logs/cit-periodics-performance/1757725494280720384
/cc @drewhli @koln67 

successful run (with up to 3rd gen machines):
```
arate@acrate-p1g4 ~ > cit-local -timeout 10m -project compute-image-test-pool-001 -filter networkperf -networkperf_test_filter=[a-z][0-3] -images projects/debian-cloud/global/images/family/debian-12,projects/debian-cloud/global/images/family/debian-12-arm64
2024/02/14 10:49:31 Running in project compute-image-test-pool-001 zone us-central1-a. Tests will run in projects: [compute-image-test-pool-001]
2024/02/14 10:49:31 using -filter networkperf
2024/02/14 10:49:31 Add test workflow for test networkperf on image projects/debian-cloud/global/images/family/debian-12
2024/02/14 10:49:35 Add test workflow for test networkperf on image projects/debian-cloud/global/images/family/debian-12-arm64
2024/02/14 10:49:36 Done with setup
2024/02/14 10:49:37 Storing artifacts and logs in gs://compute-image-test-pool-001-cloud-test-outputs/2024-02-14T10:49:37-08:00
2024/02/14 10:49:37 VM server-vm-n1-standard-2 machine type set to n1-standard-2 for test networkperf
2024/02/14 10:49:37 VM client-vm-n1-standard-2 machine type set to n1-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-n1-standard-2 machine type set to n1-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-n1-standard-2 machine type set to n1-standard-2 for test networkperf
2024/02/14 10:49:37 VM server-vm-n2-standard-2 machine type set to n2-standard-2 for test networkperf
2024/02/14 10:49:37 VM client-vm-n2-standard-2 machine type set to n2-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-n2-standard-2 machine type set to n2-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-n2-standard-2 machine type set to n2-standard-2 for test networkperf
2024/02/14 10:49:37 VM server-vm-n2d-standard-2 machine type set to n2d-standard-2 for test networkperf
2024/02/14 10:49:37 VM client-vm-n2d-standard-2 machine type set to n2d-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-n2d-standard-2 machine type set to n2d-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-n2d-standard-2 machine type set to n2d-standard-2 for test networkperf
2024/02/14 10:49:37 VM server-vm-e2-standard-2 machine type set to e2-standard-2 for test networkperf
2024/02/14 10:49:37 VM client-vm-e2-standard-2 machine type set to e2-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-e2-standard-2 machine type set to e2-standard-2 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-e2-standard-2 machine type set to e2-standard-2 for test networkperf
2024/02/14 10:49:37 VM server-vm-t2d-standard-1 machine type set to t2d-standard-1 for test networkperf
2024/02/14 10:49:37 VM client-vm-t2d-standard-1 machine type set to t2d-standard-1 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-t2d-standard-1 machine type set to t2d-standard-1 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-t2d-standard-1 machine type set to t2d-standard-1 for test networkperf
2024/02/14 10:49:37 VM server-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM client-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM tier1-server-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM tier1-client-vm-n2-standard-32 machine type set to n2-standard-32 for test networkperf
2024/02/14 10:49:37 VM server-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM client-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM tier1-server-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM tier1-client-vm-n2d-standard-48 machine type set to n2d-standard-48 for test networkperf
2024/02/14 10:49:37 VM server-vm-t2a-standard-1 machine type set to t2a-standard-1 for test networkperf
2024/02/14 10:49:37 VM client-vm-t2a-standard-1 machine type set to t2a-standard-1 for test networkperf
2024/02/14 10:49:37 VM jf-server-vm-t2a-standard-1 machine type set to t2a-standard-1 for test networkperf
2024/02/14 10:49:37 VM jf-client-vm-t2a-standard-1 machine type set to t2a-standard-1 for test networkperf
2024/02/14 10:49:37 running test networkperf/debian-12-bookworm-v20240213 (ID q6m40) in project compute-image-test-pool-001
2024/02/14 10:50:37 running test networkperf/debian-12-bookworm-arm64-v20240213 (ID trsml) in project compute-image-test-pool-001
2024/02/14 10:56:17 finished test networkperf/debian-12-bookworm-v20240213 (ID q6m40) in project compute-image-test-pool-001, time spent: 06m 39s
2024/02/14 10:56:22 cleaning up after test networkperf/debian-12-bookworm-v20240213 (ID q6m40) in project compute-image-test-pool-001
2024/02/14 10:56:43 finished test networkperf/debian-12-bookworm-arm64-v20240213 (ID trsml) in project compute-image-test-pool-001, time spent: 06m 05s
2024/02/14 10:56:43 cleaning up after test networkperf/debian-12-bookworm-arm64-v20240213 (ID trsml) in project compute-image-test-pool-001
<testsuites name="" errors="0" failures="2" disabled="0" skipped="0" tests="54" time="0">
	<testsuite name="networkperf-debian-12" tests="48" failures="0" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12" name="TestGVNICExists" time="0.01"></testcase>
		<testcase classname="networkperf-debian-12" name="TestNetworkPerformance" time="0.01"></testcase>
	</testsuite>
	<testsuite name="networkperf-debian-12-arm64" tests="6" failures="2" errors="0" disabled="0" skipped="0" time="0">
		<testcase classname="networkperf-debian-12-arm64" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12-arm64" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12-arm64" name="TestNetworkPerformance" time="0.01">
			<failure type="">    performance_test.go:69: Error: Did not meet performance expectation on machine type t2a-standard-1 with network DEFAULT. Expected: 8.5 Gbits/s, Actual: 1.77 Gbits/s</failure>
		</testcase>
		<testcase classname="networkperf-debian-12-arm64" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12-arm64" name="TestGVNICExists" time="0"></testcase>
		<testcase classname="networkperf-debian-12-arm64" name="TestNetworkPerformance" time="0">
			<failure type="">    performance_test.go:69: Error: Did not meet performance expectation on machine type t2a-standard-1 with network DEFAULT. Expected: 8.5 Gbits/s, Actual: 1.78 Gbits/s</failure>
		</testcase>
	</testsuite>
</testsuites>
2024/02/14 10:56:46 test suite has error or failure
acrate@acrate-p1g4 ~ [1]>
```