### PR TITLE
Stop building on Debian 11 for guest configs, reuse Debian 12's instead

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -371,18 +371,9 @@ local buildpackageimagetaskcos = {
 local build_guest_configs = buildpackagejob {
   local tl = self,
   package:: error 'must set package for build_guest_configs',
-  builds: ['deb12', 'deb11', 'el8', 'el9'],
+  builds: ['deb12', 'el8', 'el9'],
   gcs_dir: 'google-compute-engine',
   uploads: [
-    uploadpackageversiontask {
-      gcs_files: '"gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb"',
-      os_type: 'BUSTER_APT',
-      pkg_inside_name: 'google-compute-engine',
-      pkg_name: 'guest-configs',
-      pkg_version: '((.:package-version))',
-      reponame: 'gce-google-compute-engine-buster',
-      sbom_file: 'gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine-((.:package-version)).sbom.json',
-    },
     uploadpackageversiontask {
       gcs_files: '"gs://gcp-guest-package-uploads/google-compute-engine/google-compute-engine_((.:package-version))-g1_all.deb"',
       os_type: 'BULLSEYE_APT',


### PR DESCRIPTION
This is copying the setup we have for the guest agent builds. Currently Debian 11 images are facing an issue where `apt update` is failing due to one of the backports repos being turned down. This is thus causing package builds to fail.

Also remove the obsolete Debian 10 upload task.

/cc @dorileo @ChaitanyaKulkarni28 