### PR TITLE
Update setup.go to skip alias tests for COS images

### DIFF
--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -64,7 +64,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm1.RunTests("TestPingVMToVM|TestDHCP|TestDefaultMTU")
 
 	multinictests := "TestStaticIP"
-	if !utils.HasFeature(t.Image, "WINDOWS") && !strings.Contains(t.Image.Name, "sles-15") && !strings.Contains(t.Image.Name, "opensuse-leap") && !strings.Contains(t.Image.Name, "ubuntu-1604") && !strings.Contains(t.Image.Name, "ubuntu-pro-1604") {
+	if !utils.HasFeature(t.Image, "WINDOWS") && !strings.Contains(t.Image.Name, "sles-15") && !strings.Contains(t.Image.Name, "opensuse-leap") && !strings.Contains(t.Image.Name, "ubuntu-1604") && !strings.Contains(t.Image.Name, "ubuntu-pro-1604") && !strings.Contains(t.Image.Name, "cos") {
 		multinictests += "|TestAlias"
 	}
 


### PR DESCRIPTION
COS has ip_alias=False in our instance_config file, we can skip the alias tests on COS.