### PR TITLE
Change the timeout for Windows CIT tests run in the build pipeline to 60m.

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -14,12 +14,12 @@ local underscore(input) = std.strReplace(input, '-', '_');
 // Templates.
 local imagetestn1 = common.imagetesttask {
   filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|shapevalidation|packageupgrade|packagevalidation|ssh|winrm|metadata|sql|windowscontainers)$',
-  extra_args: [ '-x86_shape=n1-standard-4', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
+  extra_args: [ '-x86_shape=n1-standard-4', '-timeout=60m', '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 
 local imagetestc3 = common.imagetesttask {
   filter: '^(livemigrate|suspendresume|imageboot|network|hotattach|lssd|disk)$',
-  extra_args: [ '-x86_shape=c3-standard-4' ],
+  extra_args: [ '-x86_shape=c3-standard-4', '-timeout=60m' ],
 };
 
 local imgbuildjob = {


### PR DESCRIPTION
- Some test runs are taking just over 45 minutes which causes a retry.