### PR TITLE
Disable accelerator CIT tests on linux builds

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -576,7 +576,7 @@ local imggroup = {
             env: env,
             gcs_dir: 'accelerators',
             workflow_dir: 'accelerator_images',
-            additionalcitsuites: 'acceleratorconfig',
+            //additionalcitsuites: 'acceleratorconfig',
           }
           for env in envs
           for image in accelerator_images


### PR DESCRIPTION
Cannot run until NIC types rolls out.