### PR TITLE
Split rocky accelerator builds into 550/latest

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -450,6 +450,8 @@ local imggroup = {
     'rocky-linux-9-optimized-gcp-arm64',
   ],
   local rocky_linux_accelerator_images = [
+    'rocky-linux-8-optimized-gcp-nvidia-550',
+    'rocky-linux-9-optimized-gcp-nvidia-550'
     'rocky-linux-8-optimized-gcp-nvidia-latest',
     'rocky-linux-9-optimized-gcp-nvidia-latest',
   ],


### PR DESCRIPTION
Workflows already exist; latest is going to be pointed to 570.

Note that this just splits out the builds, but latest is currently installing 550 and needs to be updated to 570.