### PR TITLE
Remove Debian13 from dev pipelines

### DIFF
--- a/concourse/pipelines/guest-package-dev-build.jsonnet
+++ b/concourse/pipelines/guest-package-dev-build.jsonnet
@@ -840,24 +840,6 @@ local build_and_upload_oslogin = buildpackagejob {
       },
     },
     {
-      name: 'artifact-registry-apt-transport',
-      type: 'git',
-      source: {
-        uri: 'https://github.com/GoogleCloudPlatform/artifact-registry-apt-transport.git',
-        branch: 'main',
-        fetch_tags: true,
-      },
-    },
-    {
-      name: 'artifact-registry-apt-transport-tag',
-      type: 'github-release',
-      source: {
-        owner: 'GoogleCloudPlatform',
-        repository: 'artifact-registry-apt-transport',
-        access_token: '((github-token.token))',
-      },
-    },
-    {
       name: 'guest-test-infra',
       type: 'git',
       source: {
@@ -943,7 +925,6 @@ local build_and_upload_oslogin = buildpackagejob {
       name: 'artifact-registry-plugins',
       jobs: [
         'build-artifact-registry-yum-plugin',
-        'build-artifact-registry-apt-transport',
       ],
     },
     {

--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -386,7 +386,6 @@ local imggroup = {
 
 {
   local almalinux_images = ['almalinux-9-arm64'],
-  //local debian_images = [''],
   local rhel_images = ['rhel-10', 'rhel-10-arm64', 'rhel-10-byos', 'rhel-10-byos-arm64'],
   local centos_images = ['centos-stream-10', 'centos-stream-10-arm64'],
 
@@ -415,56 +414,18 @@ local imggroup = {
              [common.gcsimgresource { image: image, gcs_dir: 'almalinux' } for image in almalinux_images] +
              [common.gcssbomresource { image: image, sbom_destination: 'almalinux' } for image in almalinux_images] +
              [common.gcsshasumresource { image: image, shasum_destination: 'almalinux' } for image in almalinux_images] +
-             //[
-               //common.gcsimgresource {
-                 //image: image,
-                 //regexp: 'debian/%s-v([0-9]+).tar.gz' % common.debian_image_prefixes[self.image],
-               //}
-               //for image in debian_images
-             //] +
-             //[common.gcssbomresource {
-               //image: image,
-               //image_prefix: common.debian_image_prefixes[image],
-               //sbom_destination: 'debian',
-             //} for image in debian_images] +
-             //[common.gcsshasumresource {
-               //image: image,
-               //image_prefix: common.debian_image_prefixes[image],
-               //shasum_destination: 'debian',
-             //} for image in debian_images] +
              [common.gcsimgresource { image: image, gcs_dir: 'rhel' } for image in rhel_images] +
              [common.gcssbomresource { image: image, sbom_destination: 'rhel' } for image in rhel_images] +
              [common.gcsshasumresource { image: image, shasum_destination: 'rhel' } for image in rhel_images] +
              [common.gcsimgresource { image: image, gcs_dir: 'centos' } for image in centos_images] +
              [common.gcssbomresource { image: image, sbom_destination: 'centos' } for image in centos_images] +
              [common.gcsshasumresource { image: image, shasum_destination: 'centos' } for image in centos_images],
-  jobs: //[
-          // Debian build jobs
-          //debianimgbuildjob {
-            //image: image,
-            //image_prefix: common.debian_image_prefixes[image],
-          //}
-          //for image in debian_images
-        //] +
+  jobs: 
         [
           // EL build jobs
           elimgbuildjob { image: image }
           for image in almalinux_images + rhel_images + centos_images
         ] +
-        //[
-          // Debian publish jobs
-          //imgpublishjob {
-            //image: image,
-           // env: env,
-            //gcs_dir: 'debian',
-            //workflow_dir: 'debian',
-
-            // Debian tarballs and images use a longer name, but jobs use the shorter name.
-            //image_prefix: common.debian_image_prefixes[image],
-          //}
-          //for env in envs
-          //for image in debian_images
-        //] +
         [
           // RHEL publish jobs
           imgpublishjob {


### PR DESCRIPTION
We're always fighting resource constraints, so now that things build in prod we should drop these to avoid additional resource conflicts.