### PR TITLE
package build: force fetching tags from github repo

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -136,7 +136,7 @@ local base_buildpackagejob = {
             '-exc',
             // Ugly way to produce multi-line script. TODO: maybe move to scripts?
             std.lines([
-              'latest=$(cd repo;git tag -l "20*"|tail -1)',
+              'latest=$(cd repo;git fetch --tags origin;git tag -l "20*"|tail -1)',
               'latest_date=${latest/.*}',
               'todays_date=$(date "+%Y%m%d")',
               'latest_build=0',


### PR DESCRIPTION
When concourse generates the pipeline the tags should also be sync'ed up.