### PR TITLE
Split accelerator publish tasks outside of template

### DIFF
--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -443,13 +443,6 @@ local imggroup = {
                 test_projects: 'compute-image-test-pool-001',
                 extra_args:: [ '-parallel_count=1', '-compute_endpoint_override=https://www.googleapis.com/compute/alpha/', '-use_reservations=true', '-reservation_urls=cloud-image-exfr-2', '-x86_shape=a3-ultragpu-8g', '-zone=europe-west1-b', '-accelerator_type=nvidia-h200-141gb' ],
               },
-              common.imagetesttask {
-                task: 'accelerator-tests-a4',
-                filter: '^(acceleratorrdma|acceleratorconfig)$',
-                project: 'compute-image-test-pool-001',
-                test_projects: 'compute-image-test-pool-001',
-                extra_args:: [ '-parallel_count=1', '-compute_endpoint_override=https://www.googleapis.com/compute/alpha/', '-use_reservations=true', '-reservation_urls=a4-exr-compute-image-test-pool-001', '-x86_shape=a4-highgpu-8g', '-zone=us-central1-b', '-accelerator_type=nvidia-b200' ],
-              },
             ],
           },
           imgpublishjob {
@@ -465,13 +458,6 @@ local imggroup = {
                 project: 'compute-image-test-pool-001',
                 test_projects: 'compute-image-test-pool-001',
                 extra_args:: [ '-parallel_count=1', '-compute_endpoint_override=https://www.googleapis.com/compute/alpha/', '-use_reservations=true', '-reservation_urls=cloud-image-exfr-2', '-x86_shape=a3-ultragpu-8g', '-zone=europe-west1-b', '-accelerator_type=nvidia-h200-141gb' ],
-              },
-              common.imagetesttask {
-                task: 'accelerator-tests-a4',
-                filter: '^(acceleratorrdma|acceleratorconfig)$',
-                project: 'compute-image-test-pool-001',
-                test_projects: 'compute-image-test-pool-001',
-                extra_args:: [ '-parallel_count=1', '-compute_endpoint_override=https://www.googleapis.com/compute/alpha/', '-use_reservations=true', '-reservation_urls=a4-exr-compute-image-test-pool-001', '-x86_shape=a4-highgpu-8g', '-zone=us-central1-b', '-accelerator_type=nvidia-b200' ],
               },
             ],
           },


### PR DESCRIPTION
The specialized nature of the publish test tasks is going to require that these have their own specific timing resources associated to them, so they can no longer abide by the template.