### PR TITLE
Require n4 shapevalidation for linux image releases

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -20,7 +20,7 @@ local imagetesttask = common.imagetesttask {
 
 local prepublishtesttask = common.imagetesttask {
   filter: '(shapevalidation)', // TODO enable oslogin
-  extra_args: [ '-shapevalidation_test_filter=^[A-Z][0-3]' ],
+  extra_args: [ '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 
 local imgbuildjob = {


### PR DESCRIPTION
/cc @elicriffield @zmarano 