### PR TITLE
Update linux image build test filter, switch partner images to filter

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -16,7 +16,7 @@ local imgbuildtask = daisy.daisyimagetask {
 };
 
 local imagetesttask = common.imagetesttask {
-  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packageupgrade|packagevalidation|ssh|metadata|sql|vmspec)$'
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|vmspec)$'
 };
 
 local prepublishtesttask = common.imagetesttask {

--- a/concourse/pipelines/partner-image-validations.jsonnet
+++ b/concourse/pipelines/partner-image-validations.jsonnet
@@ -1,6 +1,6 @@
 local common = import '../templates/common.libsonnet';
 local imagetesttask = common.imagetesttask {
-  exclude: '(oslogin)|(storageperf)|(networkperf)|(shapevalidation)|(hotattach)|(lssd)|(mdsmtls)|(mdsroutes)',
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|vmspec)$',
 };
 
 local imagevalidationjob = {


### PR DESCRIPTION
Removed noop tests from linux image builds and added missing tests to partner image validation

/cc @jjerger @bkatyl 