### PR TITLE
Move guest-agent stable branch to topic-stable.

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1072,7 +1072,7 @@ local build_and_upload_guest_agent = build_guest_agent {
       type: 'git',
       source: {
         uri: 'https://github.com/GoogleCloudPlatform/guest-agent.git',
-        branch: 'stable',
+        branch: 'topic-stable',
         fetch_tags: false,
       },
     },


### PR DESCRIPTION
Since the "stable" ref name's been historicaly used for purposes of marking the latest stable release we are kind of limited of using it, for the purpose of stable releases we are using the topic-stable name.