### PR TITLE
Stagger build zones to avoid resource availability errors.

### DIFF
--- a/concourse/pipelines/release-package-linux-build.jsonnet
+++ b/concourse/pipelines/release-package-linux-build.jsonnet
@@ -8,8 +8,8 @@ local lego = import '../templates/lego.libsonnet';
 // Common
 local underscore(input) = std.strReplace(input, '-', '_');
 
-local build_zones = ['us-central1-b', 'europe-west1-b', 'europe-west4-b', 'asia-east1-a'];
-local arm_build_zones = ['us-west1-a', 'europe-west4-a', 'europe-west4-b'];
+local build_zones = ['us-west1-a', 'us-east1-c', 'europe-west1-c', 'asia-northeast1-b'];
+local arm_build_zones = ['us-west1-a', 'us-east1-c', 'europe-west1-b', 'asia-northeast1-b'];
 local string_hash(s) = std.foldl(function(acc, c) acc + std.codepoint(c), std.stringChars(s), 0);
 local get_zone(image) =
   local zones = if std.member(image, '-arm64') then arm_build_zones else build_zones;


### PR DESCRIPTION
/cc @bkatyl @akerekes 

This PR updates the zones that Linux release package image builds run in so there is no overlap with production Linux image builds.