### PR TITLE
Remove to be obsoleted Windows SQL Server 2016 images from Concourse Pipelines

### DIFF
--- a/concourse/pipelines/windows-image-build-staging.jsonnet
+++ b/concourse/pipelines/windows-image-build-staging.jsonnet
@@ -652,14 +652,6 @@ local ImgGroup(name, images) = {
     'windows-server-2025-dc',
     'windows-server-2025-dc-core',
   ],
-  local sql_2016_images = [
-    'sql-2016-enterprise-windows-2016-dc',
-    'sql-2016-enterprise-windows-2019-dc',
-    'sql-2016-standard-windows-2016-dc',
-    'sql-2016-standard-windows-2019-dc',
-    'sql-2016-web-windows-2016-dc',
-    'sql-2016-web-windows-2019-dc',
-  ],
   local sql_2017_images = [
     'sql-2017-enterprise-windows-2016-dc',
     'sql-2017-enterprise-windows-2019-dc',
@@ -704,7 +696,7 @@ local ImgGroup(name, images) = {
   local windows_client_images = windows_10_images + windows_11_images,
   local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images + sql_2025_images,
+  local sql_images = sql_2017_images + sql_2019_images + sql_2022_images + sql_2025_images,
 
   resource_types: [
     {
@@ -776,13 +768,6 @@ local ImgGroup(name, images) = {
           ImgBuildJob('windows-server-2016-dc-core', 'win2016-64', 'windows_gcs_updates_server2016'),
           // SQL derivative builds
 
-          SQLImgBuildJob('sql-2016-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
-
           SQLImgBuildJob('sql-2017-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2022-dc', 'windows-server-2022-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
@@ -846,7 +831,6 @@ local ImgGroup(name, images) = {
     ImgGroup('windows-2019-testing', windows_2019_images),
     ImgGroup('windows-2022-testing', windows_2022_images),
     ImgGroup('windows-2025-testing', windows_2025_images),
-    ImgGroup('sql-2016-testing', sql_2016_images),
     ImgGroup('sql-2017-testing', sql_2017_images),
     ImgGroup('sql-2019-testing', sql_2019_images),
     ImgGroup('sql-2022-testing', sql_2022_images),

--- a/concourse/pipelines/windows-image-build-standard.jsonnet
+++ b/concourse/pipelines/windows-image-build-standard.jsonnet
@@ -517,14 +517,6 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2025',
     'windows-server-2025-core',
   ],
-  local sql_2016_images = [
-    'sql-2016-enterprise-windows-2016',
-    'sql-2016-enterprise-windows-2019',
-    'sql-2016-standard-windows-2016',
-    'sql-2016-standard-windows-2019',
-    'sql-2016-web-windows-2016',
-    'sql-2016-web-windows-2019',
-  ],
   local sql_2017_images = [
     'sql-2017-enterprise-windows-2016',
     'sql-2017-enterprise-windows-2019',
@@ -557,7 +549,7 @@ local ImgGroup(name, images, environments) = {
 
   local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images,
+  local sql_images = sql_2017_images + sql_2019_images + sql_2022_images,
 
   resource_types: [
     {
@@ -596,13 +588,6 @@ local ImgGroup(name, images, environments) = {
           ImgBuildJob('windows-server-2016-core', 'win2016-64', 'windows_gcs_updates_server2016'),
 
           // SQL derivative builds
-
-          SQLImgBuildJob('sql-2016-enterprise-windows-2016', 'windows-server-2016', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-enterprise-windows-2019', 'windows-server-2019', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2016', 'windows-server-2016', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2019', 'windows-server-2019', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2016', 'windows-server-2016', 'sql-2016-web', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2019', 'windows-server-2019', 'sql-2016-web', 'windows_gcs_ssms_exe'),
 
           SQLImgBuildJob('sql-2017-enterprise-windows-2016', 'windows-server-2016', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2019', 'windows-server-2019', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
@@ -648,7 +633,6 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('windows-2019', windows_2019_images, server_envs),
     ImgGroup('windows-2022', windows_2022_images, server_envs),
     ImgGroup('windows-2025', windows_2025_images, server_envs),
-    ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),
     ImgGroup('sql-2022', sql_2022_images, sql_envs),

--- a/concourse/pipelines/windows-image-build.jsonnet
+++ b/concourse/pipelines/windows-image-build.jsonnet
@@ -758,14 +758,6 @@ local ImgGroup(name, images, environments) = {
     'windows-server-2025-dc',
     'windows-server-2025-dc-core',
   ],
-  local sql_2016_images = [
-    'sql-2016-enterprise-windows-2016-dc',
-    'sql-2016-enterprise-windows-2019-dc',
-    'sql-2016-standard-windows-2016-dc',
-    'sql-2016-standard-windows-2019-dc',
-    'sql-2016-web-windows-2016-dc',
-    'sql-2016-web-windows-2019-dc',
-  ],
   local sql_2017_images = [
     'sql-2017-enterprise-windows-2016-dc',
     'sql-2017-enterprise-windows-2019-dc',
@@ -819,7 +811,7 @@ local ImgGroup(name, images, environments) = {
   local windows_client_images = windows_11_images,
   local windows_server_images = windows_2016_images + windows_2019_images
                               + windows_2022_images + windows_2025_images,
-  local sql_images = sql_2016_images + sql_2017_images + sql_2019_images + sql_2022_images + sql_2025_images,
+  local sql_images = sql_2017_images + sql_2019_images + sql_2022_images + sql_2025_images,
 
   resource_types: [
     {
@@ -894,13 +886,6 @@ local ImgGroup(name, images, environments) = {
           ImgBuildJob('windows-server-2016-dc-core', 'win2016-64', 'windows_gcs_updates_server2016'),
 
           // SQL derivative builds
-
-          SQLImgBuildJob('sql-2016-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-enterprise', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-standard-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-standard', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2016-dc', 'windows-server-2016-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
-          SQLImgBuildJob('sql-2016-web-windows-2019-dc', 'windows-server-2019-dc', 'sql-2016-web', 'windows_gcs_ssms_exe'),
 
           SQLImgBuildJob('sql-2017-enterprise-windows-2016-dc', 'windows-server-2016-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
           SQLImgBuildJob('sql-2017-enterprise-windows-2019-dc', 'windows-server-2019-dc', 'sql-2017-enterprise', 'windows_gcs_ssms_exe'),
@@ -984,7 +969,6 @@ local ImgGroup(name, images, environments) = {
     ImgGroup('windows-2019', windows_2019_images, server_envs),
     ImgGroup('windows-2022', windows_2022_images, server_envs),
     ImgGroup('windows-2025', windows_2025_images, server_envs),
-    ImgGroup('sql-2016', sql_2016_images, sql_envs),
     ImgGroup('sql-2017', sql_2017_images, sql_envs),
     ImgGroup('sql-2019', sql_2019_images, sql_envs),
     ImgGroup('sql-2022', sql_2022_images, sql_envs),


### PR DESCRIPTION
/cc @shenpai35 

The Windows SQL Server 2016 images are to be obsoleted on July 14th, 2026. I am removing them now on the Concourse pipeline so that we will not make any more of this image