### PR TITLE
Switch to C3D for X86_64 disk naming tests

### DIFF
--- a/imagetest/test_suites/disk/setup.go
+++ b/imagetest/test_suites/disk/setup.go
@@ -21,7 +21,7 @@ var (
 			arch:        "ARM64",
 		},
 		{
-			machineType: "c3-standard-4",
+			machineType: "c3d-standard-4",
 			arch:        "X86_64",
 		},
 	}


### PR DESCRIPTION
/cc @elicriffield @drewhli 

I think this should be a less contested resource than c3. Unfortunately there is no clean way to just say "give me a 3rd gen machine type," we still have to specify one with minimum cpu platforms, and the API won't autoselect one if I just specify an nvme interface for the attached disk.