### PR TITLE
Remove Debian 11 arm from concourse build

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -388,7 +388,7 @@ local imggroup = {
 
 {
   local almalinux_images = ['almalinux-8', 'almalinux-9'],
-  local debian_images = ['debian-11', 'debian-11-arm64', 'debian-12', 'debian-12-arm64'],
+  local debian_images = ['debian-11', 'debian-12', 'debian-12-arm64'],
   local centos_images = ['centos-stream-9'],
   local rhel_sap_images = [
     'rhel-8-4-sap',


### PR DESCRIPTION
Deprecated last week; no backport maintainer