### PR TITLE
Scope down dev package builds to Deb13 only

### DIFF
--- a/concourse/pipelines/guest-package-dev-build.jsonnet
+++ b/concourse/pipelines/guest-package-dev-build.jsonnet
@@ -338,7 +338,7 @@ local buildpackageimagetaskcos = {
 local build_guest_configs = buildpackagejob {
   local tl = self,
   package:: error 'must set package for build_guest_configs',
-  builds: ['deb13', 'el10'],
+  builds: ['deb13'],
   gcs_dir: 'google-compute-engine',
   uploads: [
     uploadpackageversiontask {
@@ -348,15 +348,6 @@ local build_guest_configs = buildpackagejob {
       pkg_name: 'guest-configs',
       pkg_version: '((.:package-version))',
       reponame: 'gce-google-compute-engine-trixie',
-      sbom_file: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version)).sbom.json',
-    },
-    uploadpackageversiontask {
-      gcs_files: '"gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version))-g1.el10.noarch.rpm"',
-      os_type: 'EL10_YUM',
-      pkg_inside_name: 'google-compute-engine',
-      pkg_name: 'guest-configs',
-      pkg_version: '((.:package-version))',
-      reponame: 'gce-google-compute-engine-el10',
       sbom_file: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version)).sbom.json',
     },
   ],
@@ -390,30 +381,6 @@ local build_guest_configs = buildpackagejob {
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb',
           },
-          buildpackageimagetask {
-            image_name: 'debian-13-arm64',
-            source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
-            dest_image: 'debian-13-arm64-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb',
-            machine_type: 'c4a-standard-2',
-            disk_type: 'hyperdisk-balanced',
-            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-          },
-          buildpackageimagetask {
-            image_name: 'rhel-10',
-            source_image: 'projects/rhel-cloud/global/images/family/rhel-9',
-            dest_image: 'rhel-10-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version))-g1.el10.noarch.rpm',
-          },
-          buildpackageimagetask {
-            image_name: 'rhel-10-arm64',
-            source_image: 'projects/rhel-cloud/global/images/family/rhel-9-arm64',
-            dest_image: 'rhel-10-arm64-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version))-g1.el10.noarch.rpm',
-            machine_type: 'c4a-standard-2',
-            disk_type: 'hyperdisk-balanced',
-            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-          },
         ],
       },
     },
@@ -435,30 +402,8 @@ local build_guest_configs = buildpackagejob {
                   '-project=gcp-guest',
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
-                  '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/debian-13-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/rhel-10-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-9-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-9-optimized-gcp-((.:build-id))',
+                  '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/debian-13-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-9-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-9-optimized-gcp-((.:build-id))',
                   '-filter=^(packagemanager|networkinterfacenaming|cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|mdsroutes|vmspec)$',
-                  '-parallel_count=15',
-                ],
-              },
-            },
-          },
-          {
-            task: '%s-image-tests-arm64' % [tl.package],
-            config: {
-              platform: 'linux',
-              image_resource: {
-                type: 'registry-image',
-                source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
-              },
-              inputs: [{ name: 'guest-test-infra' }],
-              run: {
-                path: '/manager',
-                args: [
-                  '-project=gcp-guest',
-                  '-zone=us-central1-a',
-                  '-images=projects/gcp-guest/global/images/debian-13-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-10-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-9-arm64-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|mdsroutes|vmspec)$',
-                  '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-parallel_count=15',
                 ],
               },
@@ -475,7 +420,7 @@ local build_guest_agent = buildpackagejob {
 
   package:: error 'must set package in build_guest_agent',
   uploads: [],
-  builds: ['deb13', 'deb13-arm64', 'el10', 'el10-arm64'],
+  builds: ['deb13'],
   // The guest agent has additional testing steps to build derivative images then run CIT against them.
   extra_tasks: [
     {
@@ -507,30 +452,6 @@ local build_guest_agent = buildpackagejob {
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent_((.:package-version))-g1_amd64.deb' % [tl.package],
           },
-          buildpackageimagetask {
-            image_name: 'debian-13-arm64',
-            source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
-            dest_image: 'debian-13-arm64-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent_((.:package-version))-g1_arm64.deb' % [tl.package],
-            machine_type: 'c4a-standard-2',
-            disk_type: 'hyperdisk-balanced',
-            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-          },
-          buildpackageimagetask {
-            image_name: 'rhel-10',
-            source_image: 'projects/rhel-cloud/global/images/family/rhel-9',
-            dest_image: 'rhel-10-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el10.x86_64.rpm' % [tl.package],
-          },
-          buildpackageimagetask {
-            image_name: 'rhel-10-arm64',
-            source_image: 'projects/rhel-cloud/global/images/family/rhel-9-arm64',
-            dest_image: 'rhel-10-arm64-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el10.aarch64.rpm' % [tl.package],
-            machine_type: 'c4a-standard-2',
-            disk_type: 'hyperdisk-balanced',
-            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-          },
         ],
       },
     },
@@ -552,29 +473,7 @@ local build_guest_agent = buildpackagejob {
                   '-project=gcp-guest',
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
-                  '-images=projects/gcp-guest/global/images/debian-13-((.:build-id)),projects/gcp-guest/global/images/rhel-10-((.:build-id))',
-                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|vmspec|compatmanager|pluginmanager)$',
-                  '-parallel_count=15',
-                ],
-              },
-            },
-          },
-          {
-            task: '%s-image-tests-arm64' % [tl.package],
-            config: {
-              platform: 'linux',
-              image_resource: {
-                type: 'registry-image',
-                source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
-              },
-              inputs: [{ name: 'guest-test-infra' }],
-              run: {
-                path: '/manager',
-                args: [
-                  '-project=gcp-guest',
-                  '-zone=us-central1-a',
-                  '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
-                  '-images=projects/gcp-guest/global/images/rhel-10-arm64-((.:build-id))',
+                  '-images=projects/gcp-guest/global/images/debian-13-((.:build-id))',
                   '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|vmspec|compatmanager|pluginmanager)$',
                   '-parallel_count=15',
                 ],
@@ -602,15 +501,6 @@ local build_and_upload_guest_agent = build_guest_agent {
       reponame: 'google-guest-agent-trixie',
       sbom_file: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version)).sbom.json' % [tl.package],
     },
-    uploadpackageversiontask {
-      gcs_files: '"gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el10.x86_64.rpm","gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el10.aarch64.rpm"' % [tl.package, tl.package],
-      os_type: 'EL10_YUM',
-      pkg_inside_name: 'google-guest-agent',
-      pkg_name: 'guest-agent',
-      pkg_version: '((.:package-version))',
-      reponame: 'google-guest-agent-el10',
-      sbom_file: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version)).sbom.json' % [tl.package],
-    },
   ],
 };
 
@@ -618,7 +508,7 @@ local build_and_upload_oslogin = buildpackagejob {
       local tl = self,
       package:: error 'must set package in build_and_upload_oslogin',
       gcs_dir:: error 'must set gcs_dir in build_and_upload_oslogin',
-      builds: ['deb13', 'deb13-arm64', 'el10', 'el10-arm64'],
+      builds: ['deb13'],
       extra_tasks: [
         {
           task: 'generate-build-id',
@@ -650,30 +540,6 @@ local build_and_upload_oslogin = buildpackagejob {
                 dest_image: 'debian-13-((.:build-id))',
                 gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb12_amd64.deb',
               },
-              buildpackageimagetask {
-                image_name: 'debian-13-arm64',
-                source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
-                dest_image: 'debian-13-arm64-((.:build-id))',
-                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb12_arm64.deb',
-                machine_type: 'c4a-standard-2',
-                disk_type: 'hyperdisk-balanced',
-                worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-              },
-              buildpackageimagetask {
-                image_name: 'rhel-10',
-                source_image: 'projects/rhel-cloud/global/images/family/rhel-9',
-                dest_image: 'rhel-10-((.:build-id))',
-                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el10.x86_64.rpm',
-              },
-              buildpackageimagetask {
-                image_name: 'rhel-10-arm64',
-                source_image: 'projects/rhel-cloud/global/images/family/rhel-10-arm64',
-                dest_image: 'rhel-10-arm64-((.:build-id))',
-                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el10.aarch64.rpm',
-                machine_type: 'c4a-standard-2',
-                disk_type: 'hyperdisk-balanced',
-                worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
-              },
             ],
           },
         },
@@ -696,29 +562,7 @@ local build_and_upload_oslogin = buildpackagejob {
                       '-zone=us-central1-a',
                       '-test_projects=oslogin-cit',
                       '-parallel_count=2',
-                      '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/debian-13-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id)),projects/gcp-guest/global/images/rhel-10-((.:build-id))',
-                      '-filter=oslogin',
-                    ],
-                  },
-                },
-              },
-              {
-                task: 'oslogin-image-tests-arm64',
-                config: {
-                  platform: 'linux',
-                  image_resource: {
-                    type: 'registry-image',
-                    source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
-                  },
-                  inputs: [{ name: 'guest-test-infra' }],
-                  run: {
-                    path: '/manager',
-                    args: [
-                      '-project=gcp-guest',
-                      '-zone=us-central1-a',
-                      '-test_projects=oslogin-cit',
-                      '-images=projects/gcp-guest/global/images/debian-13-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-10-arm64-((.:build-id))',
-                      '-parallel_count=2',
+                      '-images=projects/gcp-guest/global/images/debian-11-((.:build-id)),projects/gcp-guest/global/images/debian-12-((.:build-id)),projects/gcp-guest/global/images/debian-13-((.:build-id)),projects/gcp-guest/global/images/rhel-8-((.:build-id)),projects/gcp-guest/global/images/rhel-9-((.:build-id))',
                       '-filter=oslogin',
                     ],
                   },
@@ -736,15 +580,6 @@ local build_and_upload_oslogin = buildpackagejob {
           pkg_name: 'guest-oslogin',
           pkg_version: '((.:package-version))',
           reponame: 'gce-google-compute-engine-oslogin-trixie',
-          sbom_file: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version)).sbom.json',
-        },
-        uploadpackageversiontask {
-          gcs_files: '"gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el10.x86_64.rpm","gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version))-g1.el10.aarch64.rpm"',
-          os_type: 'EL10_YUM',
-          pkg_inside_name: 'google-compute-engine-oslogin',
-          pkg_name: 'guest-oslogin',
-          pkg_version: '((.:package-version))',
-          reponame: 'gce-google-compute-engine-oslogin-el10',
           sbom_file: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin-((.:package-version)).sbom.json',
         },
       ],
@@ -784,40 +619,8 @@ local build_and_upload_oslogin = buildpackagejob {
       repo_name: 'guest-oslogin',
     },
     buildpackagejob {
-      package: 'guest-diskexpand',
-      builds: ['deb12', 'deb13', 'el8', 'el9', 'el10'],
-      gcs_dir: 'gce-disk-expand',
-      uploads: [
-        uploadpackageversiontask {
-          gcs_files: '"gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version))-g1.el10.noarch.rpm"',
-          os_type: 'EL10_YUM',
-          pkg_inside_name: 'gce-disk-expand',
-          pkg_name: 'guest-diskexpand',
-          pkg_version: '((.:package-version))',
-          reponame: 'gce-disk-expand-el10',
-          sbom_file: 'gs://gcp-guest-package-uploads/gce-disk-expand/gce-disk-expand-((.:package-version)).sbom.json',
-        },
-      ],
-    },
-    buildpackagejob {
-      package: 'artifact-registry-yum-plugin',
-      builds: ['el8', 'el8-arm64', 'el9', 'el9-arm64'],
-      gcs_dir: 'yum-plugin-artifact-registry',
-      uploads: [
-        uploadpackageversiontask {
-          gcs_files: '"gs://gcp-guest-package-uploads/yum-plugin-artifact-registry/dnf-plugin-artifact-registry-((.:package-version))-g1.el10.x86_64.rpm","gs://gcp-guest-package-uploads/yum-plugin-artifact-registry/dnf-plugin-artifact-registry-((.:package-version))-g1.el10.aarch64.rpm"',
-          os_type: 'EL10_YUM',
-          pkg_inside_name: 'dnf-plugin-artifact-registry',
-          pkg_name: 'artifact-registry-dnf-plugin',
-          pkg_version: '((.:package-version))',
-          reponame: 'dnf-plugin-artifact-registry-el10',
-          sbom_file: 'gs://gcp-guest-package-uploads/yum-plugin-artifact-registry/dnf-plugin-artifact-registry-((.:package-version)).sbom.json',
-        },
-      ],
-    },
-    buildpackagejob {
       package: 'artifact-registry-apt-transport',
-      builds: ['deb13', 'deb13-arm64'],
+      builds: ['deb13'],
       uploads: [
         uploadpackageversiontask {
           gcs_files: '"gs://gcp-guest-package-uploads/artifact-registry-apt-transport/apt-transport-artifact-registry_((.:package-version))-g1_amd64.deb","gs://gcp-guest-package-uploads/artifact-registry-apt-transport/apt-transport-artifact-registry_((.:package-version))-g1_arm64.deb"',


### PR DESCRIPTION
Remove RHEL10 and Debian 13 arm build/uploads to test non-arm builds. ARM can't be built until Python 3.13 is supported by gsutil in early July.