### PR TITLE
Pass timeout into the VM through metadata…

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -66,6 +66,11 @@ func main() {
 		}
 	}(ctx, firstBootSpecialAttribute)
 
+	testTimeout, err := utils.GetMetadata(ctx, "instance", "attributes", "_cit_timeout")
+	if err != nil {
+		log.Fatalf("failed to get metadata _cit_timeout: %v", err)
+	}
+
 	daisyOutsPath, err := utils.GetMetadata(ctx, "instance", "attributes", "daisy-outs-path")
 	if err != nil {
 		log.Fatalf("failed to get metadata daisy-outs-path: %v", err)
@@ -82,7 +87,7 @@ func main() {
 		log.Fatalf("failed to get metadata _test_results_url: %v", err)
 	}
 
-	var testArguments = []string{"-test.v"}
+	var testArguments = []string{"-test.v", "-test.timeout", testTimeout}
 
 	testRun, err := utils.GetMetadata(ctx, "instance", "attributes", "_test_run")
 	if err == nil && testRun != "" {

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -4,9 +4,9 @@
 package network
 
 import (
-	"time"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 	"github.com/go-ping/ping"

--- a/imagetest/test_suites/network/multinic_minimal_network_test.go
+++ b/imagetest/test_suites/network/multinic_minimal_network_test.go
@@ -4,6 +4,8 @@
 package network
 
 import (
+	"time"
+	"context"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
@@ -11,11 +13,12 @@ import (
 )
 
 func TestPingVMToVM(t *testing.T) {
-	primaryIP, err := utils.GetMetadata(utils.Context(t), "instance", "network-interfaces", "0", "ip")
+	ctx := utils.Context(t)
+	primaryIP, err := utils.GetMetadata(ctx, "instance", "network-interfaces", "0", "ip")
 	if err != nil {
 		t.Fatalf("couldn't get internal network IP from metadata, %v", err)
 	}
-	secondaryIP, err := utils.GetMetadata(utils.Context(t), "instance", "network-interfaces", "1", "ip")
+	secondaryIP, err := utils.GetMetadata(ctx, "instance", "network-interfaces", "1", "ip")
 	if err != nil {
 		t.Fatalf("couldn't get internal network IP from metadata, %v", err)
 	}
@@ -24,29 +27,25 @@ func TestPingVMToVM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to determine target vm name: %v", err)
 	}
-	if err := pingTargetRetries(primaryIP, name); err != nil {
+	if err := pingTargetRetries(ctx, primaryIP, name); err != nil {
 		t.Fatalf("failed to ping remote %s via %s (primary network): %v", name, primaryIP, err)
 	}
-	if err := pingTargetRetries(secondaryIP, vm2Config.ip); err != nil {
+	if err := pingTargetRetries(ctx, secondaryIP, vm2Config.ip); err != nil {
 		t.Fatalf("failed to ping remote %s via %s (secondary network): %v", vm2Config.ip, secondaryIP, err)
 	}
 }
 
-// pingTargetRetries pings the target up to retry limit, because remote VM is
-// not guaranteed to be up at start of test.
-func pingTargetRetries(source, target string) error {
-	// 24 (23 + final) retries of 5-second maximum connection attempts for
-	// total of 120 seconds.
-	for i := 0; i < 23; i++ {
-		if err := pingTarget(source, target); err == nil {
+func pingTargetRetries(ctx context.Context, source, target string) error {
+	// Attempt to ping target until context is expired
+	for ctx.Err() == nil {
+		if pingTarget(source, target) == nil {
 			return nil
 		}
 	}
-	return pingTarget(source, target)
+	return ctx.Err()
 }
 
-// pingTarget sends ICMP ping to target from source once a second for 5
-// seconds, expecting 5 responses.
+// send 5 ICMP echo packets and wait a maximum of one second to receieve 5 responses
 func pingTarget(source, target string) error {
 	pinger, err := ping.NewPinger(target)
 	if err != nil {
@@ -55,10 +54,6 @@ func pingTarget(source, target string) error {
 	pinger.SetPrivileged(true)
 	pinger.Source = source
 	pinger.Count = 5
+	pinger.Timeout = time.Second
 	return pinger.Run()
-}
-
-// dummy test for target VM.
-func TestEmptyTest(t *testing.T) {
-	t.Log("vm boot successfully")
 }

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -134,6 +134,7 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 		}
 		createVMStep.CreateInstances = createInstances
 	}
+	instance.Metadata["_cit_timeout"] = t.wf.DefaultTimeout
 
 	return createVMStep, instance, nil
 }
@@ -186,6 +187,7 @@ func (t *TestWorkflow) appendCreateVMStepBeta(disks []*compute.Disk, instance *d
 		}
 		createVMStep.CreateInstances = createInstances
 	}
+	instance.Metadata["_cit_timeout"] = t.wf.DefaultTimeout
 
 	return createVMStep, instance, nil
 }


### PR DESCRIPTION
 pick this up through the wrapper and call the test binary with -test.timeout $timeout

This should also bring some benefit to everything using utils.Context, as context is derived from test timeout.

In TestPingVMToVM, continue until the context is expired and add a one second timeout for individual ping attempts

/cc @drewhli @koln67 