### PR TITLE
Retry setting guest attributes in the cit manager up to three times

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -43,12 +43,18 @@ func main() {
 	// firstBootSpecialGA should be true if we need to match a different guest attribute than the usual guest attribute
 	defer func(ctx context.Context, firstBootSpecialGA bool) {
 		var err error
-		if firstBootSpecialGA {
-			err = utils.PutMetadata(ctx, path.Join("instance", "guest-attributes", utils.GuestAttributeTestNamespace,
-				utils.FirstBootGAKey), "")
-		} else {
-			err = utils.PutMetadata(ctx, path.Join("instance", "guest-attributes", utils.GuestAttributeTestNamespace,
-				utils.GuestAttributeTestKey), "")
+		for i := 0; i < 3; i++ {
+			if firstBootSpecialGA {
+				err = utils.PutMetadata(ctx, path.Join("instance", "guest-attributes", utils.GuestAttributeTestNamespace,
+					utils.FirstBootGAKey), "")
+			} else {
+				err = utils.PutMetadata(ctx, path.Join("instance", "guest-attributes", utils.GuestAttributeTestNamespace,
+					utils.GuestAttributeTestKey), "")
+			}
+			if err == nil {
+				break
+			}
+			time.Sleep(time.Duration(i) * time.Second)
 		}
 
 		if err != nil {


### PR DESCRIPTION
While I was looking into recent timeouts I noticed some of them were failing to set guest attributes. This this add a three attempt retry with a small backoff after each attempt. Tested locally and both tests that reboot and tests that don't reboot work OK.

/cc @koln67 