### PR TITLE
Fix issues with CIT in windows

### DIFF
--- a/imagetest/test_suites/guestagent/windows_password_test.go
+++ b/imagetest/test_suites/guestagent/windows_password_test.go
@@ -153,7 +153,7 @@ func resetPassword(client daisyCompute.Client, t *testing.T) (string, error) {
 	t.Logf("Set new 'windows-keys' metadata to %s", winKeys)
 
 	t.Log("Fetching encrypted password")
-	var trys int
+	var attempts int
 	var ep string
 	for {
 		if err := ctx.Err(); err != nil {
@@ -164,10 +164,10 @@ func resetPassword(client daisyCompute.Client, t *testing.T) (string, error) {
 		if err == nil {
 			break
 		}
-		if trys > 5 {
+		if attempts > 5 {
 			return "", err
 		}
-		trys++
+		attempts++
 	}
 
 	t.Log("Decrypting password")

--- a/imagetest/test_suites/guestagent/windows_password_test.go
+++ b/imagetest/test_suites/guestagent/windows_password_test.go
@@ -156,12 +156,15 @@ func resetPassword(client daisyCompute.Client, t *testing.T) (string, error) {
 	var trys int
 	var ep string
 	for {
-		time.Sleep(1 * time.Second)
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("context expired before successfully fetching encrypted password: %v", err)
+		}
+		time.Sleep(time.Minute)
 		ep, err = getEncryptedPassword(client, winKey.Modulus, instanceName, projectID, zone)
 		if err == nil {
 			break
 		}
-		if trys > 10 {
+		if trys > 5 {
 			return "", err
 		}
 		trys++

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -519,7 +519,7 @@ func validateSocketsWindows(t *testing.T) {
 			t.Errorf("could not find process name listening on port %d", p)
 		}
 		pname := strings.TrimSpace(owningprocess.Stdout)
-		if p > 49152 && pname == "svchost" {
+		if p > 49152 && (pname == "svchost" || pname == "Idle") {
 			continue
 		}
 		t.Errorf("found udp listener on unexpected port %d (process name %s)", p, pname)

--- a/imagetest/test_suites/security/image_security_test.go
+++ b/imagetest/test_suites/security/image_security_test.go
@@ -542,6 +542,10 @@ func validateSocketsWindows(t *testing.T) {
 			continue
 		case 445: // microsoft-ds
 			continue
+		case 1433: // sql server
+			continue
+		case 1434: // sql server
+			continue
 		case 3389: // rdp
 			continue
 		case 5985: // winrm

--- a/imagetest/test_suites/winrm/setup.go
+++ b/imagetest/test_suites/winrm/setup.go
@@ -1,8 +1,6 @@
 package winrm
 
 import (
-	"math/rand"
-
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest"
 	"github.com/GoogleCloudPlatform/guest-test-infra/imagetest/utils"
 )
@@ -17,7 +15,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if !utils.HasFeature(t.Image, "WINDOWS") {
 		return nil
 	}
-	passwd := genPw(14)
+	passwd := utils.ValidWindowsPassword(15)
 
 	vm, err := t.CreateTestVM("client")
 	if err != nil {
@@ -34,15 +32,4 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	vm2.RunTests("TestWaitForWinrmConnection")
 
 	return nil
-}
-
-func genPw(length int) string {
-	const allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-!@#$%^&*+"
-
-	str := make([]byte, length)
-	for i := 0; i < length; i++ {
-		str[i] = allowedChars[rand.Intn(len(allowedChars))]
-	}
-
-	return string(str)
 }


### PR DESCRIPTION
Surface unexpected service states more clearly

Wait longer for windows password reset test

Allow sql server port listeners and idle listeners on dynamic ports

Make sure passwords meet complexity requirements in winrm test

/cc @koln67 @drewhli 