### PR TITLE
container-images: install protobuffer tooling.

### DIFF
--- a/container_images/gobuild/Dockerfile
+++ b/container_images/gobuild/Dockerfile
@@ -13,8 +13,10 @@
 # limitations under the License.
 FROM golang:bullseye
 
-RUN apt-get update && apt-get install -y git && \
+RUN apt-get update && apt-get install -y git protobuf-compiler protoc-gen-go && \
     rm -rf /var/cache/apt/archives
+
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 # Copy this Dockerfile for debugging.
 COPY Dockerfile Dockerfile

--- a/container_images/gocheck/Dockerfile
+++ b/container_images/gocheck/Dockerfile
@@ -13,8 +13,10 @@
 # limitations under the License.
 FROM golang:bullseye
 
-RUN apt-get update && apt-get install -y git && \
+RUN apt-get update && apt-get install -y git protobuf-compiler protoc-gen-go && \
     rm -rf /var/cache/apt/archives
+
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install golang.org/x/lint/golint@latest
 
 # Copy this Dockerfile for debugging.

--- a/container_images/gotest/Dockerfile
+++ b/container_images/gotest/Dockerfile
@@ -13,8 +13,10 @@
 # limitations under the License.
 FROM golang:bullseye
 
-RUN apt-get update && apt-get -y install bash ca-certificates curl libssl-dev wget && \
-    rm -rf /var/cache/apt/archives
+RUN apt-get update && apt-get -y install bash ca-certificates curl libssl-dev wget \
+protobuf-compiler protoc-gen-go && rm -rf /var/cache/apt/archives
+
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 # Go test junit xml output
 RUN go install github.com/jstemmer/go-junit-report@latest


### PR DESCRIPTION
In order to be able to generate pb.go files during build time we need to have installed the protobuffer compiler and the go-grpc generator.

google-guest-agent repository is not checking in generated code but relying on its build system to generate it during build time, prow nodes must have the required tooling to do so.