### PR TITLE
Mark tests not skipped or run as disabled

### DIFF
--- a/imagetest/junit.go
+++ b/imagetest/junit.go
@@ -52,12 +52,17 @@ type testSuite struct {
 }
 
 type testCase struct {
-	Classname string        `xml:"classname,attr"`
-	Name      string        `xml:"name,attr"`
-	Time      float64       `xml:"time,attr"`
-	Skipped   *junitSkipped `xml:"skipped,omitempty"`
-	Failure   *junitFailure `xml:"failure,omitempty"`
-	SystemOut string        `xml:"system-out,omitempty"`
+	Classname string         `xml:"classname,attr"`
+	Name      string         `xml:"name,attr"`
+	Time      float64        `xml:"time,attr"`
+	Skipped   *junitSkipped  `xml:"skipped,omitempty"`
+	Disabled  *junitDisabled `xml:"disabled,omitempty"`
+	Failure   *junitFailure  `xml:"failure,omitempty"`
+	SystemOut string         `xml:"system-out,omitempty"`
+}
+
+type junitDisabled struct {
+	Message string `xml:"message,attr"`
 }
 
 type junitSkipped struct {

--- a/imagetest/test_suites/metadata/shutdown_script_test.go
+++ b/imagetest/test_suites/metadata/shutdown_script_test.go
@@ -132,7 +132,7 @@ func TestShutdownURLScripts(t *testing.T) {
 }
 
 // Determine if the OS is Windows or Linux and run the appropriate shutdown time test.
-func TestShutDownScriptTime(t *testing.T) {
+func TestShutdownScriptTime(t *testing.T) {
 	if utils.IsWindows() {
 		if err := testShutdownScriptTimeWindows(); err != nil {
 			t.Fatalf("Shutdown script time test failed with error: %v", err)


### PR DESCRIPTION
This provides a clearer signal for alerting on. It also makes which tests are and aren't run clearer to humans reading results.

Here is an example of the problem: https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics&include-filter-by-regex=metadata-sles-12

When a test encounters a workflow failure every test in the suite is marked as failing. Then later when the results are executing correctly, if one of those tests isn't run on an image there are no new results. This means alerts that fire on metadata-sles-12.TestShutDownScriptTime will fire forever because the test doesn't have new results after the failures. 

This also provides a clearer signal to humans when tests aren't being executed (intentionally or unintentionally) like the issue I just discovered that TestShutdownScriptTime isn't executed on any image because it's spelled TestShutdownScriptTime in one place and TestShutDownScriptTime in another. This PR also enables that test.