### PR TITLE
Add support for COS milestones (+109, +105)

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -274,7 +274,6 @@ local buildpackageimagetaskcos = {
   source_image:: error 'must set source_image in buildpackageimagetaskcos',
   dest_image:: error 'must set dest_image in buildpackageimagetaskcos',
   commit_sha:: error 'must set dest_image in buildpackageimagetaskcos',
-  cos_branch:: error 'must set dest_image in buildpackageimagetaskcos',
   machine_type:: 'e2-medium',
   worker_image:: 'projects/compute-image-tools/global/images/family/debian-11-worker',
 
@@ -295,7 +294,6 @@ local buildpackageimagetaskcos = {
         '-var:source_image=' + tl.source_image,
         '-var:dest_image=' + tl.dest_image,
         '-var:commit_sha=' + tl.commit_sha,
-        '-var:cos_branch=' + tl.cos_branch,
         '-var:machine_type=' + tl.machine_type,
         '-var:worker_image=' + tl.worker_image,
         './compute-image-tools/daisy_workflows/image_build/install_package/cos/install_package_cos.wf.json',


### PR DESCRIPTION
In order to add support for more COS milestones, patches will be applied from the master branch, see PR: https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2323

This means that overlay branch arg is no longer necessary and can be removed from all occurrences.

CCing @a-crate, @zmarano.