### PR TITLE
Add support to target specific Debian versions in package build

### DIFF
--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -25,6 +25,7 @@ BUILD_DIR=$(curl -f -H Metadata-Flavor:Google ${URL}/build-dir)
 VERSION=$(curl -f -H Metadata-Flavor:Google ${URL}/version)
 VERSION=${VERSION:="1dummy"}
 SBOM_UTIL_GCS_ROOT=$(curl -f -H Metadata-Flavor:Google ${URL}/sbom-util-gcs-root)
+TARGET_VERSION=$(curl -H Metadata-Flavor:Google ${URL}/version)
 
 DEBIAN_FRONTEND=noninteractive
 
@@ -123,7 +124,7 @@ sed -i"" "/^Source:/aXB-Git: ${COMMITURL}" debian/control
 RELEASE="g1${DEB}"
 dch --create -M -v 1:${VERSION}-${RELEASE} --package $SOURCE_PKGNAME -D stable \
   "Debian packaging for ${SOURCE_PKGNAME}"
-DEB_BUILD_OPTIONS="noautodbgsym nocheck" debuild -e "VERSION=${VERSION}" -e "RELEASE=${RELEASE}" -us -uc
+DEB_BUILD_OPTIONS="noautodbgsym nocheck" debuild -e "VERSION=${VERSION}" -e "RELEASE=${RELEASE}" -e "TARGET_VERSION=${TARGET_VERSION}" -us -uc
 
 SBOM_FILE="${SBOM_DIR}/${SOURCE_PKGNAME}-${VERSION}.sbom.json"
 

--- a/packagebuild/daisy_startupscript_deb.sh
+++ b/packagebuild/daisy_startupscript_deb.sh
@@ -124,7 +124,12 @@ sed -i"" "/^Source:/aXB-Git: ${COMMITURL}" debian/control
 RELEASE="g1${DEB}"
 dch --create -M -v 1:${VERSION}-${RELEASE} --package $SOURCE_PKGNAME -D stable \
   "Debian packaging for ${SOURCE_PKGNAME}"
-DEB_BUILD_OPTIONS="noautodbgsym nocheck" debuild -e "VERSION=${VERSION}" -e "RELEASE=${RELEASE}" -e "TARGET_VERSION=${TARGET_VERSION}" -us -uc
+# Only pass in target_version if building guest_configs; this is the only package that currently needs it.
+if [[ $REPO_NAME == "guest-configs" ]]; then
+  DEB_BUILD_OPTIONS="noautodbgsym nocheck" debuild -e "VERSION=${VERSION}" -e "RELEASE=${RELEASE}" -e "TARGET_VERSION=${TARGET_VERSION}" -us -uc
+else
+  DEB_BUILD_OPTIONS="noautodbgsym nocheck" debuild -e "VERSION=${VERSION}" -e "RELEASE=${RELEASE}" -us -uc
+fi
 
 SBOM_FILE="${SBOM_DIR}/${SOURCE_PKGNAME}-${VERSION}.sbom.json"
 

--- a/packagebuild/workflows/build_deb11.wf.json
+++ b/packagebuild/workflows/build_deb11.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -46,7 +49,8 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "bullseye"
         }
       }
     }

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -49,7 +52,8 @@
           "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "bullseye"
         }
       }
     }

--- a/packagebuild/workflows/build_deb12.wf.json
+++ b/packagebuild/workflows/build_deb12.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -46,7 +49,8 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "bookworm"
         }
       }
     }

--- a/packagebuild/workflows/build_deb12_arm64.wf.json
+++ b/packagebuild/workflows/build_deb12_arm64.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -49,7 +52,8 @@
           "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "bookworm"
         }
       }
     }

--- a/packagebuild/workflows/build_deb13.wf.json
+++ b/packagebuild/workflows/build_deb13.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -46,7 +49,8 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "trixie"
         }
       }
     }

--- a/packagebuild/workflows/build_deb13_arm64.wf.json
+++ b/packagebuild/workflows/build_deb13_arm64.wf.json
@@ -28,6 +28,9 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "target_version": {
+      "Required": false
     }
   },
   "Steps": {
@@ -49,7 +52,8 @@
           "disk_type": "hyperdisk-balanced",
           "zone": "us-central1-a",
           "version": "${version}",
-          "sbom_util_gcs_root": "${sbom_util_gcs_root}"
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "target_version": "trixie"
         }
       }
     }

--- a/packagebuild/workflows/build_package.wf.json
+++ b/packagebuild/workflows/build_package.wf.json
@@ -41,6 +41,9 @@
     "sbom_util_gcs_root": {
       "Required": false
     },
+    "target_version": {
+      "Required": false
+    },
     "machine_type": {
       "Value": "e2-standard-2",
       "Description": "machine type"
@@ -74,7 +77,8 @@
             "extra-git-ref": "${extra_git_ref}",
             "build-dir": "${build_dir}",
             "version": "${version}",
-            "sbom-util-gcs-root": "${sbom_util_gcs_root}"
+            "sbom-util-gcs-root": "${sbom_util_gcs_root}",
+            "target-version": "${target_version}"
           },
           "machineType": "${machine_type}",
           "zone": "${zone}",


### PR DESCRIPTION
This adds an optional variable that when set, can be used by the debhelper to build for specific Debian versions, but retain the previous behavior of building for "all" when it is not set.