### PR TITLE
SQL on 2025, cleanup, cit on c3

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -16,6 +16,7 @@ local imagetestn1 = common.imagetesttask {
   filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
   extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
+
 local imagetestc3 = common.imagetesttask {
   filter: '^(livemigrate|suspendresume|imageboot|network|hotattach|lssd|disk)$',
   extra_args: [ '-x86_shape=c3-standard-4' ],
@@ -627,7 +628,7 @@ local imgpublishjob = {
         images: 'projects/bct-prod-images/global/images/%s-((.:publish-version))' % job.image,
       },
       attempts: 3,
-    }
+    },
     {
       task: 'image-test-c3-' + job.image,
       config: imagetestc3 {

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -623,7 +623,7 @@ local imgpublishjob = {
   (if job.runtests then
   [
     {
-      task: 'image-test-n1' + job.image,
+      task: 'image-test-n1-' + job.image,
       config: imagetestn1 {
         images: 'projects/bct-prod-images/global/images/%s-((.:publish-version))' % job.image,
       },


### PR DESCRIPTION
- Adding SQL Server on 2025
- Removing SQL Preview
- SQL express on 2022/2025
- Extending CIT test execution to test on c3 for hw related tests