### PR TITLE
package build: disable debian-10 backport repos

### DIFF
--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -33,6 +33,9 @@ gsutil cp "${SRC_PATH}/common.sh" ./
 
 deploy_sbomutil
 
+# disable the backports repo for debian-10
+sed -i 's/^.*debian buster-backports main.*$//g' /etc/apt/sources.list
+
 try_command apt-get -y update
 try_command apt-get install -y --no-install-{suggests,recommends} git-core \
   debhelper devscripts build-essential equivs libdistro-info-perl


### PR DESCRIPTION
It seems the repository lost its Release file, for now we are disabling the repository as we don't need them for package builds.