### PR TITLE
Add support for the sbom shasum text file resource

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -108,6 +108,11 @@ local imgbuildjob = {
       file: '%s-sbom/url' % tl.image,
     },
     {
+      task: 'generate-build-id-shaum',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-shaum.yaml',
+      vars: { prefix: tl.image_prefix, id: '((.:id))' },
+    },
+    {
       put: tl.image + '-shasum',
       params: {
         // empty file written to GCS e.g. 'build-id-dir/centos-7-v20210107-1681318938.txt'

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -97,6 +97,11 @@ local imgbuildjob = {
       file: '%s-sbom/url' % job.image,
     },
     {
+      task: 'generate-build-id-shasum',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-shasum.yaml',
+      vars: { prefix: job.image, id: '((.:id))'},
+    },
+    {
       put: job.image + '-shasum',
       params: {
         file: 'build-id-dir-shasum/%s*' % job.image,
@@ -271,6 +276,11 @@ local sqlimgbuildjob = {
     {
       load_var: 'sbom-destination',
       file: '%s-sbom/url' % job.image,
+    },
+    {
+      task: 'generate-build-id-shasum',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-shasum.yaml',
+      vars: { prefix: job.image, id: '((.:id))'},
     },
     {
       put: job.image + '-shasum',

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -97,6 +97,19 @@ local imgbuildjob = {
       file: '%s-sbom/url' % job.image,
     },
     {
+      put: job.image + '-shasum',
+      params: {
+        file: 'build-id-dir-shasum/%s*' % job.image,
+      },
+      get_params: {
+        skip_download: 'true',
+      },
+    },
+    {
+      load_var: 'sha256-txt',
+      file: '%s-shasum/url' % job.image,
+    },
+    {
       task: 'generate-build-date',
       file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
     },
@@ -158,6 +171,7 @@ local imgbuildjob = {
       config: daisy.daisyimagetask {
         gcs_url: '((.:gcs-url))',
         sbom_destination: '((.:sbom-destination))',
+        sha256_txt: '((.:sha256-txt))',
         workflow: job.workflow,
         vars+: [
           'cloudsdk=((.:windows-cloud-sdk))',
@@ -259,6 +273,19 @@ local sqlimgbuildjob = {
       file: '%s-sbom/url' % job.image,
     },
     {
+      put: job.image + '-shasum',
+      params: {
+        file: 'build-id-dir-shasum/%s*' % job.image,
+      },
+      get_params: {
+        skip_download: 'true',
+      },
+    },
+    {
+      load_var: 'sha256-txt',
+      file: '%s-shasum/url' % job.image,
+    },
+    {
       task: 'generate-build-date',
       file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
     },
@@ -295,6 +322,7 @@ local sqlimgbuildjob = {
       config: daisy.daisyimagetask {
         gcs_url: '((.:gcs-url))',
         sbom_destination: '((.:sbom-destination))',
+        sha256_txt: '((.:sha256-txt))',
         workflow: job.workflow,
         vars+: [
           'source_image_project=bct-prod-images',
@@ -456,7 +484,9 @@ local imgpublishjob = {
   workflow:: error 'must set workflow in imgpublishjob',
   gcs_dir:: error 'must set gcs_dir in imgpublishjob',
   gcs:: 'gs://%s/%s' % [self.gcs_bucket, self.gcs_dir],
+  gcs_shasum:: 'gs://%s/%s' % [self.gcs_sbom_bucket, self.gcs_dir],
   gcs_bucket:: common.prod_bucket,
+  gcs_sbom_bucket:: common.sbom_bucket,
   topic:: common.prod_topic,
 
   // Publish can proceed if build passes.
@@ -524,6 +554,10 @@ local imgpublishjob = {
       load_var: 'publish-version',
       file: 'publish-version/version',
     },
+    {
+      load_var: 'sha256-txt',
+      file: '%s-shasum/url' % job.image,
+    },
   ] +
   (if job.env == 'prod' then
   [
@@ -531,6 +565,7 @@ local imgpublishjob = {
       task: 'arle-publish-' + job.image,
       config: arle.arlepublishtask {
         gcs_image_path: job.gcs,
+        image_sha256_hash_txt: '((.:sha256-txt))',
         source_version: 'v((.:source-version))',
         publish_version: '((.:publish-version))',
         wf: job.workflow,
@@ -744,6 +779,18 @@ local ImgGroup(name, images, environments) = {
                for image in sql_images
              ] +
              [
+               common.GcsShasumResource(image, 'windows-client')
+               for image in windows_client_images
+             ] +
+             [
+               common.GcsShasumResource(image, 'windows-server')
+               for image in windows_server_images
+             ] +
+             [
+               common.GcsShasumResource(image, 'sql')
+               for image in sql_images
+             ] +
+             [
                common.GcsImgResource(image, 'sqlserver-uefi')
                for image in sql_images
              ] +
@@ -753,6 +800,10 @@ local ImgGroup(name, images, environments) = {
              ] +
              [
                common.GcsSbomResource(image, 'sql')
+               for image in prerelease_images
+             ] +
+             [
+               common.GcsShasumResource(image, 'sql')
                for image in prerelease_images
              ] +
              [

--- a/concourse/tasks/generate-build-id-shasum.yaml
+++ b/concourse/tasks/generate-build-id-shasum.yaml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: busybox
+
+outputs:
+- name: build-id-dir-shasum
+
+run:
+  path: sh
+  args:
+  - -exc
+  - "buildid=((id)); uuid=$(date '+%s'); echo $buildid | tee build-id-dir-shasum/build-id-shasum; touch build-id-dir-shasum/((prefix))-v${buildid}-${uuid}.txt"

--- a/concourse/templates/arle.libsonnet
+++ b/concourse/templates/arle.libsonnet
@@ -58,8 +58,8 @@ local common = import '../templates/common.libsonnet';
         args: [
           '-exc',
           "wf=$(sed 's/\\\"/\\\\\"/g' ./compute-image-tools/daisy_workflows/build-publish/%s | tr -d '\\n')\n" % task.wf +
-          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"insertImage\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\", \\"gcs_sbom_path\\": \\"%s\\"}}"\n' %
-          [task.topic, task.image_name, task.gcs_image_path, task.source_version, task.publish_version, task.gcs_sbom_path],
+          'gcloud pubsub topics publish "%s" --message "{\\"type\\": \\"insertImage\\", \\"request\\":\n{\\"image_name\\": \\"%s\\", \\"gcs_image_path\\": \\"%s\\", \\"image_sha256_hash_txt\\": \\"%s\\", \\"image_publish_template\\": \\"${wf}\\",\n      \\"source_version\\": \\"%s\\", \\"publish_version\\": \\"%s\\", \\"release_notes\\": \\"\\", \\"gcs_sbom_path\\": \\"%s\\"}}"\n' %
+          [task.topic, task.image_name, task.gcs_image_path, task.image_sha256_hash_txt, task.source_version, task.publish_version, task.gcs_sbom_path],
         ],
       },
     },

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -84,6 +84,33 @@
     sbom_destination: sbom_destination,
   },
 
+
+  gcsshasumresource:: {
+    local resource = self,
+
+    regexp:: if self.shasum_destination != '' then
+      'sboms/%s/%s/%s-v([0-9]+)-([0-9]+)-shasum.txt' % [self.shasum_destination, self.image_prefix, self.image_prefix]
+    else
+      error 'must set regexp or shasum_destination in gcsshasumresource',
+
+    shasum_destination:: '',
+    image_prefix:: self.image,
+    image:: error 'must set image in gcsshasumresource template',
+    bucket:: tl.sbom_bucket,
+
+    name: self.image + '-shasum',
+    type: 'gcs',
+    source: {
+      bucket: resource.bucket,
+      regexp: resource.regexp,
+    },
+  },
+
+  GcsShasumResource(image, shasum_destination):: self.gcsshasumresource {
+    image: image,
+    shasum_destination: shasum_destination,
+  },
+
   imagetesttask:: {
     local task = self,
     images:: error 'must set images in imagetesttask',

--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -44,6 +44,7 @@
     build_date:: '',
     gcs_url:: error 'must set gcs_url in daisy image task',
     sbom_destination:: '.',
+    shasum_destination:: '.',
 
     workflow_prefix+: 'build-publish/',
     vars+: [
@@ -52,7 +53,8 @@
       // enterprise_linux and then out of build-publish, ending in daisy_workflows
       'workflow_root=../../',
       'gcs_url=' + task.gcs_url,
-      'sbom_destination=' + task.sbom_destination
+      'sbom_destination=' + task.sbom_destination,
+      'sha256_txt=' + task.shasum_destination
     ] + if self.build_date == '' then
       []
     else


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2328, don't merge this until that is merged.

This change would pass in the sha sum text file to ARLE and other workflows in the same way the sbom file is passed in. 