### PR TITLE
Disable passing in of the shasum variable

### DIFF
--- a/concourse/templates/daisy.libsonnet
+++ b/concourse/templates/daisy.libsonnet
@@ -44,7 +44,6 @@
     build_date:: '',
     gcs_url:: error 'must set gcs_url in daisy image task',
     sbom_destination:: '.',
-    shasum_destination:: '.',
 
     workflow_prefix+: 'build-publish/',
     vars+: [
@@ -53,8 +52,7 @@
       // enterprise_linux and then out of build-publish, ending in daisy_workflows
       'workflow_root=../../',
       'gcs_url=' + task.gcs_url,
-      'sbom_destination=' + task.sbom_destination,
-      'sha256_txt=' + task.shasum_destination
+      'sbom_destination=' + task.sbom_destination
     ] + if self.build_date == '' then
       []
     else


### PR DESCRIPTION
While investigating why the shasum isn't being passed in properly, use the default value so the workflow compiles.