### PR TITLE
Use a single capturing group in image build filters

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -16,7 +16,7 @@ local imgbuildtask = daisy.daisyimagetask {
 };
 
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(packageupgrade)|(packagevalidation)|(ssh)|(metadata)|(sql)|(vmspec)$'
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packageupgrade|packagevalidation|ssh|metadata|sql|vmspec)$'
 };
 
 local prepublishtesttask = common.imagetesttask {

--- a/concourse/pipelines/windows-image-build-mbr.jsonnet
+++ b/concourse/pipelines/windows-image-build-mbr.jsonnet
@@ -8,7 +8,7 @@ local envs = ['testing'];
 local underscore(input) = std.strReplace(input, '-', '_');
 
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(shapevalidation)|(packageupgrade)|(packagevalidation)|(ssh)|(winrm)|(metadata)|(sql)|(windowscontainers)$',
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 

--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -7,7 +7,7 @@ local underscore(input) = std.strReplace(input, '-', '_');
 
 // Templates.
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(shapevalidation)|(packageupgrade)|(packagevalidation)|(ssh)|(winrm)|(metadata)|(sql)|(windowscontainers)$',
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -10,7 +10,7 @@ local underscore(input) = std.strReplace(input, '-', '_');
 
 // Templates.
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(shapevalidation)|(packageupgrade)|(packagevalidation)|(ssh)|(winrm)|(metadata)|(sql)|(windowscontainers)$',
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -13,7 +13,7 @@ local underscore(input) = std.strReplace(input, '-', '_');
 
 // Templates.
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm)|(livemigrate)|(suspendresume)|(loadbalancer)|(guestagent)|(hostnamevalidation)|(imageboot)|(licensevalidation)|(network)|(security)|(hotattach)|(lssd)|(disk)|(shapevalidation)|(packageupgrade)|(packagevalidation)|(ssh)|(winrm)|(metadata)|(sql)|(windowscontainers)$',
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 


### PR DESCRIPTION
This avoids ^(cvm)|(network)|(...)$ matching networkperf

/cc @koln67 