### PR TITLE
Remove rhel-9-6-sap-ha image derivation until images/family/rhel-9-6-sap-ha is available

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -742,12 +742,6 @@ local build_guest_agent = buildpackagejob {
             gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el9.x86_64.rpm' % [tl.package],
           },
           buildpackageimagetask {
-            image_name: 'rhel-9-6-sap-ha',
-            source_image: 'projects/rhel-sap-cloud/global/images/family/rhel-9-6-sap-ha',
-            dest_image: 'rhel-9-6-sap-ha-((.:build-id))',
-            gcs_package_path: 'gs://gcp-guest-package-uploads/%s/google-guest-agent-((.:package-version))-g1.el9.x86_64.rpm' % [tl.package],
-          },
-          buildpackageimagetask {
             image_name: 'oracle-linux-9',
             source_image: 'projects/oracle-linux-cloud/global/images/family/oracle-linux-9',
             dest_image: 'oracle-linux-9-((.:build-id))',


### PR DESCRIPTION
Package builds are failing with error `projects/rhel-sap-cloud/global/images/family/rhel-9-6-sap-ha does not exist`