### PR TITLE
Only print the hash and not the file name

### DIFF
--- a/concourse/tasks/generate-hash.yaml
+++ b/concourse/tasks/generate-hash.yaml
@@ -14,4 +14,4 @@ run:
   path: sh
   args:
   - -exc
-  - "gcloud storage cp ((gcsimgfile)) ((localfile)).tar.gz; if [ $? != 0 ]; then exit 1; fi; echo $(sha256sum ((localfile)).tar.gz) | tee generate-hash/hash"
+  - "gcloud storage cp ((gcsimgfile)) ((localfile)).tar.gz; if [ $? != 0 ]; then exit 1; fi; imghash=$(sha256sum ((localfile)).tar.gz | awk '{print $1;}'); echo $imghash | tee generate-hash/hash"


### PR DESCRIPTION
sha256sum prints the hash, then a space, then the file name. We only want the hash so drop the file name.