### PR TITLE
Removing unconditional OOT GVNIC Driver variables from the rhelimgbuildjob

### DIFF
--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -281,9 +281,7 @@ local rhelimgbuildjob = imgbuildjob {
       'is_arm=' + std.toString(tl.is_arm),
       'is_byos=' + std.toString(tl.is_byos),
       'is_lvm=' + std.toString(tl.is_lvm),
-      'is_oot_driver=' + std.toString(tl.is_oot_driver),
       'is_sap=' + std.toString(tl.is_sap),
-      'is_unsigned_oot_driver=' + std.toString(tl.is_unsigned_oot_driver),
       'rhui_package_name=' + tl.rhui_package_name,
       'version_lock=' + tl.version_lock,
     ] + (if tl.major_release != '8' then ['is_eus=' + std.toString(tl.is_eus)] else [])


### PR DESCRIPTION
/cc @lpleahy 

When I added the conditional check for it below I missed removing the unconditional version