### PR TITLE
Fix isopath trimming for accelerator builds

### DIFF
--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -168,7 +168,7 @@ local elimgbuildjob = imgbuildjob {
 
   workflow_dir: 'enterprise_linux',
   sbom_util_secret_name:: 'sbom-util-secret',
-  isopath:: trim_strings(tl.image, ['-byos', '-sap', '-nvidia-latest', '-nvidia-550']),
+  isopath:: trim_strings(tl.image, ['-nvidia-latest', '-nvidia-550', '-nvidia-570']),
 
   // Add tasks to obtain ISO location and sbom util source
   // Store those in .:iso-secret and .:sbom-util-secret


### PR DESCRIPTION
Removes extra suffixes that aren't used (byos/sap); adds 570