### PR TITLE
Add tagging `deprecated-public-image-<SHA256>` to container builds. T…

### DIFF
--- a/concourse/pipelines/container-build.jsonnet
+++ b/concourse/pipelines/container-build.jsonnet
@@ -93,6 +93,29 @@ local buildcontainerimgjob = {
         ] + job.post_steps,
 };
 
+local DeprecateOldImagesTask(image_url, input_name) = {
+  task: 'deprecate-old-images',
+  config: {
+    platform: 'linux',
+    image_resource: {
+      type: 'registry-image',
+      source: {
+        // need gcrane to run tagger functionality in deprecate-images.sh
+        repository: 'gcr.io/go-containerregistry/gcrane',
+        tag: 'latest'
+      },
+    },
+    inputs: [{ name: input_name }],
+    params: {
+      DRY_RUN: "false", // Enable live tagging in the pipeline
+    },
+    run: {
+      path: './%s/concourse/scripts/deprecate-images.sh' % input_name,
+      args: [image_url],
+    },
+  },
+};
+
 // Function for our builds in guest-test-infra/container_images
 local BuildContainerImage(image, public_image_tag) = buildcontainerimgjob {
   repo:: 'gcr.io/gcp-guest',
@@ -101,6 +124,11 @@ local BuildContainerImage(image, public_image_tag) = buildcontainerimgjob {
   destination: '%s/%s' % [self.repo, image],
   context: 'guest-test-infra/container_images/' + image,
   public_image_tag: public_image_tag,
+  
+  // use script in post steps to tag old images as deprecated
+  post_steps+: [
+    DeprecateOldImagesTask(self.destination, self.input)
+  ],
 };
 
 // Start of output.

--- a/concourse/scripts/deprecate-images.sh
+++ b/concourse/scripts/deprecate-images.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+##
+# deprecate-images.sh
+# Tags older images in GCR/AR as deprecated, keeping only the latest.
+##
+
+set -euo pipefail
+
+# Default to dry run unless explicitly disabled
+DRY_RUN=${DRY_RUN:-true}
+IMAGE_URL=${1:-}
+
+if [[ -z "$IMAGE_URL" ]]; then
+  echo "Usage: [DRY_RUN=false] $0 <image_url>"
+  exit 1
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "--- DRY RUN MODE ENABLED (No changes will be made) ---"
+fi
+
+echo "Scanning $IMAGE_URL for older versions..."
+
+# Get all SHAs, sorted by upload time descending, skipping the first (latest) one.
+OLD_SHAS=$(gcrane ls "$IMAGE_URL" --json | jq -r '.manifest | to_entries | sort_by(.value.timeUploadedMs | tonumber) | reverse | .[1:] | .[].key' || echo "")
+
+if [[ -z "$OLD_SHAS" ]]; then
+  echo "No older images found for $IMAGE_URL. Skipping."
+  exit 0
+fi
+
+count=0
+for sha_with_prefix in $OLD_SHAS; do
+  FULL_SHA=${sha_with_prefix#sha256:}
+  TAG="deprecated-public-image-$FULL_SHA"
+  
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY-RUN] Would tag $IMAGE_URL@$sha_with_prefix as $TAG"
+    count=$((count + 1))
+  else
+    echo "Tagging $IMAGE_URL@$sha_with_prefix as $TAG"
+    gcrane tag "$IMAGE_URL@$sha_with_prefix" "$TAG"
+    count=$((count + 1))
+  fi
+done
+
+echo "---"
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Summary: $count images would have been tagged as deprecated."
+else
+  echo "Summary: Successfully tagged $count images as deprecated."
+fi


### PR DESCRIPTION
…his keeps only the `latest` and tags the rest as deprecated.