### PR TITLE
Removing Beta RHUI Client name

### DIFF
--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -217,8 +217,6 @@ local rhelimgbuildjob = imgbuildjob {
 
   local arch = if tl.is_arm then 'aarch64' else 'x86_64',
   local el_release_components = std.split(trim_strings(tl.isopath, ['-arm64']), '-'),
-  local is_beta = std.member(tl.image, '-beta'),
-
 
   disk_name::
     if tl.is_arm then 'disk_export_hyperdisk' else 'disk_export',
@@ -239,14 +237,12 @@ local rhelimgbuildjob = imgbuildjob {
   local rhui_package_name_base = 'google-rhui-client-rhel',
   local rhui_package_name_tenth_point_release =
     if tl.is_sap && std.length(el_release_components) > 2  && el_release_components[2] == '10' then '10' else '',
-  local rhui_package_name_beta =
-    if is_beta then '-beta' else '',
   local rhui_package_name_eus =
     if tl.is_eus then '-eus' else '',
   local rhui_package_name_sap =
     if tl.is_sap then '-sap' else '',
 
-  rhui_package_name:: rhui_package_name_base + tl.major_release + rhui_package_name_tenth_point_release + rhui_package_name_beta + rhui_package_name_eus + rhui_package_name_sap,
+  rhui_package_name:: rhui_package_name_base + tl.major_release + rhui_package_name_tenth_point_release + rhui_package_name_eus + rhui_package_name_sap,
 
   // Add tasks to obtain ISO location and sbom util source
   // Store those in .:iso-secret and .:sbom-util-secret


### PR DESCRIPTION
/cc @bkatyl  @lpleahy 

Red Hat has informed us that the RHUI Beta repos are only for the main version & that they don't release anything for any minor releases. To get these packages now we will be using the regular RHEL 10 RHUI Client.