### PR TITLE
Stagger worker image builds to zones with capacity

### DIFF
--- a/concourse/pipelines/debian-worker-image-build.yaml
+++ b/concourse/pipelines/debian-worker-image-build.yaml
@@ -83,6 +83,7 @@ jobs:
       wf: "debian/debian_11_worker.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+      zone: "europe-west1-b"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -133,6 +134,7 @@ jobs:
       wf: "debian/debian_12_worker.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+      zone: "europe-west4-b"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -183,6 +185,7 @@ jobs:
       wf: "debian/debian_12_worker_arm64.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+      zone: "europe-west4-b"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -233,6 +236,7 @@ jobs:
       wf: "debian/debian_13_worker.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+      zone: "asia-east1-a"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml
@@ -283,6 +287,7 @@ jobs:
       wf: "debian/debian_13_worker_arm64.wf.json"
       gcs_url: ((.:gcs-url))
       build_date: ((.:build-date))
+      zone: "us-central1-b"
   on_success:
     task: success
     file: guest-test-infra/concourse/tasks/publish-job-result.yaml

--- a/concourse/tasks/daisy-build-images-debian.yaml
+++ b/concourse/tasks/daisy-build-images-debian.yaml
@@ -12,7 +12,7 @@ run:
   path: /daisy
   args:
   - -project=gce-image-builder
-  - -zone=us-central1-a
+  - -zone=((zone))
   - -var:build_date=((build_date))
   - -var:gcs_url=((gcs_url))
   - -compute_endpoint_override=https://www.googleapis.com/compute/beta/projects/


### PR DESCRIPTION
Stagger worker image builds across zones with capacity

Previously, all Debian worker image build tasks hardcoded `us-central1-a` in `daisy-build-images-debian.yaml`. This caused resource contention particularly for ARM64 worker instances.

Based on the [search](https://github.com/search?q=org%3AGoogleCloudPlatform+%22daisy-build-images-debian.yaml%22&type=code) it doesn't seem to be used anywhere else and should be safe to transition from hardcoded zones to parameterized 