### PR TITLE
guest package build: force fetching tags

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -1181,7 +1181,7 @@ local build_and_upload_guest_agent = build_guest_agent {
       source: {
         uri: 'https://github.com/GoogleCloudPlatform/guest-agent.git',
         branch: 'topic-stable',
-        fetch_tags: false,
+        fetch_tags: true,
       },
     },
     {


### PR DESCRIPTION
Without forcing fetching tags we can't generate a new version on the same day.