### PR TITLE
Removing us-west1-b from from the Linux Concourse Dev Pipeline

### DIFF
--- a/concourse/pipelines/linux-image-build-dev.jsonnet
+++ b/concourse/pipelines/linux-image-build-dev.jsonnet
@@ -22,7 +22,7 @@ local imgbuildtask = daisy.daisyimagetask {
 };
 
 local prepublishtesttask = common.imagetesttask {
-  zones: ['us-west1-a', 'us-west1-b', 'us-west1-c'],
+  zones: ['us-west1-a', 'us-west1-c'],
   filter: '(shapevalidation)',
   extra_args: [ '-shapevalidation_test_filter=^(([A-Z][0-3])|(N4))' ],
 };


### PR DESCRIPTION
/cc @bkatyl @lpleahy 

Our arm images in the linux dev pipeline are currently failing the testing phase. They are build on c4a which is not available in us-west1-b. It is available in us-west1-(a/c)