### PR TITLE
Remove +win from the package name

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -830,7 +830,7 @@ local build_and_upload_guest_agent = build_guest_agent {
           sbom_file: 'gs://gcp-guest-package-uploads/osconfig/google-osconfig-agent-((.:package-version)).sbom.json',
         },
         uploadpackageversiontask {
-          gcs_files: '"gs://gcp-guest-package-uploads/osconfig/google-osconfig-agent.x86_64.((.:package-version)).0+win@1.goo"',
+          gcs_files: '"gs://gcp-guest-package-uploads/osconfig/google-osconfig-agent.x86_64.((.:package-version)).0@1.goo"',
           os_type: 'WINDOWS_ALL_GOOGET',
           pkg_inside_name: 'google-osconfig-agent',
           pkg_name: 'google-osconfig-agent',


### PR DESCRIPTION
The file naming affects the way Artifact Registry detects the googet file version, which prevents package deletion.

This should only be merged when osconfig PR 620 is also merged
https://github.com/GoogleCloudPlatform/osconfig/pull/620