### PR TITLE
Stagger Accelerator CIT Test publish tasks

### DIFF
--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -209,13 +209,6 @@ local imgpublishjob = {
     'build-' + tl.image
   else if tl.env == 'prod' then
     'publish-to-testing-' + tl.image,
-  daily:: true,
-  daily_task:: if self.daily then [
-    {
-      get: 'time-' + tl.image,
-      trigger: true,
-    },
-  ] else [],
   
   citfilter:: common.default_linux_image_build_cit_filter,
   cit_extra_args:: [],
@@ -231,7 +224,11 @@ local imgpublishjob = {
 
   // Start of job.
   name: 'publish-to-%s-%s' % [tl.env, tl.image],
-  plan: tl.daily_task + [
+  plan: [
+          {
+            get: 'time-' + tl.image,
+            trigger: true,
+          },
           { get: 'guest-test-infra' },
           { get: 'compute-image-tools' },
           {

--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -204,15 +204,19 @@ local imgpublishjob = {
   gcs_dir:: error 'must set gcs directory in imgpublishjob',
   gcs_bucket:: common.prod_bucket,
 
-  // Publish to testing after build
+  // Publish to testing after build, if within the defined test window.
   passed:: if tl.env == 'testing' then
     'build-' + tl.image
   else if tl.env == 'prod' then
     'publish-to-testing-' + tl.image,
-
-  trigger:: if tl.env == 'testing' then true
-  else false,
-
+  daily:: true,
+  daily_task:: if self.daily then [
+    {
+      get: 'time-' + tl.image,
+      trigger: true,
+    },
+  ] else [],
+  
   citfilter:: common.default_linux_image_build_cit_filter,
   cit_extra_args:: [],
   cit_project:: common.default_cit_project,
@@ -403,6 +407,37 @@ local imggroup = {
                  name: 'daily-time',
                  type: 'time',
                  source: { interval: '24h', start: '10:00 PM', stop: '10:30 PM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               // Stagger the publish tasks by 1 hour so that A3/A4 tests cannot overlap causing capacity issues.
+               {
+                 name: 'time-rocky-linux-8-optimized-gcp-nvidia-550',
+                 type: 'time',
+                 source: { start: '11:00 PM', stop: '11:30 PM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               {
+                 name: 'time-rocky-linux-8-optimized-gcp-nvidia-570',
+                 type: 'time',
+                 source: { start: '12:00 AM', stop: '12:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               {
+                 name: 'time-rocky-linux-8-optimized-gcp-nvidia-latest',
+                 type: 'time',
+                 source: { start: '1:00 AM', stop: '1:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               {
+                 name: 'time-rocky-linux-9-optimized-gcp-nvidia-550',
+                 type: 'time',
+                 source: { start: '2:00 AM', stop: '2:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               {
+                 name: 'time-rocky-linux-9-optimized-gcp-nvidia-570',
+                 type: 'time',
+                 source: { start: '3:00 AM', stop: '3:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               {
+                 name: 'time-rocky-linux-9-optimized-gcp-nvidia-latest',
+                 type: 'time',
+                 source: { start: '4:00 AM', stop: '4:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
                },
                common.gitresource { name: 'compute-image-tools' },
                common.gitresource { name: 'guest-test-infra' },

--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -21,11 +21,6 @@ local imgbuildtask = daisy.daisyimagetask {
   shasum_destination: '((.:shasum-destination))',
 };
 
-local prepublishtesttask = common.imagetesttask {
-  filter: '(shapevalidation)', // TODO enable oslogin
-  extra_args: [ '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
-};
-
 local imgbuildjob = {
   local tl = self,
 
@@ -282,16 +277,9 @@ local imgpublishjob = {
             file: 'publish-version/version',
           },
         ] +
-        // Run prepublish tests and invoke ARLE in prod
+        // Invoke ARLE in prod
         if tl.env == 'prod' then
         [
-          {
-            task: 'prepublish-test-' + tl.image,
-            config: prepublishtesttask {
-              images: 'projects/bct-prod-images/global/images/%s-((.:publish-version))' % tl.image_prefix,
-            },
-            attempts: 3,
-          },
           {
             task: 'publish-' + tl.image,
             config: arle.arlepublishtask {

--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -244,7 +244,8 @@ local imgpublishjob = {
           {
             get: tl.image + '-gcs',
             passed: [tl.passed],
-            trigger: tl.trigger,
+            trigger: if tl.env == 'testing' then true
+            else false,
             params: { skip_download: 'true' },
           },
           {

--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -231,7 +231,7 @@ local imgpublishjob = {
 
   // Start of job.
   name: 'publish-to-%s-%s' % [tl.env, tl.image],
-  plan: [
+  plan: tl.daily_task + [
           { get: 'guest-test-infra' },
           { get: 'compute-image-tools' },
           {


### PR DESCRIPTION
The lack of hardware availability requires the tests to not overlap. Setting 1 hour gaps between the publish tasks so that they can run without overlapping hardware-limited test suites.