### PR TITLE
rpm build: build package with extra source

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -29,6 +29,16 @@ function exit_error() {
 
 trap 'exit_error $LINENO' ERR
 
+function install_protoc() {
+  PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+  PB_VERSION=28.1
+  PB_PKG=protoc-${PB_VERSION}-linux-x86_64.zip
+
+  curl -LO $PB_REL/download/v${PB_VERSION}/${PB_PKG}
+  unzip ${PB_PKG} -d $HOME/.local
+  export PATH="$PATH:$HOME/.local/bin"
+}
+
 function install_go() {
   # Installs a specific version of go for compilation, since availability varies
   # across linux distributions. Needs curl and tar to be installed.


### PR DESCRIPTION
Introduce the required bits to honor extra source code when building rpm packages - this supports packaging that require more than a single source code such as guest-agent that is building plugin-manager side-by-side.