### PR TITLE
Improve suspend testing reliability

### DIFF
--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -79,7 +79,6 @@ func main() {
 		}
 	}(ctx, firstBootSpecialAttribute)
 
-
 	daisyOutsPath, err := utils.GetMetadata(ctx, "instance", "attributes", "daisy-outs-path")
 	if err != nil {
 		log.Fatalf("failed to get metadata daisy-outs-path: %v", err)

--- a/imagetest/cmd/wrapper/main.go
+++ b/imagetest/cmd/wrapper/main.go
@@ -39,7 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to get metadata _cit_timeout: %v", err)
 	}
-	d, err := time.PaseDuration(testTimeout)
+	d, err := time.ParseDuration(testTimeout)
 	if err != nil {
 		log.Fatalf("_cit_timeout %v is not a valid duration: %v", testTimeout, err)
 	}
@@ -121,6 +121,7 @@ func main() {
 	if err = utils.DownloadGCSObjectToFile(ctx, client, testPackageURL, workDir+testPackage); err != nil {
 		log.Fatalf("failed to download object: %v", err)
 	}
+	client.Close()
 
 	log.Printf("sleep 30s to allow environment to stabilize")
 	time.Sleep(30 * time.Second)
@@ -136,6 +137,11 @@ func main() {
 
 	log.Printf("command output:\n%s\n", out)
 
+	client, err = storage.NewClient(ctx)
+	if err != nil {
+		log.Fatalf("failed to create cloud storage client: %v", err)
+	}
+	defer client.Close()
 	if err = uploadGCSObject(ctx, client, resultsURL, bytes.NewReader(out)); err != nil {
 		log.Fatalf("failed to upload test result: %v", err)
 	}

--- a/imagetest/go.mod
+++ b/imagetest/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/oslogin v1.12.2
 	cloud.google.com/go/secretmanager v1.11.4
 	cloud.google.com/go/storage v1.31.0
-	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12
+	github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240305205007-7e89d75c55e6
 	github.com/GoogleCloudPlatform/guest-test-infra/container_images/cleanerupper/go-cleanerupper v0.0.0-20231129203917-db71af465791
 	github.com/go-ping/ping v1.1.0
 	github.com/google/uuid v1.4.0

--- a/imagetest/go.sum
+++ b/imagetest/go.sum
@@ -24,6 +24,8 @@ github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f 
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20230929171844-6a3c47dc7a4f/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12 h1:p/aoXPazJo0ehO3yjg3O4VNbJTO5TAshYIga5fpL1Gw=
 github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240207005040-a283f5d80c12/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240305205007-7e89d75c55e6 h1:CHuiTS82Ylz71ypwm4bAp3Iak4snfxHPvAKTWaCc0EU=
+github.com/GoogleCloudPlatform/compute-daisy v0.0.0-20240305205007-7e89d75c55e6/go.mod h1:zr7ug08Bz1pQZzWmiKYTHuF/+KbbuSFiP74D2pPukGE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -50,7 +50,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm3.AddMetadata("start-time", strconv.Itoa(time.Now().Second()))
 	vm3.RunTests("TestStartTime|TestBootTime")
 
-	if !strings.Contains(t.Image.Name, "sles") && !strings.Contains(t.Image.Name, "rhel-8-2-sap") && !strings.Contains(t.Image.Name, "rhel-8-1-sap") && !strings.Contains(t.Image.Name, "debian-10") {
+	if !strings.Contains(t.Image.Name, "sles") && !strings.Contains(t.Image.Name, "rhel-8-2-sap") && !strings.Contains(t.Image.Name, "rhel-8-1-sap") && !strings.Contains(t.Image.Name, "debian-10") && !strings.Contains(t.Image.Name, "ubuntu-pro-1804-lts-arm64") {
 		suspend := &daisy.Instance{}
 		suspend.Scopes = append(suspend.Scopes, "https://www.googleapis.com/auth/cloud-platform")
 		suspendvm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "suspend"}}, suspend)

--- a/imagetest/test_suites/imageboot/setup.go
+++ b/imagetest/test_suites/imageboot/setup.go
@@ -43,7 +43,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	}
 	vm2.RunTests("TestGuestRebootOnHost")
 
-	vm3, err := t.CreateTestVM("bootime")
+	vm3, err := t.CreateTestVM("boottime")
 	if err != nil {
 		return err
 	}
@@ -58,14 +58,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			return err
 		}
 		suspendvm.RunTests("TestSuspend")
-
-		resume := &daisy.Instance{}
-		resume.Scopes = append(resume.Scopes, "https://www.googleapis.com/auth/cloud-platform")
-		resumevm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "resume"}}, resume)
-		if err != nil {
-			return err
-		}
-		resumevm.RunTests("TestResume")
+		suspendvm.Resume()
 	}
 
 	lm := &daisy.Instance{}

--- a/imagetest/test_suites/imageboot/suspend_resume_test.go
+++ b/imagetest/test_suites/imageboot/suspend_resume_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
@@ -58,46 +57,5 @@ func TestSuspend(t *testing.T) {
 	_, err = http.Get("https://cloud.google.com")
 	if err != nil {
 		t.Errorf("no network connectivity after resume: %v", err)
-	}
-}
-
-func TestResume(t *testing.T) {
-	target, err := utils.GetRealVMName("suspend")
-	if err != nil {
-		t.Fatalf("could not get target name: %v", err)
-	}
-	ctx := utils.Context(t)
-	prj, zone, err := utils.GetProjectZone(ctx)
-	if err != nil {
-		t.Fatalf("could not find project and zone: %v", err)
-	}
-	client, err := compute.NewInstancesRESTClient(ctx)
-	if err != nil {
-		t.Fatalf("could not make compute api client: %v", err)
-	}
-	t.Cleanup(func() { client.Close() })
-	for {
-		if ctx.Err() != nil {
-			t.Fatalf("test ended before instance %s was suspended: %v", target, err)
-		}
-		req := &computepb.GetInstanceRequest{
-			Project:  prj,
-			Zone:     zone,
-			Instance: target,
-		}
-		instance, err := client.Get(ctx, req)
-		if err == nil && *instance.Status == "SUSPENDED" {
-			break
-		}
-		time.Sleep(time.Second * 2)
-	}
-	req := &computepb.ResumeInstanceRequest{
-		Project:  prj,
-		Zone:     zone,
-		Instance: target,
-	}
-	_, err = client.Resume(ctx, req)
-	if err != nil {
-		t.Fatalf("could not resume target: %v", err)
 	}
 }


### PR DESCRIPTION
Waiting on GoogleCloudPlatform/compute-daisy#41
/hold

My local testing shows far less (none so far) flakes on this implementation. I moved the watching for suspension and the resume call to the CIT framework and out of a secondary VM, and close and reopend the connection the GCS before and after executing the test binary so that whatever tests do to the VM has less effect on the test wrapper.