### PR TITLE
Wait for zypper lock for a long time

### DIFF
--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -94,7 +94,7 @@ func TestShutdownScripts(t *testing.T) {
 		t.Fatalf("failed to clear shutdown script result: %s", err)
 	}
 
-	if err := reinstallGuestAgent(); err != nil {
+	if err := reinstallGuestAgent(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/imagetest/test_suites/metadata/startup_script_test.go
+++ b/imagetest/test_suites/metadata/startup_script_test.go
@@ -74,23 +74,24 @@ func testDaemonScriptWindows() error {
 // by checking the output content of the Startup script. It also checks that
 // the script does not run after a reinstall/upgrade of guest agent.
 func TestStartupScripts(t *testing.T) {
-	result, err := utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
+	ctx := utils.Context(t)
+	result, err := utils.GetMetadata(ctx, "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read startup script result key: %v", err)
 	}
 	if result != expectedStartupContent {
 		t.Fatalf(`startup script output expected "%s", got "%s".`, expectedStartupContent, result)
 	}
-	err = utils.PutMetadata(utils.Context(t), path.Join("instance", "guest-attributes", "testing", "result"), "")
+	err = utils.PutMetadata(ctx, path.Join("instance", "guest-attributes", "testing", "result"), "")
 	if err != nil {
 		t.Fatalf("failed to clear startup script result: %s", err)
 	}
 
-	if err := reinstallGuestAgent(); err != nil {
+	if err := reinstallGuestAgent(ctx); err != nil {
 		t.Fatal(err)
 	}
 
-	result, err = utils.GetMetadata(utils.Context(t), "instance", "guest-attributes", "testing", "result")
+	result, err = utils.GetMetadata(ctx, "instance", "guest-attributes", "testing", "result")
 	if err != nil {
 		t.Fatalf("failed to read startup script result key: %v", err)
 	}


### PR DESCRIPTION
Fix for metadata-sles-12.TestStartupScripts failures.

Waiting forever would be ideal but older versions of libzypp are bugged. Since we're waiting for such a long time, plumb a context through reinstallGuestAgent so that we kill the process when the test times out.

/cc @drewhli @koln67 