### PR TITLE
Switch rocky-8 from 550 to latest

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -444,7 +444,7 @@ local imggroup = {
     'rocky-linux-9-optimized-gcp-arm64',
   ],
   local rocky_accelerator_images = [
-    'rocky-linux-8-optimized-gcp-with-nvidia-550',
+    'rocky-linux-8-optimized-gcp-with-nvidia-latest',
     'rocky-linux-9-optimized-gcp-with-nvidia-550',
   ],
 


### PR DESCRIPTION
Updates based on [PR](https://github.com/GoogleCloudPlatform/compute-image-tools/pull/2398), builds are failing with - `no such file or directory`

/cc @a-crate @jjerger 