### PR TITLE
Update work_dir for accelerator image builds

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -514,7 +514,7 @@ local imggroup = {
         ] +
         [
           // accelerator build jobs
-          imgbuildjob { image: image, workflow_dir: 'accelerator_images' }
+          imgbuildjob { image: image, workflow_dir: 'enterprise_linux' }
           for image in rocky_accelerator_images
         ] +
         [
@@ -570,7 +570,7 @@ local imggroup = {
             image: image,
             env: env,
             gcs_dir: 'accelerators',
-            workflow_dir: 'accelerator_images',
+            workflow_dir: 'enterprise_linux',
             // Acceleratorconfig test disabled until nictype is updated
             //additionalcitsuites: 'acceleratorconfig',
           }


### PR DESCRIPTION
PR https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2392 moved rocky builds from `accelerator_images` to `enterprise_linux` update workflow_dir in pipeline as well

/cc @a-crate @jjerger 