### PR TITLE
Add secure boot exception for c3 metal images

### DIFF
--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -14,6 +14,7 @@ var Name = "imageboot"
 
 var sbUnsupported = []*regexp.Regexp{
 	// Permanent exceptions
+	regexp.MustCompile("-c3m$"),
 	regexp.MustCompile("debian-1[01].*arm64"),
 	regexp.MustCompile("windows-server-2012-r2-dc-core"), // Working but not easily testable and EOL in 1.5 months
 	// Temporary exceptions


### PR DESCRIPTION
/cc @bkatyl @ajorg 
An `imgpublish-without-testing` step would be better so that we can skip CIT or make it an informational step only for future testing or limited use images, but in the meantime this will let is release this stuff right now.