### PR TITLE
Randomize zone for linux-image-build-dev pipeline

### DIFF
--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -26,6 +26,11 @@ local prepublishtesttask = common.imagetesttask {
   extra_args: [ '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };
 
+// Select a random build zone based on the TIMESTAMP external variable.
+local seed = std.parseInt(std.extVar('TIMESTAMP'));
+local selected_arm_build_zone = common.arm_build_zones[seed % std.length(common.arm_build_zones)];
+local selected_x86_build_zone = common.x86_build_zones[seed % std.length(common.x86_build_zones)];
+
 local imgbuildjob = {
   local tl = self,
 
@@ -36,6 +41,7 @@ local imgbuildjob = {
   build_task:: imgbuildtask {
     workflow: tl.workflow,
     vars+: ['google_cloud_repo=stable'],
+    zone: if std.endsWith(tl.image, 'arm64') then selected_arm_build_zone else selected_x86_build_zone,
   },
   extra_tasks:: [],
   daily:: true,

--- a/concourse/tasks/render-templates.yaml
+++ b/concourse/tasks/render-templates.yaml
@@ -19,5 +19,5 @@ run:
   - |
     for template in guest-test-infra/((config_dir))/*.jsonnet; do
       base=$(basename "$template")
-      jsonnet $template > rendered/${base//.jsonnet}.json
+      jsonnet --ext-str TIMESTAMP="$(date +%s%N)" $template > rendered/${base//.jsonnet}.json
     done

--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -17,6 +17,19 @@
     'debian-13-arm64': 'debian-13-trixie-arm64',
   },
 
+  arm_build_zones: [
+    'us-central1-a',
+    'us-east1-b',
+    'europe-west4-a',
+  ],
+  x86_build_zones: [
+    'us-central1-b',
+    'us-east1-c',
+    'us-east4-c',
+    'us-west1-a',
+    'europe-west1-b',
+  ],
+
   gitresource:: {
     local resource = self,
 

--- a/container_images/fly-validate-pipelines/main.sh
+++ b/container_images/fly-validate-pipelines/main.sh
@@ -24,7 +24,7 @@ find . -type f -iname '*.yaml'|while read yaml; do
 done
 
 find . -type f -iname '*.jsonnet'|while read jsonnet; do
-  jsonnet "$jsonnet" | tee temp.json
+  jsonnet --ext-str TIMESTAMP="$(date +%s%N)" "$jsonnet" | tee temp.json
   fly vp -c temp.json
 done
 


### PR DESCRIPTION
Our jsonnet files were fully deterministic -- they generate the same JSON output every time they are run. In this change, we introduce an "external variable" to inject non-determinism in a controlled manner.

The external variable, `TIMESTAMP`, is set to `date +%s%N` (current timestamp including seconds and nanoseconds), and is used as a random seed to pick a random zone for the linux-image-build-dev pipeline. This PR uses the x86 and ARM build zones proposed in @lpleahy's previous PR (#1503). 

If this approach works, we can apply similar randomization to linux-image-build and windows-image-build.