### PR TITLE
Include test suites instead of excluding

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -16,7 +16,7 @@ local imgbuildtask = daisy.daisyimagetask {
 };
 
 local imagetesttask = common.imagetesttask {
-  filter: '(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(packageupgrade)|(packagevalidation)|(ssh)|(sql)|(metadata)|(windowscontainers)|(vmspec)'
+  filter: '(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(packageupgrade)|(packagevalidation)|(ssh)|(metadata)|(sql)|(vmspec)'
 };
 
 local prepublishtesttask = common.imagetesttask {

--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -16,7 +16,7 @@ local imgbuildtask = daisy.daisyimagetask {
 };
 
 local imagetesttask = common.imagetesttask {
-  exclude: '(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(mdsmtls)|(mdsroutes)',
+  filter: '(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(packageupgrade)|(packagevalidation)|(ssh)|(sql)|(metadata)|(windowscontainers)|(vmspec)'
 };
 
 local prepublishtesttask = common.imagetesttask {

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -13,7 +13,7 @@ local underscore(input) = std.strReplace(input, '-', '_');
 
 // Templates.
 local imagetesttask = common.imagetesttask {
-  exclude: '(oslogin)|(storageperf)|(networkperf)|(mdsmtls)|(mdsroutes)',
+  filter: '(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(shapevalidation)|(packageupgrade)|(packagevalidation)|(ssh)|(winrm)|(metadata)|(sql)|(windowscontainers)',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 


### PR DESCRIPTION
Use "filter" instead of "exclude": this change uses "filter" for all the test suites which were not previously covered by "exclude."