### PR TITLE
Pass in image family (not full path to image family)

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -513,7 +513,7 @@ local build_guest_agent = buildpackagejob {
           },
           buildpackageimagetaskcos {
             image_name: 'cos-113',
-            source_image: 'projects/cos-cloud/global/images/family/cos-113-lts',
+            source_image: 'cos-113-lts',
             dest_image: 'cos-113-((.:build-id))',
             commit_sha: '((.:commit-sha))',
             cos_branch: 'release-R113'


### PR DESCRIPTION
The preloading script only needs the image family name, the full path is not needed. This is because cos-customizer (how preloading is implemented) doesn't take the full path.

The preloading script will get the path from the other args passed in (for ex: _BASE_IMAGE_PROJECT in compute-image-tools).