### PR TITLE
Update Debian13 image paths for testing

### DIFF
--- a/concourse/pipelines/guest-package-dev-build.jsonnet
+++ b/concourse/pipelines/guest-package-dev-build.jsonnet
@@ -386,7 +386,7 @@ local build_guest_configs = buildpackagejob {
         steps: [
           buildpackageimagetask {
             image_name: 'debian-13',
-            source_image: 'projects/bct-prod-images/global/images/family/debian-12',
+            source_image: 'projects/bct-prod-images/global/images/family/debian-13',
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb',
           },
@@ -494,7 +494,7 @@ local build_guest_agent = buildpackagejob {
         steps: [
           buildpackageimagetask {
             image_name: 'debian-13',
-            source_image: 'projects/bct-prod-images/global/images/family/debian-12',
+            source_image: 'projects/bct-prod-images/global/images/family/debian-13',
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent_((.:package-version))-g1_amd64.deb' % [tl.package],
           },
@@ -628,7 +628,7 @@ local build_and_upload_oslogin = buildpackagejob {
             steps: [
               buildpackageimagetask {
                 image_name: 'debian-13',
-                source_image: 'projects/bct-prod-images/global/images/family/debian-12',
+                source_image: 'projects/bct-prod-images/global/images/family/debian-13',
                 dest_image: 'debian-13-((.:build-id))',
                 gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb12_amd64.deb',
               },

--- a/packagebuild/workflows/build_deb13.wf.json
+++ b/packagebuild/workflows/build_deb13.wf.json
@@ -37,7 +37,7 @@
         "Path": "./build_package.wf.json",
         "Vars": {
           "type": "deb",
-          "sourceImage": "projects/bct-prod-images/global/images/family/debian-12",
+          "sourceImage": "projects/bct-prod-images/global/images/family/debian-13",
           "gcs_path": "${gcs_path}",
           "repo_owner": "${repo_owner}",
           "repo_name": "${repo_name}",


### PR DESCRIPTION
Switches package build image sources to a bootstrap image I think will do the trick.