### PR TITLE
Switch CIT package tests to explicit include list

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -434,7 +434,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/cos-113-((.:build-id)),projects/gcp-guest/global/images/cos-109-((.:build-id)),projects/gcp-guest/global/images/cos-105-((.:build-id)),projects/gcp-guest/global/images/cos-101-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|metadata|mdsroutes|vmspec)$'
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|mdsroutes|vmspec)$',
                   '-parallel_count=15',
                 ],
               },
@@ -456,7 +456,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|metadata|mdsroutes|vmspec)$'
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|mdsroutes|vmspec)$',
                   '-parallel_count=15',
                 ],
               },

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -434,7 +434,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/cos-113-((.:build-id)),projects/gcp-guest/global/images/cos-109-((.:build-id)),projects/gcp-guest/global/images/cos-105-((.:build-id)),projects/gcp-guest/global/images/cos-101-((.:build-id))',
-                  '-exclude=(mdsmtls)|(image)|(livemigrate)|(suspendresume)|(disk)|(security)|(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(hotattach)|(lssd)|(licensevalidation)|(acceleratorconfig)',
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|winrm|sql|metadata|mdsroutes|windowscontainers|vmspec)$'
                   '-parallel_count=15',
                 ],
               },
@@ -456,7 +456,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
-                  '-exclude=(mdsmtls)|(image)|(suspendresume)|(livemigrate)|(disk)|(security)|(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(hotattach)|(lssd)|(licensevalidation)|(acceleratorconfig)',
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|winrm|sql|metadata|mdsroutes|windowscontainers|vmspec)$'
                   '-parallel_count=15',
                 ],
               },

--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -434,7 +434,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/cos-113-((.:build-id)),projects/gcp-guest/global/images/cos-109-((.:build-id)),projects/gcp-guest/global/images/cos-105-((.:build-id)),projects/gcp-guest/global/images/cos-101-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|winrm|sql|metadata|mdsroutes|windowscontainers|vmspec)$'
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|metadata|mdsroutes|vmspec)$'
                   '-parallel_count=15',
                 ],
               },
@@ -456,7 +456,7 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|winrm|sql|metadata|mdsroutes|windowscontainers|vmspec)$'
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packageupgrade|packagevalidation|ssh|metadata|mdsroutes|vmspec)$'
                   '-parallel_count=15',
                 ],
               },


### PR DESCRIPTION
Previous was an implicit include, which made it unnecessarily pick up new test suites unless explicitly excluded.