### PR TITLE
Update source image to use in package build workflow

### DIFF
--- a/packagebuild/workflows/build_goo.wf.json
+++ b/packagebuild/workflows/build_goo.wf.json
@@ -35,7 +35,7 @@
         "Path": "./build_package.wf.json",
         "Vars": {
           "type": "goo",
-          "sourceImage": "projects/debian-cloud/global/images/family/debian-11",
+          "sourceImage": "projects/debian-cloud/global/images/family/debian-12",
           "gcs_path": "${gcs_path}",
           "repo_owner": "${repo_owner}",
           "repo_name": "${repo_name}",


### PR DESCRIPTION
Makes it consistent with other worfklows using debian source images and should fix 

`E: The repository 'https://deb.debian.org/debian bullseye-backports Release' no longer has a Release file.`


/cc @dorileo @drewhli 

