### PR TITLE
Change to Debian 12 worker due to incompabitilities between the Debiann 13 worker and older images

### DIFF
--- a/concourse/pipelines/guest-package-build.jsonnet
+++ b/concourse/pipelines/guest-package-build.jsonnet
@@ -523,7 +523,7 @@ local buildpackageimagetask = {
   dest_image:: error 'must set dest_image in buildpackageimagetask',
   gcs_package_path:: error 'must set gcs_package_path in buildpackageimagetask',
   machine_type:: 'e2-medium',
-  worker_image:: 'projects/compute-image-tools/global/images/family/debian-13-worker',
+  worker_image:: 'projects/compute-image-tools/global/images/family/debian-12-worker',
   disk_type:: 'pd-ssd',
   zone:: 'us-central1-a',
 


### PR DESCRIPTION
Tested locally, and it seemed to work fine.

/cc @bkatyl @akerekes @SaswatPadhi @ChaitanyaKulkarni28 