### PR TITLE
Send daisy logs to GCS

### DIFF
--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -628,7 +628,6 @@ func NewTestWorkflow(client daisycompute.Client, computeEndpointOverride, name, 
 	t.wf.DefaultTimeout = timeout
 	t.wf.Zone = zone
 
-	t.wf.DisableGCSLogging()
 	t.wf.DisableCloudLogging()
 	t.wf.DisableStdoutLogging()
 


### PR DESCRIPTION
/cc @zmarano @drewhli 
not sure why this was initially disabled, the PR that disabled it doesn't address it. It's making debugging potential daisy bugs that show up in testgrids a bit difficult.