### PR TITLE
Remove calls to sha256 sum

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -262,16 +262,6 @@ local imgpublishjob = {
             load_var: 'publish-version',
             file: 'publish-version/version',
           },
-	  {
-	    task: 'generate-hash',
-	    file: 'guest-test-infra/concourse/tasks/generate-hash.yaml',
-	    // tl.gcs is gs://artifact-releaser-prod-rtp/centos if nothing is appended, how do we get the img tar file name? The output of "get-debian-10-gcs" as a task seems to have the file name, how do we get that?
-	    vars: { gcsimgfile: '%s/%s-v((.:source-version)).tar.gz' % [tl.gcs, tl.image_prefix], localfile: tl.image + '((.:start-timestamp-ms))' },
-	  },
-          {
-            load_var: 'sha-hash',
-            file: 'generate-hash/hash',
-          },
         ] +
         // Run prepublish tests and invoke ARLE in prod
         if tl.env == 'prod' then
@@ -288,7 +278,6 @@ local imgpublishjob = {
             config: arle.arlepublishtask {
               gcs_image_path: tl.gcs,
               gcs_sbom_path: '((.:sbom-destination))',
-              image_sha256_hash: '((.:sha-hash))',
               source_version: 'v((.:source-version))',
               publish_version: '((.:publish-version))',
               wf: tl.workflow,

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -524,15 +524,6 @@ local imgpublishjob = {
       load_var: 'publish-version',
       file: 'publish-version/version',
     },
-    {
-      task: 'generate-hash',
-      file: 'guest-test-infra/concourse/tasks/generate-hash.yaml',
-      vars: { gcsimgfile: '%s/%s-v((.:source-version)).tar.gz' % [job.gcs, job.image], localfile: job.image + '((.:start-timestamp-ms))' },
-    },
-    {
-      load_var: 'sha-hash',
-      file: 'generate-hash/hash',
-    },
   ] +
   (if job.env == 'prod' then
   [
@@ -540,7 +531,6 @@ local imgpublishjob = {
       task: 'arle-publish-' + job.image,
       config: arle.arlepublishtask {
         gcs_image_path: job.gcs,
-        image_sha256_hash: '((.:sha-hash))',
         source_version: 'v((.:source-version))',
         publish_version: '((.:publish-version))',
         wf: job.workflow,
@@ -553,7 +543,6 @@ local imgpublishjob = {
     {
       task: 'gce-image-publish-' + job.image,
       config: arle.gcepublishtask {
-        image_sha256_hash: '((.:sha-hash))',
         source_gcs_path: job.gcs,
         source_version: 'v((.:source-version))',
         publish_version: '((.:publish-version))',

--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -40,7 +40,7 @@ local common = import '../templates/common.libsonnet';
 
       topic:: common.prod_topic,
       image_name:: error 'must set image_name in arlepublishtask',
-      image_sha256_hash:: '',
+      image_sha256_hash_txt:: '',
       gcs_image_path:: error 'must set gcs_image_path in arlepublishtask',
       wf:: error 'must set wf in arlepublishtask',
       source_version:: error 'must set source_version in arlepublishtask',
@@ -58,8 +58,8 @@ local common = import '../templates/common.libsonnet';
         args: [
           '-exc',
           "wf=$(sed 's/\\\"/\\\\\"/g' ./compute-image-tools/daisy_workflows/build-publish/%s | tr -d '\\n')\n" % task.wf +
-          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"insertImage\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_sha256_hash\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\", \\"gcs_sbom_path\\": \\"%s\\"}}"\n' %
-          [task.topic, task.image_name, task.gcs_image_path, task.image_sha256_hash, task.source_version, task.publish_version, task.gcs_sbom_path],
+          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"insertImage\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\", \\"gcs_sbom_path\\": \\"%s\\"}}"\n' %
+          [task.topic, task.image_name, task.gcs_image_path, task.source_version, task.publish_version, task.gcs_sbom_path],
         ],
       },
     },


### PR DESCRIPTION
The sha256 calculation is moving to the daisy workflows.

In the pubsub message handling, we will make a change so that we do not accept the sha sum directly, but instead accept a file which has the sha sum. Since we're deprecating image_sha256_hash in the pubsub message soon, remove it from the concourse calls.