### PR TITLE
Add 'dc' string to windows image name

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -622,7 +622,7 @@ local build_guest_agent = buildpackagejob {
           buildpackageimagetaskwindows {
             image_name: 'windows-2022',
             source_image: 'projects/windows-cloud/global/images/family/windows-2022',
-            dest_image: 'windows-2022-((.:build-id))',
+            dest_image: 'windows-server-2022-dc-((.:build-id))',
             gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-compute-engine-windows.x86_64.((.:package-version)).0@1.goo' % [tl.package],
           },
           buildpackageimagetask {


### PR DESCRIPTION
CIT tests like [this](https://github.com/GoogleCloudPlatform/cloud-image-tests/blob/8a96c0c5dfed9483be5ed84499a10903ef70f5b4/test_suites/packagevalidation/windows_version_test.go#L296) expects `dc` keyword in image names


/cc @dorileo @drewhli 