### PR TITLE
Allow 14 char passwords and use one in winrm

### DIFF
--- a/imagetest/test_suites/winrm/setup.go
+++ b/imagetest/test_suites/winrm/setup.go
@@ -15,7 +15,7 @@ func TestSetup(t *imagetest.TestWorkflow) error {
 	if !utils.HasFeature(t.Image, "WINDOWS") {
 		return nil
 	}
-	passwd := utils.ValidWindowsPassword(15)
+	passwd := utils.ValidWindowsPassword(14)
 
 	vm, err := t.CreateTestVM("client")
 	if err != nil {

--- a/imagetest/utils/test_utils.go
+++ b/imagetest/utils/test_utils.go
@@ -551,7 +551,7 @@ func Context(t *testing.T) context.Context {
 // meets Windows complexity requirements.
 func ValidWindowsPassword(userPwLgth int) string {
 	var pwLgth int
-	minPwLgth := 15
+	minPwLgth := 14
 	maxPwLgth := 255
 	lower := []byte("abcdefghijklmnopqrstuvwxyz")
 	upper := []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
Fixes this failure: https://console.cloud.google.com/storage/browser/_details/gcp-guest-cloud-test-outputs/2024-04-25T10:52:30Z/winrm/windows-server-2016-dc-core-v20240415/daisy-winrm-20240425-13:07:14-716br/logs/server-winrm-716br-serial-port1.log;tab=live_object