### PR TITLE
parameterize build zones in all package build workflows

### DIFF
--- a/packagebuild/workflows/build_deb11.wf.json
+++ b/packagebuild/workflows/build_deb11.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -49,6 +53,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "bullseye"
         }

--- a/packagebuild/workflows/build_deb11_arm64.wf.json
+++ b/packagebuild/workflows/build_deb11_arm64.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-east1-c",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -50,7 +54,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "bullseye"

--- a/packagebuild/workflows/build_deb12.wf.json
+++ b/packagebuild/workflows/build_deb12.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -49,6 +53,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "bookworm"
         }

--- a/packagebuild/workflows/build_deb12_arm64.wf.json
+++ b/packagebuild/workflows/build_deb12_arm64.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-east1-c",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -50,7 +54,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "bookworm"

--- a/packagebuild/workflows/build_deb13.wf.json
+++ b/packagebuild/workflows/build_deb13.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -49,6 +53,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "trixie"
         }

--- a/packagebuild/workflows/build_deb13_arm64.wf.json
+++ b/packagebuild/workflows/build_deb13_arm64.wf.json
@@ -31,6 +31,10 @@
     },
     "target_version": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-east1-c",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -50,7 +54,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
           "target_version": "trixie"

--- a/packagebuild/workflows/build_el10.wf.json
+++ b/packagebuild/workflows/build_el10.wf.json
@@ -33,6 +33,10 @@
       "Value": "projects/rhel-cloud/global/images/family/rhel-10",
       "Description": "Source image to use for package build instance",
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -51,6 +55,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }

--- a/packagebuild/workflows/build_el10_arm64.wf.json
+++ b/packagebuild/workflows/build_el10_arm64.wf.json
@@ -33,6 +33,10 @@
       "Value": "projects/rhel-cloud/global/images/family/rhel-10-arm64",
       "Description": "Source image to use for package build instance",
       "Required": false
+    },
+    "zone": {
+      "Value": "europe-west4-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -52,7 +56,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }

--- a/packagebuild/workflows/build_el8.wf.json
+++ b/packagebuild/workflows/build_el8.wf.json
@@ -28,6 +28,10 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -46,6 +50,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }

--- a/packagebuild/workflows/build_el8_arm64.wf.json
+++ b/packagebuild/workflows/build_el8_arm64.wf.json
@@ -28,6 +28,10 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "zone": {
+      "Value": "europe-west4-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -47,7 +51,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }

--- a/packagebuild/workflows/build_el9.wf.json
+++ b/packagebuild/workflows/build_el9.wf.json
@@ -28,6 +28,10 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -46,6 +50,7 @@
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }
       }

--- a/packagebuild/workflows/build_el9_arm64.wf.json
+++ b/packagebuild/workflows/build_el9_arm64.wf.json
@@ -28,6 +28,10 @@
     },
     "sbom_util_gcs_root": {
       "Required": false
+    },
+    "zone": {
+      "Value": "europe-west4-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -47,7 +51,7 @@
           "build_dir": "${build_dir}",
           "machine_type": "c4a-standard-2",
           "disk_type": "hyperdisk-balanced",
-          "zone": "us-central1-a",
+          "zone": "${zone}",
           "version": "${version}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}"
         }

--- a/packagebuild/workflows/build_goo.wf.json
+++ b/packagebuild/workflows/build_goo.wf.json
@@ -36,6 +36,10 @@
     },
     "spec_name": {
       "Required": false
+    },
+    "zone": {
+      "Value": "us-central1-a",
+      "Description": "zone"
     }
   },
   "Steps": {
@@ -50,13 +54,14 @@
           "repo_name": "${repo_name}",
           "git_ref": "${git_ref}",
           "extra_repo": "${extra_repo}",
-	  "extra_repo_owner": "${extra_repo_owner}",
+          "extra_repo_owner": "${extra_repo_owner}",
           "extra_git_ref": "${extra_git_ref}",
           "build_dir": "${build_dir}",
           "version": "${version}",
+          "zone": "${zone}",
           "sbom_util_gcs_root": "${sbom_util_gcs_root}",
-	  "lkg_gcs_path": "${lkg_gcs_path}",
-	  "spec_name": "${spec_name}"
+          "lkg_gcs_path": "${lkg_gcs_path}",
+          "spec_name": "${spec_name}"
         }
       }
     }


### PR DESCRIPTION
All zones are hardcoded to `us-central1-a` with no option to override. Parameterize build zones in all package build workflows. Move defaults for arm builds from `us-central1-a` to `europe-west4-a` for EL builds and `us-east1-c` for debian builds.

Refer b/511534656#comment2 for details