### PR TITLE
Bump package build and container build's golang version

### DIFF
--- a/container_images/gointegtest/common.sh
+++ b/container_images/gointegtest/common.sh
@@ -33,7 +33,7 @@ function install_go() {
   # Installs a specific version of go for compilation, since availability varies
   # across linux distributions. Needs curl and tar to be installed.
 
-  local GOLANG="go1.22.5.linux-amd64.tar.gz"
+  local GOLANG="go1.23.2.linux-amd64.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 

--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -37,7 +37,7 @@ function install_go() {
     arch="arm64"
   fi
 
-  local GOLANG="go1.22.5.linux-${arch}.tar.gz"
+  local GOLANG="go1.23.2.linux-${arch}.tar.gz"
   export GOPATH=/usr/share/gocode
   export GOCACHE=/tmp/.cache
 


### PR DESCRIPTION
Due to some vulnerabilities with 1.22 we are bumping the toolchain we use both to build packages and the container image to 1.23.2.