### PR TITLE
Retry partner image validation three times

### DIFF
--- a/concourse/pipelines/partner-image-validations.jsonnet
+++ b/concourse/pipelines/partner-image-validations.jsonnet
@@ -257,6 +257,7 @@ local imagevalidationjob = {
           },
         ],
       },
+      attempts: 3,
       config: imagetesttask {
         images: '((.:partial))',
         extra_args: tl.extra_args,


### PR DESCRIPTION
CIT for partner images is much more reliable now, a lot of test failures are the suites attempting to use the resource before it's ready or flaky zone resource pool exhaustion stuff.

example: http://localhost:8080/teams/guestos/pipelines/partner-image-validations/jobs/ubuntu-pro-2004-lts-arm64/builds/22 retrying this would likely pass on the second attempt

/cc @zmarano @drewhli 