### PR TITLE
Change zones for windows image tests

### DIFF
--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -19,7 +19,7 @@ local imagetestn1 = common.imagetesttask {
 };
 
 local imagetestc3 = common.imagetesttask {
-  zones: ['us-central1-a', 'us-central1-b', 'us-central1-f'],
+  zones: ['asia-east1-a', 'europe-north1-b', 'us-west1-c'],
   filter: '^(livemigrate|suspendresume|imageboot|network|hotattach|lssd|disk)$',
   extra_args: [ '-x86_shape=c3-standard-4', '-timeout=60m' ],
 };


### PR DESCRIPTION
This changes the zones from `us-central1-a`, `us-central1-b`, and `us-central1-f` to `asia-east1-a`, `europe-north1-b`, and `us-west1-c`.

/cc @TylerJDao 