### PR TITLE
package build: make sure we fetch tags as well

### DIFF
--- a/packagebuild/common.sh
+++ b/packagebuild/common.sh
@@ -81,7 +81,7 @@ function git_checkout() {
   git init
 
   # fetch only the branch that we want to build
-  git_command="git fetch https://github.com/${BASE_REPO}/${REPO}.git ${PULL_REF:-"master"}"
+  git_command="git fetch --tags https://github.com/${BASE_REPO}/${REPO}.git ${PULL_REF:-"master"}"
   echo "Running ${git_command}"
   $git_command
 


### PR DESCRIPTION
When building a package the pipeline knows only about the tags it creates, in case of guest agent's multi pipeline and multi branches one pipeline doesn't have the context or knowledge of the tags created by the other - even though they share the same git repository.