### PR TITLE
Add Linux and Windows release package testing pipelines to Concourse

### DIFF
--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -60,5 +60,5 @@ jobs:
     file: rendered/container-build.json
   - set_pipeline: artifact-releaser-test
     file: rendered/artifact-releaser-test.json
-  - set_pipeline: release-package-image-build
-    file: rendered/release-package-image-build.json
+  - set_pipeline: release-package-linux-build
+    file: rendered/release-package-linux-build.json

--- a/concourse/pipelines/pipeline-set-pipeline.yaml
+++ b/concourse/pipelines/pipeline-set-pipeline.yaml
@@ -62,3 +62,5 @@ jobs:
     file: rendered/artifact-releaser-test.json
   - set_pipeline: release-package-linux-build
     file: rendered/release-package-linux-build.json
+  - set_pipeline: release-package-windows-build
+    file: rendered/release-package-windows-build.json

--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -1,0 +1,643 @@
+// Imports.
+local arle = import '../templates/arle.libsonnet';
+local common = import '../templates/common.libsonnet';
+local daisy = import '../templates/daisy.libsonnet';
+local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
+local lego = import '../templates/lego.libsonnet';
+
+// Common
+local underscore(input) = std.strReplace(input, '-', '_');
+
+local build_zones = ['us-central1-b', 'europe-west1-b', 'europe-west4-b', 'asia-east1-a'];
+local arm_build_zones = ['us-west1-a', 'europe-west4-a', 'europe-west4-b'];
+local string_hash(s) = std.foldl(function(acc, c) acc + std.codepoint(c), std.stringChars(s), 0);
+local get_zone(image) =
+  local zones = if std.member(image, '-arm64') then arm_build_zones else build_zones;
+  zones[std.mod(string_hash(image), std.length(zones))];
+
+local trim_strings(s, trim) =
+  if std.length(trim) == 0 then s
+  else trim_strings(std.strReplace(s, trim[0], ''), trim[1:]);
+
+local imgbuildtask = daisy.daisyimagetask {
+  gcs_url: '((.:gcs-url))',
+  sbom_destination: '((.:sbom-destination))',
+  shasum_destination: '((.:shasum-destination))',
+};
+
+local imgbuildjob = {
+  local tl = self,
+
+  use_dynamic_template:: false,
+
+  image:: error 'must set image in imgbuildjob',
+  image_prefix:: self.image,
+  zone:: get_zone(self.image),
+  workflow_dir:: error 'must set workflow_dir in imgbuildjob',
+  workflow::
+    if tl.use_dynamic_template then '%s/rhel_%s_consolidated.wf.json' % [tl.workflow_dir, tl.major_release]
+    else '%s/%s.wf.json' % [tl.workflow_dir, underscore(tl.image)],
+  build_task:: imgbuildtask {
+    workflow: tl.workflow,
+    zone: tl.zone,
+    vars+: ['google_cloud_repo=unstable'],
+  },
+  extra_tasks:: [],
+  daily:: true,
+  daily_task:: if self.daily then
+    [
+      {
+        get: 'daily-time',
+        trigger: true,
+      },
+    ] else [],
+
+  // Start of job
+  name: 'build-release-package-testing-%s' + self.image,
+  plan: tl.daily_task + [
+    { get: 'compute-image-tools' },
+    { get: 'guest-test-infra' },
+    {
+      get: '%s-gcs' % [tl.image],
+      trigger: true,
+      params: { skip_download: 'true' },
+    },
+    {
+      task: 'generate-timestamp',
+      file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+    },
+    {
+      load_var: 'start-timestamp-ms',
+      file: 'timestamp/timestamp-ms',
+    },
+    {
+      // generate the build id so the tarball and sbom have the same name
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
+      task: 'generate-build-id',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
+      vars: { prefix: tl.image_prefix, id: '((.:id))' },
+    },
+    // This is the 'put trick'. We don't have the real image tarball to write to GCS here, but we want
+    // Concourse to treat this job as producing it. So we write an empty file now, and overwrite it later in
+    // the daisy workflow. This also generates the final URL for use in the daisy workflow.
+    // This is also done for the sbom file.
+    {
+      put: tl.image + '-unstable-gcs',
+      params: {
+        // empty file written to GCS e.g. 'build-id-dir/centos-7-v20210107.tar.gz'
+        file: 'build-id-dir/%s*' % tl.image_prefix,
+      },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'gcs-url',
+      file: '%s-unstable-gcs/url' % tl.image,
+    },
+    {
+      task: 'generate-build-id-sbom',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-sbom.yaml',
+      vars: { prefix: tl.image_prefix, id: '((.:id))' },
+    },
+    {
+      put: tl.image + '-sbom',
+      params: {
+        // empty file written to GCS e.g. 'build-id-dir/centos-7-v20210107-1681318938.sbom.json'
+        file: 'build-id-dir-sbom/%s*' % tl.image_prefix,
+      },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'sbom-destination',
+      file: '%s-sbom/url' % tl.image,
+    },
+    {
+      task: 'generate-build-id-shasum',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-shasum.yaml',
+      vars: { prefix: tl.image_prefix, id: '((.:id))' },
+    },
+    {
+      put: tl.image + '-shasum',
+      params: {
+        // empty file written to GCS e.g. 'build-id-dir/centos-7-v20210107-1681318938.txt'
+        file: 'build-id-dir-shasum/%s*' % tl.image_prefix,
+      },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'shasum-destination',
+      file: '%s-shasum/url' % tl.image,
+    },
+    {
+      task: 'generate-build-date',
+      file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+    },
+    {
+      load_var: 'build-date',
+      file: 'publish-version/version',
+    },
+  ] + tl.extra_tasks + [
+    {
+      task: 'daisy-build-' + tl.image,
+      config: tl.build_task,
+    },
+  ],
+  on_success: {
+    task: 'success',
+    config: common.publishresulttask {
+      pipeline: 'release-package-linux-build',
+      job: tl.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'failure',
+    config: common.publishresulttask {
+      pipeline: 'release-package-linux-build',
+      job: tl.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+};
+
+local centosimgbuildjob = imgbuildjob {
+  local tl = self,
+
+  workflow_dir: 'enterprise_linux',
+  sbom_util_secret_name:: 'sbom-util-secret',
+  isopath:: trim_strings(tl.image, ['-byos', '-eus', '-lvm', '-sap', '-nvidia-latest', '-nvidia-550']),
+
+  // Add tasks to obtain ISO location and sbom util source
+  // Store those in .:iso-secret and .:sbom-util-secret
+  extra_tasks: [
+    {
+      task: 'get-secret-iso',
+      config: gcp_secret_manager.getsecrettask { secret_name: tl.isopath },
+    },
+    {
+      load_var: 'iso-secret',
+      file: 'gcp-secret-manager/' + tl.isopath,
+    },
+    {
+      task: 'get-secret-sbom-util',
+      config: gcp_secret_manager.getsecrettask { secret_name: tl.sbom_util_secret_name },
+    },
+    {
+      load_var: 'sbom-util-secret',
+      file: 'gcp-secret-manager/' + tl.sbom_util_secret_name,
+    },
+  ],
+
+  // Add EL and sbom util args to build task.
+  build_task+: { vars+: ['installer_iso=((.:iso-secret))', 'sbom_util_gcs_root=((.:sbom-util-secret))'] },
+};
+
+local debianimgbuildjob = imgbuildjob {
+  local tl = self,
+
+  workflow_dir: 'debian',
+  sbom_util_secret_name:: 'sbom-util-secret',
+
+  // Add tasks to obtain sbom util source
+  // Store in .:sbom-util-secret
+  extra_tasks: [
+    {
+      task: 'get-secret-sbom-util',
+      config: gcp_secret_manager.getsecrettask { secret_name: tl.sbom_util_secret_name },
+    },
+    {
+      load_var: 'sbom-util-secret',
+      file: 'gcp-secret-manager/' + tl.sbom_util_secret_name,
+    },
+  ],
+
+  // Add sbom util args to build task.
+  build_task+: { vars+: ['sbom_util_gcs_root=((.:sbom-util-secret))'] },
+};
+
+local rhelimgbuildjob = imgbuildjob {
+  local tl = self,
+
+  workflow_dir: 'enterprise_linux',
+  sbom_util_secret_name:: 'sbom-util-secret',
+  isopath:: trim_strings(tl.image, ['-byos', '-eus', '-lvm', '-sap', '-nvidia-latest', '-nvidia-550', '-gvnic-baremetal']),
+
+  is_arm:: std.member(tl.image, '-arm64'),
+  is_byos:: std.member(tl.image, '-byos'),
+  is_eus:: std.member(tl.image, '-eus'),
+  is_lvm:: std.member(tl.image, '-lvm'),
+  is_oot_driver:: std.member(tl.image, '-gvnic-baremetal'),
+  is_sap:: std.member(tl.image, '-sap'),
+  use_dynamic_template:: true,
+
+  local arch = if tl.is_arm then 'aarch64' else 'x86_64',
+  local el_release_components = std.split(trim_strings(tl.isopath, ['-arm64']), '-'),
+
+  disk_name:: if tl.is_arm then 'disk_export_hyperdisk' else 'disk_export',
+  disk_type:: if tl.is_arm then 'hyperdisk-balanced' else 'pd-ssd',
+  el_install_disk_size:: if tl.is_lvm then '50' else '20',
+  machine_type:: if tl.is_arm then 'c4a-standard-4' else 'e2-standard-4',
+  major_release:: el_release_components[1],
+  version_lock::
+    if std.length(el_release_components) > 2 then tl.major_release + '-' + el_release_components[2]
+    else '',
+  worker_image::
+    if tl.is_arm then 'projects/compute-image-tools/global/images/family/debian-12-worker-arm64'
+    else 'projects/compute-image-tools/global/images/family/debian-12-worker',
+
+  local rhui_package_name_base = 'google-rhui-client-rhel',
+  local rhui_package_name_tenth_point_release =
+    if tl.is_sap && std.length(el_release_components) > 2 && el_release_components[2] == '10' then '10' else '',
+  local rhui_package_name_eus =
+    if tl.is_eus then '-eus' else '',
+  local rhui_package_name_sap =
+    if tl.is_sap then '-sap' else '',
+
+  rhui_package_name:: rhui_package_name_base + tl.major_release + rhui_package_name_tenth_point_release + rhui_package_name_eus + rhui_package_name_sap,
+
+  // Extra tasks to obtain ISO location and sbom util source
+  // Store those in .:iso-secret and .:sbom-util-secret
+  extra_tasks: [
+    {
+      task: 'get-secret-iso',
+      config: gcp_secret_manager.getsecrettask { secret_name: tl.isopath },
+    },
+    {
+      load_var: 'iso-secret',
+      file: 'gcp-secret-manager/' + tl.isopath,
+    },
+    {
+      task: 'get-secret-sbom-util',
+      config: gcp_secret_manager.getsecrettask { secret_name: tl.sbom_util_secret_name },
+    },
+    {
+      load_var: 'sbom-util-secret',
+      file: 'gcp-secret-manager/' + tl.sbom_util_secret_name,
+    },
+  ],
+
+  // Add EL and sbom util args to build task.
+  build_task+: {
+    vars+: [
+             'installer_iso=((.:iso-secret))',
+             'sbom_util_gcs_root=((.:sbom-util-secret))',
+             'el_install_disk_size=' + tl.el_install_disk_size,
+             'el_release=' + tl.isopath,
+             'disk_name=' + tl.disk_name,
+             'disk_type=' + tl.disk_type,
+             'machine_type=' + tl.machine_type,
+             'worker_image=' + tl.worker_image,
+             'is_arm=' + std.toString(tl.is_arm),
+             'is_byos=' + std.toString(tl.is_byos),
+             'is_lvm=' + std.toString(tl.is_lvm),
+             'is_sap=' + std.toString(tl.is_sap),
+             'rhui_package_name=' + tl.rhui_package_name,
+             'version_lock=' + tl.version_lock,
+           ] + (if tl.major_release != '8' then ['is_eus=' + std.toString(tl.is_eus)] else [])
+           + (if tl.major_release == '10' then ['is_oot_driver=' + std.toString(tl.is_oot_driver)] else []),
+  },
+};
+
+local imgpublishjob = {
+  local tl = self,
+
+  env:: 'package',
+  workflow:: '%s/%s.publish.json' % [self.workflow_dir, underscore(self.image)],
+  workflow_dir:: error 'must set workflow_dir in imgpublishjob',
+
+  image:: error 'must set image in imgpublishjob',
+  image_prefix:: self.image,
+
+  gcs:: 'gs://%s/%s' % [self.gcs_bucket, self.gcs_dir],
+  gcs_dir:: error 'must set gcs directory in imgpublishjob',
+  gcs_bucket:: common.prod_bucket,
+
+  // Start of job.
+  name: 'publish-to-release-package-testing-%s-%s' % [tl.env, tl.image],
+  plan: [
+          { get: 'guest-test-infra' },
+          { get: 'compute-image-tools' },
+          {
+            task: 'generate-timestamp',
+            file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+          },
+          {
+            load_var: 'start-timestamp-ms',
+            file: 'timestamp/timestamp-ms',
+          },
+          // all the "get" steps must happen before loading them, otherwise concourse seems to
+          // erase all the other "get" steps
+          {
+            get: tl.image + '-unstable-gcs',
+            passed: ['build-release-package-testing-%s' % tl.image],
+            trigger: true,
+            params: { skip_download: 'true' },
+          },
+          {
+            get: tl.image + '-sbom',
+            passed: ['build-release-package-testing-%s' % tl.image],
+            params: { skip_download: 'true' },
+          },
+          {
+            get: tl.image + '-shasum',
+            passed: ['build-release-package-testing-%s' % tl.image],
+            params: { skip_download: 'true' },
+          },
+          {
+            load_var: 'sbom-destination',
+            file: '%s-sbom/url' % tl.image,
+          },
+          {
+            load_var: 'shasum-destination',
+            file: '%s-shasum/url' % tl.image,
+          },
+          {
+            load_var: 'source-version',
+            file: tl.image + '-unstable-gcs/version',
+          },
+          {
+            task: 'generate-version',
+            file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+          },
+          {
+            load_var: 'publish-version',
+            file: 'publish-version/version',
+          },
+        ] +
+        [
+          {
+            task: 'publish-release-package-testing-' + tl.image,
+            config: arle.gcepublishtask {
+              source_gcs_path: tl.gcs,
+              source_version: 'v((.:source-version))',
+              publish_version: '((.:publish-version))',
+              wf: tl.workflow,
+              environment: tl.env,
+            },
+          },
+        ],
+  on_success: {
+    task: 'success',
+    config: common.publishresulttask {
+      pipeline: 'release-package-linux-build',
+      job: tl.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'failure',
+    config: common.publishresulttask {
+      pipeline: 'release-package-linux-build',
+      job: tl.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+};
+
+local imggroup = {
+  local tl = self,
+
+  images:: error 'must set images in imggroup',
+  env:: 'package',
+
+  // Start of group.
+  name: error 'must set name in imggroup',
+  jobs: [
+    'build-release-package-testing-' + image
+    for image in tl.images
+  ] + [
+    'publish-to-release-package-testing-%s-%s' % [tl.env, image]
+    for image in tl.images
+  ],
+};
+
+{
+  local debian_images = ['debian-11', 'debian-12', 'debian-12-arm64', 'debian-13', 'debian-13-arm64'],
+  local centos_images = ['centos-stream-9', 'centos-stream-9-arm64', 'centos-stream-10', 'centos-stream-10-arm64'],
+  // Each rhel image group includes PAYG, BYOS, and LVM variation.
+  local rhel_8_base_images = [
+    'rhel-8',
+    'rhel-8-arm64',
+    'rhel-8-byos',
+    'rhel-8-byos-arm64',
+    'rhel-8-lvm',
+    'rhel-8-lvm-byos',
+    'rhel-8-lvm-arm64',
+    'rhel-8-lvm-byos-arm64',
+  ],
+  local rhel_8_sap_images = [
+    'rhel-8-8-sap',
+    'rhel-8-8-sap-byos',
+    'rhel-8-10-sap',
+    'rhel-8-10-sap-byos',
+  ],
+  local rhel_9_base_images = [
+    'rhel-9',
+    'rhel-9-arm64',
+    'rhel-9-lvm',
+    'rhel-9-lvm-byos',
+    'rhel-9-lvm-arm64',
+    'rhel-9-lvm-byos-arm64',
+    'rhel-9-byos',
+    'rhel-9-byos-arm64',
+  ],
+  local rhel_9_sap_images = [
+    'rhel-9-2-sap',
+    'rhel-9-2-sap-byos',
+    'rhel-9-4-sap',
+    'rhel-9-4-sap-byos',
+    'rhel-9-6-sap',
+    'rhel-9-6-sap-byos',
+    'rhel-9-8-sap',
+    'rhel-9-8-sap-byos',
+  ],
+  local rhel_9_eus_images = [
+    'rhel-9-6-eus',
+    'rhel-9-6-eus-arm64',
+    'rhel-9-6-eus-byos',
+    'rhel-9-6-eus-byos-arm64',
+    'rhel-9-8-eus',
+    'rhel-9-8-eus-arm64',
+    'rhel-9-8-eus-byos',
+    'rhel-9-8-eus-byos-arm64',
+  ],
+  local rhel_9_eus_lvm_images = [
+    'rhel-9-6-eus-lvm',
+    'rhel-9-6-eus-lvm-byos',
+    'rhel-9-6-eus-lvm-arm64',
+    'rhel-9-6-eus-lvm-byos-arm64',
+    'rhel-9-8-eus-lvm',
+    'rhel-9-8-eus-lvm-arm64',
+    'rhel-9-8-eus-lvm-byos',
+    'rhel-9-8-eus-lvm-byos-arm64',
+  ],
+  local rhel_10_base_images = [
+    'rhel-10',
+    'rhel-10-arm64',
+    'rhel-10-byos',
+    'rhel-10-byos-arm64',
+    'rhel-10-lvm',
+    'rhel-10-lvm-byos',
+    'rhel-10-lvm-arm64',
+    'rhel-10-lvm-byos-arm64',
+  ],
+  local rhel_10_sap_images = [
+    'rhel-10-0-sap',
+    'rhel-10-0-sap-byos',
+    'rhel-10-2-sap',
+    'rhel-10-2-sap-byos',
+  ],
+  local rhel_10_eus_images = [
+    'rhel-10-0-eus',
+    'rhel-10-0-eus-arm64',
+    'rhel-10-0-eus-byos',
+    'rhel-10-0-eus-byos-arm64',
+    'rhel-10-2-eus',
+    'rhel-10-2-eus-arm64',
+    'rhel-10-2-eus-byos',
+    'rhel-10-2-eus-byos-arm64',
+    'rhel-10-2-eus-gvnic-baremetal',
+    'rhel-10-2-eus-gvnic-baremetal-byos',
+  ],
+  local rhel_10_eus_lvm_images = [
+    'rhel-10-0-eus-lvm',
+    'rhel-10-0-eus-lvm-byos',
+    'rhel-10-0-eus-lvm-arm64',
+    'rhel-10-0-eus-lvm-byos-arm64',
+    'rhel-10-2-eus-lvm',
+    'rhel-10-2-eus-lvm-arm64',
+    'rhel-10-2-eus-lvm-byos',
+    'rhel-10-2-eus-lvm-byos-arm64',
+    'rhel-10-2-eus-lvm-gvnic-baremetal',
+    'rhel-10-2-eus-lvm-gvnic-baremetal-byos',
+  ],
+  local rhel_images = rhel_8_base_images + rhel_8_sap_images + rhel_9_base_images + rhel_9_sap_images + rhel_9_eus_images + rhel_9_eus_lvm_images + rhel_10_base_images + rhel_10_sap_images + rhel_10_eus_images + rhel_10_eus_lvm_images,
+
+  // Start of output.
+  resource_types: [
+    {
+      name: 'gcs',
+      type: 'registry-image',
+      source: { repository: 'frodenas/gcs-resource' },
+    },
+    {
+      name: 'registry-image-forked',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
+    },
+  ],
+  resources: [
+               {
+                 name: 'daily-time',
+                 type: 'time',
+                 source: { interval: '24h', start: '8:00 AM', stop: '8:30 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               common.gitresource { name: 'compute-image-tools' },
+               common.gitresource { name: 'guest-test-infra' },
+             ] + [
+               common.gcsimgresource {
+                 image: image,
+                 regexp: 'debian/%s-v([0-9]+).tar.gz' % common.debian_image_prefixes[self.image],
+               }
+               for image in debian_images
+             ] + [
+               common.gcsimgresource {
+                 image: image,
+                 name: '%s-unstable-gcs' % [self.image],
+                 regexp: 'debian/%s-v([0-9]+).tar.gz' % common.debian_image_prefixes[self.image],
+               }
+               for image in debian_images
+             ] + [
+               common.gcssbomresource {
+                 image: image,
+                 image_prefix: common.debian_image_prefixes[image],
+                 sbom_destination: 'debian',
+               }
+               for image in debian_images
+             ] + [
+               common.gcsshasumresource {
+                 image: image,
+                 image_prefix: common.debian_image_prefixes[image],
+                 shasum_destination: 'debian',
+               }
+               for image in debian_images
+             ] +
+             [common.gcsimgresource { image: image, gcs_dir: 'centos' } for image in centos_images] +
+             [common.GcsImgResource(image, 'centos-unstable') { name: '%s-unstable-gcs' % [self.image] } for image in centos_images] +
+             [common.gcssbomresource { image: image, sbom_destination: 'centos' } for image in centos_images] +
+             [common.gcsshasumresource { image: image, shasum_destination: 'centos' } for image in centos_images] +
+             [common.gcsimgresource { image: image, gcs_dir: 'rhel' } for image in rhel_images] +
+             [common.GcsImgResource(image, 'rhel-unstable') { name: '%s-unstable-gcs' % [self.image] } for image in rhel_images] +
+             [common.gcssbomresource { image: image, sbom_destination: 'rhel' } for image in rhel_images] +
+             [common.gcsshasumresource { image: image, shasum_destination: 'rhel' } for image in rhel_images],
+  jobs: [
+    // Build CentOS images
+    centosimgbuildjob { image: image }
+    for image in centos_images
+  ] + [
+    // Build Debian images
+    debianimgbuildjob {
+      image: image,
+      image_prefix: common.debian_image_prefixes[image],
+    }
+    for image in debian_images
+  ] + [
+    // Build RHEL images
+    rhelimgbuildjob { image: image }
+    for image in rhel_images
+  ] + [
+    // Publish Debian images
+    imgpublishjob {
+      image: image,
+      env: 'package',
+      gcs_dir: 'debian',
+      workflow_dir: 'debian',
+
+      // Debian tarballs and images use a longer name, but jobs use the shorter name.
+      image_prefix: common.debian_image_prefixes[image],
+    }
+    for image in debian_images
+  ] + [
+    // Publish RHEL images
+    imgpublishjob {
+      image: image,
+      env: 'package',
+      gcs_dir: 'rhel',
+      workflow_dir: 'enterprise_linux',
+    }
+    for image in rhel_images
+  ] + [
+    // Publish CentOS images
+    imgpublishjob {
+      image: image,
+      env: 'package',
+      gcs_dir: 'centos',
+      workflow_dir: 'enterprise_linux',
+    }
+    for image in centos_images
+  ],
+  groups: [
+    imggroup { name: 'centos', images: centos_images },
+    imggroup { name: 'debian', images: debian_images },
+    imggroup { name: 'rhel-8-base', images: rhel_8_base_images },
+    imggroup { name: 'rhel-8-sap', images: rhel_8_sap_images },
+    imggroup { name: 'rhel-9-base', images: rhel_9_base_images },
+    imggroup { name: 'rhel-9-sap', images: rhel_9_sap_images },
+    imggroup { name: 'rhel-9-eus', images: rhel_9_eus_images },
+    imggroup { name: 'rhel-9-eus-lvm', images: rhel_9_eus_lvm_images },
+    imggroup { name: 'rhel-10-base', images: rhel_10_base_images },
+    imggroup { name: 'rhel-10-sap', images: rhel_10_sap_images },
+    imggroup { name: 'rhel-10-eus', images: rhel_10_eus_images },
+    imggroup { name: 'rhel-10-eus-lvm', images: rhel_10_eus_lvm_images },
+  ],
+}

--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -53,7 +53,7 @@ local imgbuildjob = {
     ] else [],
 
   // Start of job
-  name: 'build-release-package-testing-%s' + self.image,
+  name: 'build-release-package-testing-' + self.image,
   plan: tl.daily_task + [
     { get: 'compute-image-tools' },
     { get: 'guest-test-infra' },

--- a/concourse/pipelines/release-package-windows-build.jsonnet
+++ b/concourse/pipelines/release-package-windows-build.jsonnet
@@ -1,0 +1,414 @@
+// Imports.
+local arle = import '../templates/arle.libsonnet';
+local common = import '../templates/common.libsonnet';
+local daisy = import '../templates/daisy.libsonnet';
+local gcp_secret_manager = import '../templates/gcp-secret-manager.libsonnet';
+
+local underscore(input) = std.strReplace(input, '-', '_');
+
+// Templates.
+local imagetestn1 = common.imagetesttask {
+  zones: ['europe-west1-b', 'europe-west1-c', 'europe-west1-d'],
+  filter: '^(cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|imageboot|licensevalidation|network|security|hotattach|lssd|disk|packagevalidation|ssh|winrm|metadata|sql|mdsmtls|mdsroutes|packagemanager|compatmanager|packageupgrade)$',
+  extra_args: ['-x86_shape=n1-standard-4', '-timeout=60m'],
+};
+
+local imagetestc3 = common.imagetesttask {
+  zones: ['asia-northeast1-b', 'europe-north1-b', 'us-west1-c'],
+  filter: '^(livemigrate|suspendresume|imageboot|network|hotattach|lssd|disk)$',
+  extra_args: ['-x86_shape=c3-standard-4', '-timeout=60m'],
+};
+
+local imgbuildjob = {
+  local job = self,
+
+  image:: error 'must set image in imgbuildjob',
+  workflow:: error 'must set workflow in imgbuildjob',
+  iso_secret:: error 'must set iso_secret in imgbuildjob',
+  updates_secret:: error 'must set updates_secret in imgbuildjob',
+  daily:: true,
+  daily_task:: if self.daily then [
+    {
+      get: 'daily-time',
+      trigger: true,
+    },
+  ] else [],
+
+  // Start of job.
+  name: 'build-release-package-testing-' + job.image,
+  plan: job.daily_task + [
+    { get: 'compute-image-tools' },
+    { get: 'guest-test-infra' },
+    {
+      task: 'generate-timestamp',
+      file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+    },
+    {
+      load_var: 'start-timestamp-ms',
+      file: 'timestamp/timestamp-ms',
+    },
+    {
+      task: 'generate-id',
+      file: 'guest-test-infra/concourse/tasks/generate-id.yaml',
+    },
+    {
+      load_var: 'id',
+      file: 'generate-id/id',
+    },
+    {
+      task: 'generate-build-id',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id.yaml',
+      vars: { prefix: job.image, id: '((.:id))' },
+    },
+    {
+      put: job.image + '-unstable-gcs',
+      params: { file: 'build-id-dir/%s*' % job.image },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'gcs-url',
+      file: '%s-unstable-gcs/url' % job.image,
+    },
+    {
+      task: 'generate-build-id-sbom',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-sbom.yaml',
+      vars: { prefix: job.image, id: '((.:id))' },
+    },
+    {
+      put: job.image + '-sbom',
+      params: { file: 'build-id-dir-sbom/%s*' % job.image },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'sbom-destination',
+      file: '%s-sbom/url' % job.image,
+    },
+    {
+      task: 'generate-build-id-shasum',
+      file: 'guest-test-infra/concourse/tasks/generate-build-id-shasum.yaml',
+      vars: { prefix: job.image, id: '((.:id))' },
+    },
+    {
+      put: job.image + '-shasum',
+      params: { file: 'build-id-dir-shasum/%s*' % job.image },
+      get_params: { skip_download: 'true' },
+    },
+    {
+      load_var: 'sha256-txt',
+      file: '%s-shasum/url' % job.image,
+    },
+    {
+      task: 'generate-build-date',
+      file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+    },
+    {
+      load_var: 'build-date',
+      file: 'publish-version/version',
+    },
+    {
+      task: 'get-secret-iso',
+      config: gcp_secret_manager.getsecrettask { secret_name: job.iso_secret },
+    },
+    {
+      load_var: 'windows-iso',
+      file: 'gcp-secret-manager/' + job.iso_secret,
+    },
+    {
+      task: 'get-secret-updates',
+      config: gcp_secret_manager.getsecrettask { secret_name: job.updates_secret },
+    },
+    {
+      load_var: 'windows-updates',
+      file: 'gcp-secret-manager/' + job.updates_secret,
+    },
+    {
+      task: 'get-secret-pwsh',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_pwsh' },
+    },
+    {
+      load_var: 'windows-gcs-pwsh',
+      file: 'gcp-secret-manager/windows_gcs_pwsh',
+    },
+    {
+      task: 'get-secret-cloud-sdk',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_cloud_sdk' },
+    },
+    {
+      load_var: 'windows-cloud-sdk',
+      file: 'gcp-secret-manager/windows_gcs_cloud_sdk',
+    },
+    {
+      task: 'get-secret-dotnet48',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'windows_gcs_dotnet48' },
+    },
+    {
+      load_var: 'windows-gcs-dotnet48',
+      file: 'gcp-secret-manager/windows_gcs_dotnet48',
+    },
+    {
+      task: 'get-secret-sbom-util',
+      config: gcp_secret_manager.getsecrettask { secret_name: 'sbom-util-secret' },
+    },
+    {
+      load_var: 'sbom-util-secret',
+      file: 'gcp-secret-manager/sbom-util-secret',
+    },
+    {
+      task: 'daisy-build-' + job.image,
+      config: daisy.daisyimagetask {
+        gcs_url: '((.:gcs-url))',
+        sbom_destination: '((.:sbom-destination))',
+        shasum_destination: '((.:sha256-txt))',
+        workflow: job.workflow,
+        vars+: [
+          'cloudsdk=((.:windows-cloud-sdk))',
+          'dotnet48=((.:windows-gcs-dotnet48))',
+          'media=((.:windows-iso))',
+          'pwsh=((.:windows-gcs-pwsh))',
+          'updates=((.:windows-updates))',
+          'google_cloud_repo=unstable',
+          'sbom_util_gcs_root=((.:sbom-util-secret))',
+        ],
+      },
+    },
+  ],
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'release-package-windows-build',
+      job: job.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'release-package-windows-build',
+      job: job.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+};
+
+local imgpublishjob = {
+  local job = self,
+
+  image:: error 'must set image in imgpublishjob',
+  env:: 'package',
+  workflow:: error 'must set workflow in imgpublishjob',
+  gcs_dir:: error 'must set gcs_dir in imgpublishjob',
+  gcs:: 'gs://%s/%s' % [self.gcs_bucket, self.gcs_dir],
+  gcs_shasum:: 'gs://%s/%s' % [self.gcs_sbom_bucket, self.gcs_dir],
+  gcs_bucket:: common.prod_bucket,
+  gcs_sbom_bucket:: common.sbom_bucket,
+  generate_shasum:: true,
+  topic:: common.prod_topic,
+
+  // Start of job.
+  name: 'publish-to-release-package-testing-%s-%s' % [job.env, job.image],
+  plan: [
+          { get: 'guest-test-infra' },
+          { get: 'compute-image-tools' },
+          {
+            task: 'generate-timestamp',
+            file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
+          },
+          {
+            load_var: 'start-timestamp-ms',
+            file: 'timestamp/timestamp-ms',
+          },
+          {
+            get: '%s-unstable-gcs' % job.image,
+            params: { skip_download: 'true' },
+            passed: ['build-release-package-testing-%s' % job.image],
+            trigger: true,
+          },
+          {
+            load_var: 'source-version',
+            file: '%s-unstable-gcs/version' % job.image,
+          },
+          {
+            task: 'generate-version',
+            file: 'guest-test-infra/concourse/tasks/generate-version.yaml',
+          },
+          {
+            load_var: 'publish-version',
+            file: 'publish-version/version',
+          },
+        ] +
+        (
+          if job.generate_shasum then
+            [
+              {
+                get: '%s-shasum' % job.image,
+                params: { skip_download: 'true' },
+                passed: ['build-release-package-testing-%s' % job.image],
+                trigger: true,
+              },
+              {
+                load_var: 'sha256-txt',
+                file: '%s-shasum/url' % job.image,
+              },
+            ] else []
+        ) +
+        [
+          {
+            task: 'publish-release-package-testing-' + job.image,
+            config: arle.gcepublishtask {
+              source_gcs_path: job.gcs,
+              source_version: 'v((.:source-version))',
+              publish_version: '((.:publish-version))',
+              wf: job.workflow,
+              environment: job.env,
+            },
+          },
+        ],
+  on_success: {
+    task: 'publish-success-metric',
+    config: common.publishresulttask {
+      pipeline: 'release-package-windows-build',
+      job: job.name,
+      result_state: 'success',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+  on_failure: {
+    task: 'publish-failure-metric',
+    config: common.publishresulttask {
+      pipeline: 'release-package-windows-build',
+      job: job.name,
+      result_state: 'failure',
+      start_timestamp: '((.:start-timestamp-ms))',
+    },
+  },
+};
+
+local ImgBuildJob(image, iso_secret, updates_secret) = imgbuildjob {
+  image: image,
+  iso_secret: iso_secret,
+  updates_secret: updates_secret,
+  workflow: 'windows/%s-uefi.wf.json' % image,
+};
+
+local ImgPublishJob(image, env, workflow_dir, gcs_dir) = imgpublishjob {
+  image: image,
+  env: env,
+  gcs_dir: gcs_dir,
+  workflow: '%s/%s' % [workflow_dir, image + '-uefi.publish.json'],
+};
+
+local ImgGroup(name, images) = {
+  name: name,
+  jobs: [
+    'build-release-package-testing-' + image
+    for image in images
+  ] + [
+    'publish-to-release-package-testing-%s-%s' % ['package', image]
+    for image in images
+  ],
+};
+
+// Start of output.
+{
+  local windows_11_images = [
+    'windows-11-23h2-ent-x64',  // remove after Nov 10, 2026
+    'windows-11-24h2-ent-x64',  // remove after Oct 12, 2027
+    'windows-11-25h2-ent-x64',
+  ],
+  local windows_2016_images = [
+    'windows-server-2016-dc',
+    'windows-server-2016-dc-core',
+  ],
+  local windows_2019_images = [
+    'windows-server-2019-dc',
+    'windows-server-2019-dc-core',
+  ],
+  local windows_2022_images = [
+    'windows-server-2022-dc',
+    'windows-server-2022-dc-core',
+  ],
+  local windows_2025_images = [
+    'windows-server-2025-dc',
+    'windows-server-2025-dc-core',
+  ],
+
+  local windows_client_images = windows_11_images,
+  local windows_server_images = windows_2016_images + windows_2019_images + windows_2022_images + windows_2025_images,
+
+  resource_types: [
+    {
+      name: 'gcs',
+      source: { repository: 'frodenas/gcs-resource' },
+      type: 'registry-image',
+    },
+    {
+      name: 'registry-image-forked',
+      type: 'registry-image',
+      source: { repository: 'gcr.io/compute-image-tools/registry-image-forked' },
+    },
+  ],
+  resources: [
+               {
+                 name: 'daily-time',
+                 type: 'time',
+                 source: { interval: '24h', start: '10:30 AM', stop: '11:00 AM', location: 'America/Los_Angeles', days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], initial_version: true },
+               },
+               common.GitResource('compute-image-tools'),
+               common.GitResource('guest-test-infra'),
+             ] +
+             [
+               common.GcsImgResource(image, 'windows-uefi')
+               for image in windows_client_images + windows_server_images
+             ] +
+             [
+               common.GcsImgResource(image, 'windows-uefi-unstable') {
+                 name: '%s-unstable-gcs' % [self.image],
+               }
+               for image in windows_client_images + windows_server_images
+             ] +
+             [
+               common.GcsSbomResource(image, 'windows-client')
+               for image in windows_client_images
+             ] +
+             [
+               common.GcsSbomResource(image, 'windows-server')
+               for image in windows_server_images
+             ] +
+             [
+               common.GcsShasumResource(image, 'windows-client')
+               for image in windows_client_images
+             ] +
+             [
+               common.GcsShasumResource(image, 'windows-server')
+               for image in windows_server_images
+             ],
+  jobs: [
+          // Windows builds
+          ImgBuildJob('windows-11-23h2-ent-x64', 'win11-23h2-64', 'windows_gcs_updates_client11-23h2-64'),
+          ImgBuildJob('windows-11-24h2-ent-x64', 'win11-24h2-64', 'windows_gcs_updates_client11-24h2-64'),
+          ImgBuildJob('windows-11-25h2-ent-x64', 'win11-25h2-64', 'windows_gcs_updates_client11-25h2-64'),
+          ImgBuildJob('windows-server-2025-dc', 'win2025-64', 'windows_gcs_updates_server2025'),
+          ImgBuildJob('windows-server-2025-dc-core', 'win2025-64', 'windows_gcs_updates_server2025'),
+          ImgBuildJob('windows-server-2022-dc', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2022-dc-core', 'win2022-64', 'windows_gcs_updates_server2022'),
+          ImgBuildJob('windows-server-2019-dc', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2019-dc-core', 'win2019-64', 'windows_gcs_updates_server2019'),
+          ImgBuildJob('windows-server-2016-dc', 'win2016-64', 'windows_gcs_updates_server2016'),
+          ImgBuildJob('windows-server-2016-dc-core', 'win2016-64', 'windows_gcs_updates_server2016'),
+        ] +
+        // Publish jobs
+        [
+          ImgPublishJob(image, 'package', 'windows', 'windows-uefi')
+          for image in windows_server_images
+        ],
+
+  groups: [
+    ImgGroup('windows-11', windows_11_images),
+    ImgGroup('windows-2016', windows_2016_images),
+    ImgGroup('windows-2019', windows_2019_images),
+    ImgGroup('windows-2022', windows_2022_images),
+    ImgGroup('windows-2025', windows_2025_images),
+  ],
+}

--- a/concourse/pipelines/release-package-windows-build.jsonnet
+++ b/concourse/pipelines/release-package-windows-build.jsonnet
@@ -40,6 +40,11 @@ local imgbuildjob = {
     { get: 'compute-image-tools' },
     { get: 'guest-test-infra' },
     {
+      get: job.image + '-gcs',
+      trigger: true,
+      params: { skip_download: 'true' },
+    },
+    {
       task: 'generate-timestamp',
       file: 'guest-test-infra/concourse/tasks/generate-timestamp.yaml',
     },
@@ -401,7 +406,7 @@ local ImgGroup(name, images) = {
         // Publish jobs
         [
           ImgPublishJob(image, 'package', 'windows', 'windows-uefi')
-          for image in windows_server_images
+          for image in windows_client_images + windows_server_images
         ],
 
   groups: [


### PR DESCRIPTION
Adding modified versions of pre-existing Linux and Windows build pipelines to Concourse.
TODO: clean up unneeded code/files at a later date.

/cc @bkatyl @TylerJDao 