### PR TITLE
Enforce a lack of dashes in testworkflow vm names.

### DIFF
--- a/imagetest/fixtures.go
+++ b/imagetest/fixtures.go
@@ -897,7 +897,7 @@ func (t *TestWorkflow) appendCreateFirewallStep(firewallName, networkName, proto
 
 // AddSSHKey generate ssh key pair and return public key.
 func (t *TestWorkflow) AddSSHKey(user string) (string, error) {
-	keyFileName := "/id_rsa_" + uuid.New().String()
+	keyFileName := os.TempDir() + "/id_rsa_" + uuid.New().String()
 	if _, err := os.Stat(keyFileName); os.IsExist(err) {
 		os.Remove(keyFileName)
 	}

--- a/imagetest/test_suites/cvm/setup.go
+++ b/imagetest/test_suites/cvm/setup.go
@@ -11,8 +11,6 @@ import (
 // Name is the name of the test package. It must match the directory name.
 var Name = "cvm"
 
-const vmName = "vm"
-
 // TestSetup sets up test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
 	for _, feature := range t.Image.GuestOsFeatures {
@@ -20,7 +18,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		case "SEV_CAPABLE":
 			sevtests := "TestSEVEnabled"
 			vm := &daisy.InstanceBeta{}
-			vm.Name = vmName + "-SEV"
+			vm.Name = "sev"
 			vm.ConfidentialInstanceConfig = &computeBeta.ConfidentialInstanceConfig{
 				ConfidentialInstanceType:  "SEV",
 				EnableConfidentialCompute: true,
@@ -34,7 +32,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			}
 			vm.MachineType = "n2d-standard-2"
 			vm.MinCpuPlatform = "AMD Milan"
-			disks := []*compute.Disk{{Name: vmName + "-SEV", Type: imagetest.PdBalanced}}
+			disks := []*compute.Disk{{Name: vm.Name, Type: imagetest.PdBalanced}}
 			tvm, err := t.CreateTestVMFromInstanceBeta(vm, disks)
 			if err != nil {
 				return err
@@ -42,7 +40,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			tvm.RunTests(sevtests)
 		case "SEV_SNP_CAPABLE":
 			vm := &daisy.InstanceBeta{}
-			vm.Name = vmName + "-SEVSNP"
+			vm.Name = "sevsnp"
 			vm.Zone = "us-central1-a" // SEV_SNP not available in all regions
 			vm.ConfidentialInstanceConfig = &computeBeta.ConfidentialInstanceConfig{
 				ConfidentialInstanceType:  "SEV_SNP",
@@ -52,7 +50,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			vm.MachineType = "n2d-standard-2"
 			vm.MinCpuPlatform = "AMD Milan"
 			disks := []*compute.Disk{
-				{Name: vmName + "-SEVSNP", Type: imagetest.PdBalanced, Zone: "us-central1-a"},
+				{Name: vm.Name, Type: imagetest.PdBalanced, Zone: "us-central1-a"},
 			}
 			tvm, err := t.CreateTestVMFromInstanceBeta(vm, disks)
 			if err != nil {
@@ -61,7 +59,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			tvm.RunTests("TestSEVSNPEnabled")
 		case "TDX_CAPABLE":
 			vm := &daisy.InstanceBeta{}
-			vm.Name = vmName + "-TDX"
+			vm.Name = "tdx"
 			vm.Zone = "us-central1-a" // TDX not available in all regions
 			vm.ConfidentialInstanceConfig = &computeBeta.ConfidentialInstanceConfig{
 				ConfidentialInstanceType:  "TDX",
@@ -71,7 +69,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			vm.MachineType = "c3-standard-2"
 			vm.MinCpuPlatform = "Intel Sapphire Rapids"
 			disks := []*compute.Disk{
-				{Name: vmName + "-TDX", Type: imagetest.PdBalanced, Zone: "us-central1-a"},
+				{Name: vm.Name, Type: imagetest.PdBalanced, Zone: "us-central1-a"},
 			}
 			tvm, err := t.CreateTestVMFromInstanceBeta(vm, disks)
 			if err != nil {

--- a/imagetest/test_suites/disk/setup.go
+++ b/imagetest/test_suites/disk/setup.go
@@ -1,6 +1,8 @@
 package disk
 
 import (
+	"strings"
+
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
@@ -28,7 +30,6 @@ var (
 )
 
 const (
-	vmName         = "vm"
 	resizeDiskSize = 200
 )
 
@@ -36,7 +37,7 @@ const (
 func TestSetup(t *imagetest.TestWorkflow) error {
 	rebootInst := &daisy.Instance{}
 	rebootInst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: vmName}}, rebootInst)
+	vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "resize"}}, rebootInst)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,8 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			}
 			inst := &daisy.Instance{}
 			inst.MachineType = tc.machineType
-			inst.Name = "test-block-naming-" + tc.machineType
+			series, _, _ := strings.Cut(tc.machineType, "-")
+			inst.Name = "blockNaming" + strings.ToUpper(series)
 			vm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: inst.Name, Type: imagetest.PdBalanced}, {Name: "secondary", Type: imagetest.PdBalanced, SizeGb: 10}}, inst)
 			if err != nil {
 				return err

--- a/imagetest/test_suites/guestagent/setup.go
+++ b/imagetest/test_suites/guestagent/setup.go
@@ -26,7 +26,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	telemetrydisabledinst := &daisy.Instance{}
 	telemetrydisabledinst.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
-	telemetrydisabledinst.Name = "telemetry-disabled"
+	telemetrydisabledinst.Name = "telemetryDisabled"
 	telemetrydisabledvm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: telemetrydisabledinst.Name, Type: imagetest.PdBalanced}}, telemetrydisabledinst)
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	telemetryenabledinst := &daisy.Instance{}
 	telemetryenabledinst.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
-	telemetryenabledinst.Name = "telemetry-enabled"
+	telemetryenabledinst.Name = "telemetryEnabled"
 	telemetryenabledvm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: telemetryenabledinst.Name, Type: imagetest.PdBalanced}}, telemetryenabledinst)
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	snapshotinst := &daisy.Instance{}
 	snapshotinst.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
-	snapshotinst.Name = "snapshot-scripts"
+	snapshotinst.Name = "snapshotScripts"
 	snapshotvm, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: snapshotinst.Name, Type: imagetest.PdBalanced}}, snapshotinst)
 	if err != nil {
 		return err

--- a/imagetest/test_suites/hotattach/setup.go
+++ b/imagetest/test_suites/hotattach/setup.go
@@ -11,7 +11,6 @@ import (
 var Name = "hotattach"
 
 const (
-	instanceName   = "hotattachvm"
 	bootDiskSizeGB = 10
 
 	// the path to write the file on linux
@@ -25,7 +24,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	hotattachInst := &daisy.Instance{}
 	hotattachInst.Scopes = append(hotattachInst.Scopes, "https://www.googleapis.com/auth/cloud-platform")
 
-	hotattach, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: instanceName + "-pdbalanced", Type: imagetest.PdBalanced, SizeGb: bootDiskSizeGB}, {Name: "hotattachmount", Type: imagetest.PdBalanced, SizeGb: 30}}, hotattachInst)
+	hotattach, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "reattachPDBalanced", Type: imagetest.PdBalanced, SizeGb: bootDiskSizeGB}, {Name: "hotattachmount", Type: imagetest.PdBalanced, SizeGb: 30}}, hotattachInst)
 	if err != nil {
 		return err
 	}
@@ -37,7 +36,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		lssdMountInst.Zone = "us-east4-b"
 		lssdMountInst.MachineType = "c3-standard-8-lssd"
 
-		lssdMount, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Zone: "us-east4-b", Name: instanceName + "-lssd", Type: imagetest.PdBalanced, SizeGb: bootDiskSizeGB}}, lssdMountInst)
+		lssdMount, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Zone: "us-east4-b", Name: "remountLSSD", Type: imagetest.PdBalanced, SizeGb: bootDiskSizeGB}}, lssdMountInst)
 		if err != nil {
 			return err
 		}

--- a/imagetest/test_suites/metadata/setup.go
+++ b/imagetest/test_suites/metadata/setup.go
@@ -35,14 +35,14 @@ var scripts embed.FS
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
 
-	vm, err := t.CreateTestVM("vm")
+	vm, err := t.CreateTestVM("mdscommunication")
 	if err != nil {
 		return err
 	}
 
 	vm2Inst := &daisy.Instance{}
 	vm2Inst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm2"}}, vm2Inst)
+	vm2, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "shutdownscripts"}}, vm2Inst)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	vm3Inst := &daisy.Instance{}
 	vm3Inst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm3, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm3"}}, vm3Inst)
+	vm3, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "shutdownscriptsfailed"}}, vm3Inst)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	vm4Inst := &daisy.Instance{}
 	vm4Inst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm4, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm4"}}, vm4Inst)
+	vm4, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "shutdownurlscripts"}}, vm4Inst)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 
 	vm5Inst := &daisy.Instance{}
 	vm5Inst.Metadata = map[string]string{imagetest.ShouldRebootDuringTest: "true"}
-	vm5, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "vm5"}}, vm5Inst)
+	vm5, err := t.CreateTestVMMultipleDisks([]*compute.Disk{{Name: "shutdownscripttime"}}, vm5Inst)
 	if err != nil {
 		return err
 	}
@@ -84,19 +84,19 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		return err
 	}
 
-	vm6, err := t.CreateTestVM("vm6")
+	vm6, err := t.CreateTestVM("startupscripts")
 	if err != nil {
 		return err
 	}
 	vm6.AddMetadata("enable-guest-attributes", "TRUE")
 
-	vm7, err := t.CreateTestVM("vm7")
+	vm7, err := t.CreateTestVM("startupscriptsfailed")
 	if err != nil {
 		return err
 	}
 	vm7.AddMetadata("enable-guest-attributes", "TRUE")
 
-	vm8, err := t.CreateTestVM("vm8")
+	vm8, err := t.CreateTestVM("daemonscripts")
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/network/setup.go
+++ b/imagetest/test_suites/network/setup.go
@@ -18,8 +18,8 @@ type InstanceConfig struct {
 	ip   string
 }
 
-var vm1Config = InstanceConfig{name: "vm1", ip: "192.168.0.2"}
-var vm2Config = InstanceConfig{name: "vm2", ip: "192.168.0.3"}
+var vm1Config = InstanceConfig{name: "ping1", ip: "192.168.0.2"}
+var vm2Config = InstanceConfig{name: "ping2", ip: "192.168.0.3"}
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {

--- a/imagetest/test_suites/networkperf/setup.go
+++ b/imagetest/test_suites/networkperf/setup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"regexp"
+	"strings"
 
 	daisy "github.com/GoogleCloudPlatform/compute-daisy"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
@@ -298,7 +299,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				defaultPerfTarget := fmt.Sprint(defaultPerfTargetInt)
 
 				// Default VMs.
-				serverDisk := compute.Disk{Name: serverConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				serverDisk := compute.Disk{Name: strings.ReplaceAll(serverConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				serverVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&serverDisk}, nil)
 				if err != nil {
 					return err
@@ -312,7 +313,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 					return err
 				}
 
-				clientDisk := compute.Disk{Name: clientConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				clientDisk := compute.Disk{Name: strings.ReplaceAll(clientConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				clientVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&clientDisk}, nil)
 				if err != nil {
 					return err
@@ -331,7 +332,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				clientVM.AddMetadata("network-tier", net)
 
 				// Jumbo frames VMs.
-				jfServerDisk := compute.Disk{Name: jfServerConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				jfServerDisk := compute.Disk{Name: strings.ReplaceAll(jfServerConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				jfServerVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&jfServerDisk}, nil)
 				if err != nil {
 					return err
@@ -345,7 +346,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 					return err
 				}
 
-				jfClientDisk := compute.Disk{Name: jfClientConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				jfClientDisk := compute.Disk{Name: strings.ReplaceAll(jfClientConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				jfClientVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&jfClientDisk}, nil)
 				jfClientVM.ForceMachineType(tc.machineType)
 				jfClientVM.ForceZone(zone)
@@ -408,7 +409,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				tier1PerfTarget := fmt.Sprint(tier1PerfTargetInt)
 
 				// Tier 1 VMs.
-				t1ServerDisk := compute.Disk{Name: tier1ServerConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				t1ServerDisk := compute.Disk{Name: strings.ReplaceAll(tier1ServerConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				tier1ServerVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&t1ServerDisk}, nil)
 				if err != nil {
 					return err
@@ -423,7 +424,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 				}
 				tier1ServerVM.SetNetworkPerformanceTier("TIER_1")
 
-				t1ClientDisk := compute.Disk{Name: tier1ClientConfig.name + "-" + tc.machineType, Type: diskType, Zone: zone}
+				t1ClientDisk := compute.Disk{Name: strings.ReplaceAll(tier1ClientConfig.name+"-"+tc.machineType, "-", ""), Type: diskType, Zone: zone}
 				tier1ClientVM, err := t.CreateTestVMMultipleDisks([]*compute.Disk{&t1ClientDisk}, nil)
 				if err != nil {
 					return err

--- a/imagetest/test_suites/packagevalidation/setup.go
+++ b/imagetest/test_suites/packagevalidation/setup.go
@@ -10,7 +10,7 @@ var Name = "packagevalidation"
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm1, err := t.CreateTestVM("vm1")
+	vm1, err := t.CreateTestVM("installedPackages")
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	// are only used to run windows tests. The tests themselves
 	// have components which need to be run on different vms.
 	if utils.HasFeature(t.Image, "WINDOWS") {
-		vm2, err := t.CreateTestVM("vm2")
+		vm2, err := t.CreateTestVM("googetFunctionality")
 		if err != nil {
 			return err
 		}
@@ -31,14 +31,14 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 			return err
 		}
 		vm3.RunTests("TestRepoManagement")
-		vm4, err := t.CreateTestVM("vm4")
+		vm4, err := t.CreateTestVM("repoManagement")
 		if err != nil {
 			return err
 		}
 		vm4.RunTests("TestNetworkDriverLoaded|TestDriversInstalled|TestDriversRemoved")
 		// the former windows_image_validation test suite tests are run by this VM.
 		// It may make sense to move some of these tests to other suites in the future.
-		vm5, err := t.CreateTestVM("vm5")
+		vm5, err := t.CreateTestVM("drivers")
 		if err != nil {
 			return err
 		}

--- a/imagetest/test_suites/security/setup.go
+++ b/imagetest/test_suites/security/setup.go
@@ -7,7 +7,7 @@ var Name = "security"
 
 // TestSetup sets up the test workflow.
 func TestSetup(t *imagetest.TestWorkflow) error {
-	vm, err := t.CreateTestVM("vm")
+	vm, err := t.CreateTestVM("securitySetttings")
 	vm.AddMetadata("enable-windows-ssh", "true")
 	vm.AddMetadata("sysprep-specialize-script-cmd", "googet -noconfirm=true install google-compute-engine-ssh")
 	return err

--- a/imagetest/test_suites/shapevalidation/setup.go
+++ b/imagetest/test_suites/shapevalidation/setup.go
@@ -79,7 +79,7 @@ var x86shapes = map[string]*shape{
 		mem:             1488,
 		numa:            2,
 		zone:            "us-east5-b",
-		disks:           []*compute.Disk{{Name: "C4-192", Type: imagetest.HyperdiskBalanced, Zone: "us-east5-b"}},
+		disks:           []*compute.Disk{{Name: "C4", Type: imagetest.HyperdiskBalanced, Zone: "us-east5-b"}},
 		quota:           &daisy.QuotaAvailable{Metric: "CPUS", Units: 192, Region: "us-east5"},
 		requireFeatures: []string{"GVNIC"},
 	},

--- a/imagetest/test_suites/sql/setup.go
+++ b/imagetest/test_suites/sql/setup.go
@@ -17,8 +17,8 @@ type InstanceConfig struct {
 	ip   string
 }
 
-var serverConfig = InstanceConfig{name: "server-vm", ip: "192.168.0.10"}
-var clientConfig = InstanceConfig{name: "client-vm", ip: "192.168.0.11"}
+var serverConfig = InstanceConfig{name: "server", ip: "192.168.0.10"}
+var clientConfig = InstanceConfig{name: "client", ip: "192.168.0.11"}
 
 //go:embed *
 var scripts embed.FS
@@ -85,7 +85,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		serverVM.AddMetadata("windows-startup-script-ps1", serverStartup)
 		clientVM.AddMetadata("windows-startup-script-ps1", clientStartup)
 
-		vm1, err := t.CreateTestVM("vm1")
+		vm1, err := t.CreateTestVM("settings")
 		if err != nil {
 			return err
 		}

--- a/imagetest/test_suites/ssh/setup.go
+++ b/imagetest/test_suites/ssh/setup.go
@@ -16,7 +16,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if err != nil {
 		return err
 	}
-	vm, err := t.CreateTestVM("vm")
+	vm, err := t.CreateTestVM("client")
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm.AddMetadata("sysprep-specialize-script-cmd", "googet -noconfirm=true install google-compute-engine-ssh")
 	vm.RunTests("TestSSHInstanceKey|TestHostKeysAreUnique|TestMatchingKeysInGuestAttributes")
 
-	vm2, err := t.CreateTestVM("vm2")
+	vm2, err := t.CreateTestVM("server")
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm2.AddMetadata("sysprep-specialize-script-cmd", "googet -noconfirm=true install google-compute-engine-ssh")
 	vm2.RunTests("TestEmptyTest")
 
-	vm3, err := t.CreateTestVM("vm3")
+	vm3, err := t.CreateTestVM("hostkeysafteragentrestart")
 	if err != nil {
 		return err
 	}

--- a/imagetest/test_suites/storageperf/setup.go
+++ b/imagetest/test_suites/storageperf/setup.go
@@ -185,7 +185,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 		if bootdiskSizeGB == mountdiskSizeGB {
 			mountdiskSizeGB++
 		}
-		bootDisk := &compute.Disk{Name: vmName + tc.machineType + tc.diskType, Type: tc.bootDiskType, SizeGb: bootdiskSizeGB, Zone: tc.zone}
+		bootDisk := &compute.Disk{Name: strings.ReplaceAll(tc.machineType+tc.diskType, "-", ""), Type: tc.bootDiskType, SizeGb: bootdiskSizeGB, Zone: tc.zone}
 		disks := []*compute.Disk{bootDisk}
 
 		if tc.diskType != "lssd" {

--- a/imagetest/test_suites/storageperf/storage_perf_utils.go
+++ b/imagetest/test_suites/storageperf/storage_perf_utils.go
@@ -25,7 +25,6 @@ type PerformanceTargets struct {
 }
 
 const (
-	vmName = "vm"
 	// iopsErrorMargin allows for a small difference between iops found in the test and the iops value listed in public documentation.
 	iopsErrorMargin = 0.85
 	bootdiskSizeGB  = 50

--- a/imagetest/testworkflow.go
+++ b/imagetest/testworkflow.go
@@ -89,6 +89,9 @@ func (t *TestWorkflow) appendCreateVMStep(disks []*compute.Disk, instanceParams 
 	}
 	// The boot disk is the first disk, and the VM name comes from that
 	name := disks[0].Name
+	if strings.Contains(name, "-") {
+		return nil, nil, fmt.Errorf("dashes are disallowed in testworkflow vm names: %s", name)
+	}
 
 	var suffix string
 	if utils.HasFeature(t.Image, "WINDOWS") {


### PR DESCRIPTION
The utils.GetRealVMName relies on this convention even though it's completely unenforced, meaning it doesn't work unless the test author complied. This enforces it. Also use a proper temp dir for ssh test setup in the manager.

/cc @drewhli @koln67 