### PR TITLE
metadata: fix the dnf and yum repo restriction

### DIFF
--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -93,15 +93,11 @@ func TestShutdownScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to clear shutdown script result: %s", err)
 	}
-	if utils.IsWindows() {
-		if err := reinstallPackage("google-compute-engine-windows"); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		if err := reinstallPackage("google-guest-agent"); err != nil {
-			t.Fatal(err)
-		}
+
+	if err := reinstallGuestAgent(); err != nil {
+		t.Fatal(err)
 	}
+
 	result, err = utils.GetMetadata(ctx, "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read shutdown script result key: %v", err)

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -85,15 +85,11 @@ func TestStartupScripts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to clear startup script result: %s", err)
 	}
-	if utils.IsWindows() {
-		if err := reinstallPackage("google-compute-engine-windows"); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		if err := reinstallPackage("google-guest-agent"); err != nil {
-			t.Fatal(err)
-		}
+
+	if err := reinstallGuestAgent(); err != nil {
+		t.Fatal(err)
 	}
+
 	result, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read startup script result key: %v", err)


### PR DESCRIPTION
The repository names for EL distros are pretty stable for guest environment packages, this change fixes it to the known and stable name.