### PR TITLE
Removing deprecated 2014 and 2012 references from builds

### DIFF
--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -261,9 +261,6 @@ local ImgGroup(name, images, environments) = {
 
 // Start of output.
 {
-  local windows_2012_images = [
-    'windows-server-2012-r2-dc-bios',
-  ],
   local windows_2016_images = [
     'windows-server-2016-dc-bios',
   ],
@@ -274,7 +271,7 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2022-dc-bios',
   ],
 
-  local images = windows_2012_images + windows_2016_images + windows_2019_images
+  local images = windows_2016_images + windows_2019_images
                + windows_2022_images,
 
   resource_types: [
@@ -305,7 +302,6 @@ local ImgGroup(name, images, environments) = {
           ImgBuildJob('windows-server-2022-dc-bios', 'win2022-64', 'windows_gcs_updates_server2022'),
           ImgBuildJob('windows-server-2019-dc-bios', 'win2019-64', 'windows_gcs_updates_server2019'),
           ImgBuildJob('windows-server-2016-dc-bios', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2-dc-bios', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
         ] +
         [
           ImgPublishJob(image, env, 'windows', 'windows-bios')
@@ -314,7 +310,6 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-2012-bios', windows_2012_images, envs),
     ImgGroup('windows-2016-bios', windows_2016_images, envs),
     ImgGroup('windows-2019-bios', windows_2019_images, envs),
     ImgGroup('windows-2022-bios', windows_2022_images, envs),

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -346,6 +346,14 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
+    {
+       task: 'get-secret-updates-path-2012r2',
+       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
+     },
+     {
+       load_var: 'updates_path_2012r2',
+       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
+     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -354,10 +362,11 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2',
+        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
+        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -315,6 +315,14 @@ local windowsinstallmediaimgbuildjob = {
       file: 'gcp-secret-manager/win2016-64',
     },
     {
+      task: 'get-secret-iso-path-2012r2',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
+    },
+    {
+      load_var: 'iso_path_2012r2',
+      file: 'gcp-secret-manager/win2012-r2-64',
+    },
+    {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
      },
@@ -346,6 +354,7 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
+        iso_path_2012r2: '((.:iso_path_2012r2',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -315,14 +315,6 @@ local windowsinstallmediaimgbuildjob = {
       file: 'gcp-secret-manager/win2016-64',
     },
     {
-      task: 'get-secret-iso-path-2012r2',
-      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
-    },
-    {
-      load_var: 'iso_path_2012r2',
-      file: 'gcp-secret-manager/win2012-r2-64',
-    },
-    {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
      },
@@ -346,14 +338,6 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
-    {
-       task: 'get-secret-updates-path-2012r2',
-       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
-     },
-     {
-       load_var: 'updates_path_2012r2',
-       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
-     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -362,11 +346,9 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
-        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],
@@ -526,9 +508,6 @@ local ImgGroup(name, images) = {
     'windows-server-2025-dc',
     'windows-server-2025-dc-core',
   ],
-  local sql_2014_images = [
-    'sql-2014-enterprise-windows-2016-dc',
-  ],
   local sql_2016_images = [
     'sql-2016-enterprise-windows-2016-dc',
     'sql-2016-enterprise-windows-2019-dc',
@@ -573,7 +552,7 @@ local ImgGroup(name, images) = {
   local windows_client_images = windows_10_images + windows_11_images,
   local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
+  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
 
   resource_types: [
     {
@@ -632,8 +611,6 @@ local ImgGroup(name, images) = {
           ImgBuildJob('windows-server-2016-dc', 'win2016-64', 'windows_gcs_updates_server2016'),
           ImgBuildJob('windows-server-2016-dc-core', 'win2016-64', 'windows_gcs_updates_server2016'),
           // SQL derivative builds
-
-          SQLImgBuildJob('sql-2014-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
 
           SQLImgBuildJob('sql-2016-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
@@ -699,7 +676,6 @@ local ImgGroup(name, images) = {
     ImgGroup('windows-2019-testing', windows_2019_images),
     ImgGroup('windows-2022-testing', windows_2022_images),
     ImgGroup('windows-2025-testing', windows_2025_images),
-    ImgGroup('sql-2014-testing', sql_2014_images),
     ImgGroup('sql-2016-testing', sql_2016_images),
     ImgGroup('sql-2017-testing', sql_2017_images),
     ImgGroup('sql-2019-testing', sql_2019_images),

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -309,6 +309,14 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
+    {
+       task: 'get-secret-updates-path-2012r2',
+       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
+     },
+     {
+       load_var: 'updates_path_2012r2',
+       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
+     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -317,10 +325,11 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2',
+        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
+        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -277,7 +277,14 @@ local windowsinstallmediaimgbuildjob = {
       load_var: 'iso_path_2016',
       file: 'gcp-secret-manager/win2016-64',
     },
-
+    {
+      task: 'get-secret-iso-path-2012r2',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
+    },
+    {
+      load_var: 'iso_path_2012r2',
+      file: 'gcp-secret-manager/win2012-r2-64',
+    },
     {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
@@ -310,6 +317,7 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
+        iso_path_2012r2: '((.:iso_path_2012r2',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -277,14 +277,7 @@ local windowsinstallmediaimgbuildjob = {
       load_var: 'iso_path_2016',
       file: 'gcp-secret-manager/win2016-64',
     },
-    {
-      task: 'get-secret-iso-path-2012r2',
-      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
-    },
-    {
-      load_var: 'iso_path_2012r2',
-      file: 'gcp-secret-manager/win2012-r2-64',
-    },
+
     {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
@@ -309,14 +302,6 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
-    {
-       task: 'get-secret-updates-path-2012r2',
-       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
-     },
-     {
-       load_var: 'updates_path_2012r2',
-       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
-     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -325,11 +310,9 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
-        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],
@@ -501,10 +484,6 @@ local ImgGroup(name, images, environments) = {
 
 // Start of output.
 {
-  local windows_2012_images = [
-    'windows-server-2012-r2',
-    'windows-server-2012-r2-core',
-  ],
   local windows_2016_images = [
     'windows-server-2016',
     'windows-server-2016-core',
@@ -521,20 +500,11 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2025',
     'windows-server-2025-core',
   ],
-  local sql_2014_images = [
-    'sql-2014-enterprise-windows-2012-r2',
-    'sql-2014-enterprise-windows-2016',
-    'sql-2014-standard-windows-2012-r2',
-    'sql-2014-web-windows-2012-r2',
-  ],
   local sql_2016_images = [
-    'sql-2016-enterprise-windows-2012-r2',
     'sql-2016-enterprise-windows-2016',
     'sql-2016-enterprise-windows-2019',
-    'sql-2016-standard-windows-2012-r2',
     'sql-2016-standard-windows-2016',
     'sql-2016-standard-windows-2019',
-    'sql-2016-web-windows-2012-r2',
     'sql-2016-web-windows-2016',
     'sql-2016-web-windows-2019',
   ],
@@ -542,7 +512,6 @@ local ImgGroup(name, images, environments) = {
     'sql-2017-enterprise-windows-2016',
     'sql-2017-enterprise-windows-2019',
     'sql-2017-enterprise-windows-2022',
-    'sql-2017-express-windows-2012-r2',
     'sql-2017-express-windows-2016',
     'sql-2017-express-windows-2019',
     'sql-2017-standard-windows-2016',
@@ -569,9 +538,9 @@ local ImgGroup(name, images, environments) = {
     'sql-2022-web-windows-2022',
   ],
 
-  local windows_server_images = windows_2012_images + windows_2016_images + windows_2019_images
+  local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
+  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
 
   resource_types: [
     {
@@ -608,30 +577,19 @@ local ImgGroup(name, images, environments) = {
           ImgBuildJob('windows-server-2019-core', 'win2019-64', 'windows_gcs_updates_server2019'),
           ImgBuildJob('windows-server-2016', 'win2016-64', 'windows_gcs_updates_server2016'),
           ImgBuildJob('windows-server-2016-core', 'win2016-64', 'windows_gcs_updates_server2016'),
-          ImgBuildJob('windows-server-2012-r2', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
-          ImgBuildJob('windows-server-2012-r2-core', 'win2012-r2-64', 'windows_gcs_updates_server2012r2'),
 
           // SQL derivative builds
 
-          SQLImgBuildJob('sql-2014-enterprise-windows-2012-r2', 'windows-server-2012-r2', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2014-enterprise-windows-2016', 'windows-server-2016', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2014-standard-windows-2012-r2', 'windows-server-2012-r2', 'sql-2014-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2014-web-windows-2012-r2', 'windows-server-2012-r2', 'sql-2014-web', 'windows_gcs_ssms_exe'),
-
-          SQLImgBuildJob('sql-2016-enterprise-windows-2012-r2', 'windows-server-2012-r2', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2016', 'windows-server-2016', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2019', 'windows-server-2019', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2012-r2', 'windows-server-2012-r2', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-standard-windows-2016', 'windows-server-2016', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-standard-windows-2019', 'windows-server-2019', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2012-r2', 'windows-server-2012-r2', 'sql-2016-web', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-web-windows-2016', 'windows-server-2016', 'sql-2016-web', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-web-windows-2019', 'windows-server-2019', 'sql-2016-web', 'windows_gcs_ssms_exe'),
 
           SQLImgBuildJob('sql-2017-enterprise-windows-2016', 'windows-server-2016', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2019', 'windows-server-2019', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2022', 'windows-server-2022', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2017-express-windows-2012-r2', 'windows-server-2012-r2', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-express-windows-2016', 'windows-server-2016', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-express-windows-2019', 'windows-server-2019', 'sql-2017-express', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-standard-windows-2016', 'windows-server-2016', 'sql-2017-standard', 'windows_gcs_ssms_exe'),
@@ -669,12 +627,10 @@ local ImgGroup(name, images, environments) = {
         ],
 
   groups: [
-    ImgGroup('windows-2012', windows_2012_images, server_envs),
     ImgGroup('windows-2016', windows_2016_images, server_envs),
     ImgGroup('windows-2019', windows_2019_images, server_envs),
     ImgGroup('windows-2022', windows_2022_images, server_envs),
     ImgGroup('windows-2025', windows_2025_images, server_envs),
-    ImgGroup('sql-2014', sql_2014_images, sql_envs),
     ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -428,7 +428,14 @@ local windowsinstallmediaimgbuildjob = {
       load_var: 'iso_path_2016',
       file: 'gcp-secret-manager/win2016-64',
     },
-
+    {
+      task: 'get-secret-iso-path-2012r2',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
+    },
+    {
+      load_var: 'iso_path_2012r2',
+      file: 'gcp-secret-manager/win2012-r2-64',
+    },
     {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
@@ -461,6 +468,7 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
+        iso_path_2012r2: '((.:iso_path_2012r2',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -460,6 +460,14 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
+    {
+       task: 'get-secret-updates-path-2012r2',
+       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
+     },
+     {
+       load_var: 'updates_path_2012r2',
+       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
+     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -468,10 +476,11 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2',
+        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
+        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -428,14 +428,7 @@ local windowsinstallmediaimgbuildjob = {
       load_var: 'iso_path_2016',
       file: 'gcp-secret-manager/win2016-64',
     },
-    {
-      task: 'get-secret-iso-path-2012r2',
-      config: gcp_secret_manager.getsecrettask { secret_name: 'win2012-r2-64' },
-    },
-    {
-      load_var: 'iso_path_2012r2',
-      file: 'gcp-secret-manager/win2012-r2-64',
-    },
+
     {
        task: 'get-secret-updates-path-2022',
        config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2022' },
@@ -460,14 +453,6 @@ local windowsinstallmediaimgbuildjob = {
        load_var: 'updates_path_2016',
        file: 'gcp-secret-manager/windows_gcs_updates_server2016',
      },
-    {
-       task: 'get-secret-updates-path-2012r2',
-       config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_updates_server2012r2' },
-     },
-     {
-       load_var: 'updates_path_2012r2',
-       file: 'gcp-secret-manager/windows_gcs_updates_server2012r2',
-     },
      {
       task: 'daisy-build',
       config: daisy.daisywindowsinstallmediatask {
@@ -476,11 +461,9 @@ local windowsinstallmediaimgbuildjob = {
         iso_path_2022: '((.:iso_path_2022))',
         iso_path_2019: '((.:iso_path_2019))',
         iso_path_2016: '((.:iso_path_2016))',
-        iso_path_2012r2: '((.:iso_path_2012r2))',
         updates_path_2022: '((.:updates_path_2022))',
         updates_path_2019: '((.:updates_path_2019))',
         updates_path_2016: '((.:updates_path_2016))',
-        updates_path_2012r2: '((.:updates_path_2012r2))',
       },
     },
   ],
@@ -714,9 +697,6 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2025-dc',
     'windows-server-2025-dc-core',
   ],
-  local sql_2014_images = [
-    'sql-2014-enterprise-windows-2016-dc',
-  ],
   local sql_2016_images = [
     'sql-2016-enterprise-windows-2016-dc',
     'sql-2016-enterprise-windows-2019-dc',
@@ -766,7 +746,7 @@ local ImgGroup(name, images, environments) = {
   local windows_client_images = windows_10_images + windows_11_images,
   local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2014_images + sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
+  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
 
   resource_types: [
     {
@@ -852,8 +832,6 @@ local ImgGroup(name, images, environments) = {
 
           // SQL derivative builds
 
-          SQLImgBuildJob('sql-2014-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2014-enterprise', 'windows_gcs_ssms_exe'),
-
           SQLImgBuildJob('sql-2016-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2016-standard-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
@@ -938,7 +916,6 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('windows-2019', windows_2019_images, server_envs),
     ImgGroup('windows-2022', windows_2022_images, server_envs),
     ImgGroup('windows-2025', windows_2025_images, server_envs),
-    ImgGroup('sql-2014', sql_2014_images, sql_envs),
     ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),


### PR DESCRIPTION
Dropping SQL Server 2014 as well as remaining 2012 references from windows build pipelines