### PR TITLE
Make CIT's post-testworkflow cleanerupper more aggressive

### DIFF
--- a/imagetest/cleanerupper/cleanerupper.go
+++ b/imagetest/cleanerupper/cleanerupper.go
@@ -165,31 +165,31 @@ func WorkflowPolicy(id string) PolicyFunc {
 			name = r.Name
 			desc = r.Description
 		case *compute.Disk:
+			desc = r.Description
 			labels = r.Labels
 			name = r.Name
-			desc = r.Description
 		case *compute.Image:
+			desc = r.Description
 			labels = r.Labels
 			name = r.Name
-			desc = r.Description
 		case *compute.Snapshot:
+			desc = r.Description
 			labels = r.Labels
 			name = r.Name
-			desc = r.Description
 		case *compute.Instance:
+			desc = r.Description
 			if r.DeletionProtection {
 				return false
 			}
 			labels = r.Labels
 			name = r.Name
-			desc = r.Description
 		default:
 			return false
 		}
 		if _, keep := labels[keepLabel]; keep {
 			return false
 		}
-		return strings.HasSuffix(name, id) && strings.Contains(desc, `created by Daisy in workflow "`+id+`"`) && !strings.Contains(desc, keepLabel)
+		return strings.HasSuffix(name, id) && !strings.Contains(desc, keepLabel)
 	}
 }
 

--- a/imagetest/cleanerupper/cleanerupper_test.go
+++ b/imagetest/cleanerupper/cleanerupper_test.go
@@ -230,12 +230,6 @@ func TestWorkflowPolicy(t *testing.T) {
 			resource: &compute.Instance{Name: "network-asdf", Description: "created by Daisy in workflow \"asdf\" on behalf of root. do-not-delete"},
 			output:   false,
 		},
-		{
-			name:     "Different workflow in description",
-			wfID:     "asdf",
-			resource: &compute.Instance{Name: "network-asdf", Description: "created by Daisy in workflow \"1234\" on behalf of root."},
-			output:   false,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Match only the workflow name. This will allow this hook to clean up things created in test binaries since they usually don't set a description but reuse the workflow id.