### PR TITLE
Update CIT to run only during testing publish for Windows

### DIFF
--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -388,9 +388,9 @@ local imgpublishjob = {
   // Builds are automatically pushed to testing.
   trigger:: true,
 
-  // Run CIT on server and sql when publishing to testing
-  runtests:: if job.env == 'testing' then true
-    else false,
+  // Run CIT by default on server and sql
+  runtests:: if std.length(std.findSubstr("server", job.image)) > 0 || std.length(std.findSubstr("sql", job.image)) > 0 then true
+  else false,
 
   // Start of job.
   name: 'publish-to-testing-%s' % [job.image],

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -388,9 +388,9 @@ local imgpublishjob = {
   // Builds are automatically pushed to testing.
   trigger:: true,
 
-  // Run CIT by default on server and sql
-  runtests:: if std.length(std.findSubstr("server", job.image)) > 0 || std.length(std.findSubstr("sql", job.image)) > 0 then true
-  else false,
+  // Run CIT on server and sql when publishing to testing
+  runtests:: if job.env == 'testing' then true
+    else false,
 
   // Start of job.
   name: 'publish-to-testing-%s' % [job.image],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -476,8 +476,8 @@ local imgpublishjob = {
     else if job.env == 'client' then true
     else false,
 
-  // Run CIT on server and sql when publishing to testing
-  runtests:: if job.env == 'testing' then true
+  // Run tests on server and sql images
+  runtests:: if (std.length(std.findSubstr("server", job.image)) > 0 || std.length(std.findSubstr("sql", job.image)) > 0) && job.env == 'testing' then true
     else false,
 
   // Start of job.

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -477,7 +477,8 @@ local imgpublishjob = {
     else false,
 
   // Run CIT on server and sql when publishing to testing
-  runtests:: if job.env == 'testing' then true else false,
+  runtests:: if job.env == 'testing' then true
+    else false,
 
   // Start of job.
   name: 'publish-to-%s-%s' % [job.env, job.image],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -476,9 +476,8 @@ local imgpublishjob = {
     else if job.env == 'client' then true
     else false,
 
-  // Run tests on server and sql images
-  runtests:: if std.length(std.findSubstr("server", job.image)) > 0 || std.length(std.findSubstr("sql", job.image)) > 0 then true
-  else false,
+  // Run CIT on server and sql when publishing to testing
+  runtests:: if job.env == 'testing' then true else false,
 
   // Start of job.
   name: 'publish-to-%s-%s' % [job.env, job.image],


### PR DESCRIPTION
Probably to be moved to prod when we can fully automate the publish process. For now, we don't want to run the tests on publish-to-prod as thats the final human step to send it to ARLE, and we should be blocking on publish-to-testing if CIT fails.