### PR TITLE
Changing Linux arm builds back to us-central1-a and us-central1-b

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -10,7 +10,7 @@ local envs = ['testing', 'prod'];
 local underscore(input) = std.strReplace(input, '-', '_');
 
 local build_zones = ['us-central1-b', 'europe-west1-b', 'europe-west4-b', 'asia-east1-a'];
-local arm_build_zones = ['us-west1-a', 'europe-west4-a', 'europe-west4-b'];
+local arm_build_zones = ['us-central1-a', 'us-central1-b',  'europe-west4-a', 'europe-west4-b'];
 local string_hash(s) = std.foldl(function(acc, c) acc + std.codepoint(c), std.stringChars(s), 0);
 local get_zone(image) =
   local zones = if std.member(image, '-arm64') then arm_build_zones else build_zones;


### PR DESCRIPTION
/cc @drewhli 

The t2a machine type is not available in us-west1-a. Changing it back to us-central1-b to resolve this. Also adding us-cenntral1-a 