### PR TITLE
Remove machine_type specification to rely on workflow default values

### DIFF
--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -167,9 +167,6 @@ local centosimgbuildjob = imgbuildjob {
   sbom_util_secret_name:: 'sbom-util-secret',
   isopath:: trim_strings(tl.image, ['-byos', '-eus', '-lvm', '-sap', '-nvidia-latest', '-nvidia-550']),
 
-  local is_arm = std.member(tl.image, '-arm64'),
-  machine_type:: if is_arm then 'c4a-standard-4' else 'e2-standard-4',
-
   // Add tasks to obtain ISO location and sbom util source
   // Store those in .:iso-secret and .:sbom-util-secret
   extra_tasks: [
@@ -196,7 +193,6 @@ local centosimgbuildjob = imgbuildjob {
     vars+: [
       'installer_iso=((.:iso-secret))',
       'sbom_util_gcs_root=((.:sbom-util-secret))',
-      'machine_type=' + tl.machine_type,
     ],
   },
 };
@@ -206,9 +202,6 @@ local debianimgbuildjob = imgbuildjob {
 
   workflow_dir: 'debian',
   sbom_util_secret_name:: 'sbom-util-secret',
-
-  local is_arm = std.member(tl.image, '-arm64'),
-  machine_type:: if is_arm then 'c4a-standard-4' else 'e2-standard-4',
 
   // Add tasks to obtain sbom util source
   // Store in .:sbom-util-secret
@@ -227,7 +220,6 @@ local debianimgbuildjob = imgbuildjob {
   build_task+: {
     vars+: [
       'sbom_util_gcs_root=((.:sbom-util-secret))',
-      'build_machine_type=' + tl.machine_type,
     ],
   },
 };

--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -411,9 +411,7 @@ local imgpublishjob = {
               project: 'gce-unstable-pkg-qualification',
               test_projects: 'gce-unstable-pkg-qualification',
               images: 'projects/gce-unstable-pkg-qualification/global/images/qual-image-%s-((.:publish-version))' % tl.image,
-              extra_args::
-                ['-gcs_path=gs://gce-unstable-pkg-qualification-daisy-bkt'] +
-                (if std.member(tl.image, '-arm64') then ['-arm64_shape=c4a-standard-1'] else []),
+              extra_args:: if std.member(tl.image, '-arm64') then ['-arm64_shape=c4a-standard-1'] else [],
             },
             ensure: {
               task: 'delete-qual-image-' + tl.image,

--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -419,7 +419,9 @@ local imgpublishjob = {
               project: 'gce-unstable-pkg-qualification',
               test_projects: 'gce-unstable-pkg-qualification',
               images: 'projects/gce-unstable-pkg-qualification/global/images/qual-image-%s-((.:publish-version))' % tl.image,
-              extra_args:: if std.member(tl.image, '-arm64') then ['-arm64_shape=c4a-standard-1'] else [],
+              extra_args::
+                ['-gcs_path=gs://gce-unstable-pkg-qualification-daisy-bkt'] +
+                (if std.member(tl.image, '-arm64') then ['-arm64_shape=c4a-standard-1'] else []),
             },
             ensure: {
               task: 'delete-qual-image-' + tl.image,


### PR DESCRIPTION
/cc @bkatyl @akerekes 

Pinning down the manual GCS bucket path for Daisy output directory for unstable package pre-publish boot test step.
EDIT: Reverting this change so that there is no dependency on bucket values or naming.

Removing machine_type specifications from image build tasks so that we rely on workflow default values.