### PR TITLE
Stripping the gvnic baremetal and unsigned from use for the isopath

### DIFF
--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -207,7 +207,7 @@ local rhelimgbuildjob = imgbuildjob {
 
   workflow_dir: 'enterprise_linux',
   sbom_util_secret_name:: 'sbom-util-secret',
-  isopath:: trim_strings(tl.image, ['-byos', '-eus', '-lvm', '-sap', '-nvidia-latest', '-nvidia-550']),
+  isopath:: trim_strings(tl.image, ['-byos', '-eus', '-lvm', '-sap', '-nvidia-latest', '-nvidia-550', '-gvnic-baremetal', '-unsigned']),
 
   is_arm:: std.member(tl.image, '-arm64'),
   is_byos:: std.member(tl.image, '-byos'),


### PR DESCRIPTION
/cc @bkatyl @lpleahy 

The OOT GVNIC Driver images will be using the same ISO's as the base image so it should have the same isopath name. For example wit the image `rhel-10-gvnic-baremetal-unsigned`, we only want it to have `rhel-10` in the isopath.