### PR TITLE
east1-a -> east1-b because east1-a doesn't exist

### DIFF
--- a/concourse/pipelines/linux-image-build.jsonnet
+++ b/concourse/pipelines/linux-image-build.jsonnet
@@ -11,7 +11,7 @@ local underscore(input) = std.strReplace(input, '-', '_');
 
 local build_zones = ['us-central1-b', 'europe-west1-b', 'europe-west4-b', 'asia-east1-a'];
 // ARM builds on c3-standard-4.
-local arm_build_zones = ['us-central1-a', 'us-east1-a', 'europe-west4-a', 'europe-west4-b'];
+local arm_build_zones = ['us-central1-a', 'us-east1-b', 'europe-west4-a', 'europe-west4-b'];
 local string_hash(s) = std.foldl(function(acc, c) acc + std.codepoint(c), std.stringChars(s), 0);
 local get_zone(image) =
   local zones = if std.member(image, '-arm64') then arm_build_zones else build_zones;


### PR DESCRIPTION
Turns out it's not good to assume that the `-a` zone always exists.

/cc @akerekes @bkatyl 