### PR TITLE
Removing CIT for windows-install-media

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -550,7 +550,8 @@ local imgpublishjob = {
     else false,
 
   // Run tests on the testing stage
-  runtests:: if job.env == 'testing' then true
+  runtests:: if job.env == 'testing' &&
+  std.length(std.findSubstr("install-media", job.image)) == 0  then true
     else false,
 
   // Start of job.


### PR DESCRIPTION
/cc @bkatyl 

The windows installer media shouldn't have CIT running on them like the other images. This was mistakenly added when trying to add CIT's to the Window Client images in these PR's. [PR 1](https://github.com/GoogleCloudPlatform/guest-test-infra/pull/1538) [PR 2](https://github.com/GoogleCloudPlatform/guest-test-infra/pull/1539)