### PR TITLE
Remove trigger from gcs-get operation

### DIFF
--- a/concourse/pipelines/accelerator-image-build.jsonnet
+++ b/concourse/pipelines/accelerator-image-build.jsonnet
@@ -244,8 +244,6 @@ local imgpublishjob = {
           {
             get: tl.image + '-gcs',
             passed: [tl.passed],
-            trigger: if tl.env == 'testing' then true
-            else false,
             params: { skip_download: 'true' },
           },
           {


### PR DESCRIPTION
This was causing concurrency when build runs pass. This makes it such that the time resource is the only authoritative trigger in the plan.