### PR TITLE
Avoid line breaks when getting agent output on windows

### DIFF
--- a/imagetest/test_suites/guestagent/telemetry_test.go
+++ b/imagetest/test_suites/guestagent/telemetry_test.go
@@ -41,7 +41,7 @@ func restartAgent(t *testing.T) {
 func getAgentOutput(t *testing.T) string {
 	t.Helper()
 	if utils.IsWindows() {
-		out, err := utils.RunPowershellCmd(`Get-WinEvent -Providername GCEGuestAgent | Format-List -Property Message`)
+		out, err := utils.RunPowershellCmd(`(Get-WinEvent -Providername GCEGuestAgent).Message`)
 		if err != nil {
 			t.Fatalf("could not get agent output: %v", err)
 		}


### PR DESCRIPTION
/cc @jjerger @koln67 

My last attempt still line wrapped in some situations. This just dumps raw output with no formatting, so no more parsing failures.