### PR TITLE
Update linux-image-build and linux-image-build-dev cit invocations

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -235,13 +235,11 @@ local imgpublishjob = {
   trigger:: if tl.env == 'testing' then true
   else false,
 
-  // Use citfilter list as default; append additionalcitsuites if not nil
-  // additionalcitsuites must be in the valid regex concatenation format of 'item1|item2|item3'
-  additionalcitsuites:: '',
-  citfilter:: if tl.additionalcitsuites == '' then '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|vmspec)$'
-  else '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|vmspec|%s)$' % tl.additionalcitsuites,
-  runtests:: if tl.env == 'testing' then true
-  else false,
+  citfilter:: common.default_linux_image_build_cit_filter,
+  cit_extra_args:: [],
+
+   runtests:: if tl.env == 'testing' then true
+   else false,
 
   // Start of job.
   name: 'publish-to-%s-%s' % [tl.env, tl.image],
@@ -344,6 +342,7 @@ local imgpublishjob = {
               config: common.imagetesttask {
                 filter: tl.citfilter,
                 images: 'projects/bct-prod-images/global/images/%s-((.:publish-version))' % tl.image_prefix,
+                extra_args:: tl.cit_extra_args,
               },
               attempts: 3,
             },

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -111,6 +111,8 @@
     shasum_destination: shasum_destination,
   },
 
+  default_linux_image_build_cit_filter:: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|metadata|vmspec)$',
+
   imagetesttask:: {
     local task = self,
     images:: error 'must set images in imagetesttask',


### PR DESCRIPTION
Define the default linux image build CIT filter in a central location. Allow passing extra args. Skip licensevalidation in rocky accelerator pipelines (temporarily, while it's publishing to the preview project). Run accelerator tests and use the alpha API for accelerator images.

/cc
/hold