### PR TITLE
Update test proejct to run in to avoid cross project usage errors

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -842,6 +842,7 @@ local build_guest_configs = buildpackagejob {
               'projects/guest-package-builder/global/images/debian-12-((.:build-id))',
             ],
             tests=['networkconfig'],
+            project='compute-image-test-pool-001',
             test_projects=['compute-image-test-pool-001'], // This is the only project with the necessary reservation.
             extra_args=[
               '-accelerator_type=nvidia-h200-141gb',


### PR DESCRIPTION
Default is guest-package-builder, we're seeing errors like `"create-networks" run error: googleapi: Error 400: Invalid value for field 'resource.networkProfile': 'https://www.googleapis.com/compute/v1/projects/guest-package-builder/global/networkProfiles/...'. Cross project referencing is not allowed for this resource.`