### PR TITLE
Update rhel package build script

### DIFF
--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -49,7 +49,6 @@ VERSION_ID=6
 if [[ -f /etc/os-release ]]; then
   eval $(grep VERSION_ID /etc/os-release)
   VERSION_ID=${VERSION_ID%.*}
-  echo "Version: ${VERSION_ID}"
 fi
 
 GIT="git"

--- a/packagebuild/daisy_startupscript_rpm.sh
+++ b/packagebuild/daisy_startupscript_rpm.sh
@@ -48,7 +48,8 @@ deploy_sbomutil
 VERSION_ID=6
 if [[ -f /etc/os-release ]]; then
   eval $(grep VERSION_ID /etc/os-release)
-  VERSION_ID=${VERSION_ID:0:1}
+  VERSION_ID=${VERSION_ID%.*}
+  echo "Version: ${VERSION_ID}"
 fi
 
 GIT="git"
@@ -77,6 +78,11 @@ if [[ ${VERSION_ID} = 9 ]]; then
 fi
 
 try_command yum install -y $GIT rpmdevtools yum-utils python3-devel make
+
+# RHEL 10 requires gcc in addition to the previous command's packages
+if [[ ${VERSION_ID} == 10 ]]; then
+  try_command yum install -y gcc
+fi
 
 ROOT_WORK_DIR=$(pwd)
 git_checkout "$REPO_OWNER" "$REPO_NAME" "$GIT_REF"


### PR DESCRIPTION
Building in 10 requires gcc now; added version check to install gcc for version 10. Required change to logic setting VERSION_ID as it would truncate 2 digit version numbers. Tested with CentOS 8, 9, 10, all succeed to build guest agent in testing.