### PR TITLE
Remove us-west1-b from the common zones

### DIFF
--- a/concourse/templates/common.libsonnet
+++ b/concourse/templates/common.libsonnet
@@ -119,7 +119,7 @@
   default_oslogin_test_project:: 'oslogin-cit',
   default_cit_test_projects: 'compute-image-test-pool-002,compute-image-test-pool-003,compute-image-test-pool-004,compute-image-test-pool-005',
   default_cit_zone:: 'us-central1-b',
-  default_cit_zones:: ['us-central1-a', 'us-central1-b', 'us-central1-f', 'us-east1-b', 'us-east1-c', 'us-east1-d', 'us-west1-a', 'us-west1-b', 'us-west1-c'],
+  default_cit_zones:: ['us-central1-a', 'us-central1-b', 'us-central1-f', 'us-east1-b', 'us-east1-c', 'us-east1-d', 'us-west1-a', 'us-west1-c'],
 
   imagetesttask:: {
     local task = self,


### PR DESCRIPTION
/cc @bkatyl  @lpleahy 

Our arm images in the linux dev pipeline are currently failing the testing phase. They are build on c4a which is not available in us-west1-b. It is available in us-west1-(a/c)

Attempted to resolve this by removing the zone from the Linux Dev Concoure pipeline in [PR](https://github.com/GoogleCloudPlatform/guest-test-infra/pull/1719) but the zone is still being inherited from the common.libsonnet file 