### PR TITLE
rpm build: install make and add arm64 support

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -32,7 +32,14 @@ trap 'exit_error $LINENO' ERR
 function install_protoc() {
   PB_REL="https://github.com/protocolbuffers/protobuf/releases"
   PB_VERSION=28.1
-  PB_PKG=protoc-${PB_VERSION}-linux-x86_64.zip
+  ARCH=$(uname -m)
+
+  # protobuffer's release and uname mismatch for aarch.
+  if [[ "${ARCH}" == "aarch64" ]]; then
+    ARCH="aarch_64"
+  fi
+
+  PB_PKG=protoc-${PB_VERSION}-linux-${ARCH}.zip
 
   curl -LO $PB_REL/download/v${PB_VERSION}/${PB_PKG}
   unzip ${PB_PKG} -d $HOME/.local

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -76,7 +76,7 @@ if [[ ${VERSION_ID} = 9 ]]; then
   fi
 fi
 
-try_command yum install -y $GIT rpmdevtools yum-utils python3-devel
+try_command yum install -y $GIT rpmdevtools yum-utils python3-devel make
 
 ROOT_WORK_DIR=$(pwd)
 git_checkout "$REPO_OWNER" "$REPO_NAME" "$GIT_REF"


### PR DESCRIPTION
We are missing make as a build dep and we were installing x86 protoc regardless the running system's architecture, this change fixes both.