### PR TITLE
Fix image name in definition

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -428,8 +428,8 @@ local imggroup = {
     'rocky-linux-9-optimized-gcp-arm64',
   ],
   local rocky_accelerator_images = [
-    'rocky-linux-8-optimized-gcp-with-nvidia-latest',
-    'rocky-linux-9-optimized-gcp-with-nvidia-latest',
+    'rocky-linux-8-optimized-gcp-nvidia-latest',
+    'rocky-linux-9-optimized-gcp-nvidia-latest',
   ],
 
   // Start of output.


### PR DESCRIPTION
Dropped with on a recent PR for conciseness but didn't drop it from image definitions