### PR TITLE
Reintroduce Arm64 builds for Debian13 packages

### DIFF
--- a/concourse/pipelines/guest-package-dev-build.jsonnet
+++ b/concourse/pipelines/guest-package-dev-build.jsonnet
@@ -381,6 +381,15 @@ local build_guest_configs = buildpackagejob {
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb',
           },
+          buildpackageimagetask {
+            image_name: 'debian-13-arm64',
+            source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
+            dest_image: 'debian-13-arm64-((.:build-id))',
+            gcs_package_path: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb',
+            machine_type: 'c4a-standard-2',
+            disk_type: 'hyperdisk-balanced',
+            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
+          },
         ],
       },
     },
@@ -409,6 +418,28 @@ local build_guest_configs = buildpackagejob {
               },
             },
           },
+          {
+            task: '%s-image-tests-arm64' % [tl.package],
+            config: {
+              platform: 'linux',
+              image_resource: {
+                type: 'registry-image',
+                source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
+              },
+              inputs: [{ name: 'guest-test-infra' }],
+              run: {
+                path: '/manager',
+                args: [
+                  '-project=gcp-guest',
+                  '-zone=us-central1-a',
+                  '-images=projects/gcp-guest/global/images/debian-13-arm64-((.:build-id))',
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|mdsroutes|vmspec)$',
+                  '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
+                  '-parallel_count=15',
+                ],
+              },
+            },
+          },
         ],
       },
     },
@@ -420,7 +451,7 @@ local build_guest_agent = buildpackagejob {
 
   package:: error 'must set package in build_guest_agent',
   uploads: [],
-  builds: ['deb13'],
+  builds: ['deb13', 'deb13-arm64'],
   // The guest agent has additional testing steps to build derivative images then run CIT against them.
   extra_tasks: [
     {
@@ -452,6 +483,15 @@ local build_guest_agent = buildpackagejob {
             dest_image: 'debian-13-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent_((.:package-version))-g1_amd64.deb' % [tl.package],
           },
+          buildpackageimagetask {
+            image_name: 'debian-13-arm64',
+            source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
+            dest_image: 'debian-13-arm64-((.:build-id))',
+            gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent_((.:package-version))-g1_arm64.deb' % [tl.package],
+            machine_type: 'c4a-standard-2',
+            disk_type: 'hyperdisk-balanced',
+            worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
+          },
         ],
       },
     },
@@ -474,6 +514,28 @@ local build_guest_agent = buildpackagejob {
                   '-zone=us-central1-a',
                   '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
                   '-images=projects/gcp-guest/global/images/debian-13-((.:build-id))',
+                  '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|vmspec|compatmanager|pluginmanager)$',
+                  '-parallel_count=15',
+                ],
+              },
+            },
+          },
+          {
+            task: '%s-image-tests-arm64' % [tl.package],
+            config: {
+              platform: 'linux',
+              image_resource: {
+                type: 'registry-image',
+                source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
+              },
+              inputs: [{ name: 'guest-test-infra' }],
+              run: {
+                path: '/manager',
+                args: [
+                  '-project=gcp-guest',
+                  '-zone=us-central1-a',
+                  '-test_projects=compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
+                  '-images=projects/gcp-guest/global/images/debian-13-arm64-((.:build-id))',
                   '-filter=^(cvm|loadbalancer|guestagent|hostnamevalidation|network|packagevalidation|ssh|metadata|vmspec|compatmanager|pluginmanager)$',
                   '-parallel_count=15',
                 ],
@@ -508,7 +570,7 @@ local build_and_upload_oslogin = buildpackagejob {
       local tl = self,
       package:: error 'must set package in build_and_upload_oslogin',
       gcs_dir:: error 'must set gcs_dir in build_and_upload_oslogin',
-      builds: ['deb13'],
+      builds: ['deb13', 'deb13-arm'],
       extra_tasks: [
         {
           task: 'generate-build-id',
@@ -540,6 +602,15 @@ local build_and_upload_oslogin = buildpackagejob {
                 dest_image: 'debian-13-((.:build-id))',
                 gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb13_amd64.deb',
               },
+              buildpackageimagetask {
+                image_name: 'debian-13-arm64',
+                source_image: 'projects/bct-prod-images/global/images/family/debian-13-arm64',
+                dest_image: 'debian-13-arm64-((.:build-id))',
+                gcs_package_path: 'gs://gcp-guest-package-uploads/oslogin/google-compute-engine-oslogin_((.:package-version))-g1+deb12_arm64.deb',
+                machine_type: 'c4a-standard-2',
+                disk_type: 'hyperdisk-balanced',
+                worker_image: 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64',
+              },
             ],
           },
         },
@@ -563,6 +634,28 @@ local build_and_upload_oslogin = buildpackagejob {
                       '-test_projects=oslogin-cit',
                       '-parallel_count=2',
                       '-images=projects/gcp-guest/global/images/debian-13-((.:build-id))',
+                      '-filter=oslogin',
+                    ],
+                  },
+                },
+              },
+              {
+                task: 'oslogin-image-tests-arm64',
+                config: {
+                  platform: 'linux',
+                  image_resource: {
+                    type: 'registry-image',
+                    source: { repository: 'gcr.io/compute-image-tools/cloud-image-tests' },
+                  },
+                  inputs: [{ name: 'guest-test-infra' }],
+                  run: {
+                    path: '/manager',
+                    args: [
+                      '-project=gcp-guest',
+                      '-zone=us-central1-a',
+                      '-test_projects=oslogin-cit',
+                      '-images=projects/gcp-guest/global/images/debian-13-arm64-((.:build-id)),projects/gcp-guest/global/images/debian-12-arm64-((.:build-id)),projects/gcp-guest/global/images/rocky-linux-8-optimized-gcp-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-9-arm64-((.:build-id)),projects/gcp-guest/global/images/rhel-10-arm64-((.:build-id))',
+                      '-parallel_count=2',
                       '-filter=oslogin',
                     ],
                   },
@@ -620,7 +713,7 @@ local build_and_upload_oslogin = buildpackagejob {
     },
     buildpackagejob {
       package: 'artifact-registry-apt-transport',
-      builds: ['deb13'],
+      builds: ['deb13', 'deb13-arm64'],
       uploads: [
         uploadpackageversiontask {
           gcs_files: '"gs://gcp-guest-package-uploads/artifact-registry-apt-transport/apt-transport-artifact-registry_((.:package-version))-g1_amd64.deb","gs://gcp-guest-package-uploads/artifact-registry-apt-transport/apt-transport-artifact-registry_((.:package-version))-g1_arm64.deb"',


### PR DESCRIPTION
I messed up the commits so this is probably easier than reverting. I'll have to make a followup to revert RHEL10 once this is done.