### PR TITLE
Update package_test.go to skip COS in TestStandardPrograms

### DIFF
--- a/imagetest/test_suites/packagevalidation/package_test.go
+++ b/imagetest/test_suites/packagevalidation/package_test.go
@@ -49,6 +49,10 @@ func TestStandardPrograms(t *testing.T) {
 		// SLES/SUSE does not have the Google Cloud SDK installed.
 		t.Skip("Cloud SDK Not supported on SLES/SUSE")
 	}
+	if strings.Contains(image, "cos") {
+		// COS does not have the Google Cloud SDK installed.
+		t.Skip("Cloud SDK Not supported on COS")
+	}
 
 	cmd := exec.Command("gcloud", "-h")
 	cmd.Start()


### PR DESCRIPTION
COS does not ship gcloud and gsutil utilities.